### PR TITLE
changed the docs so that the examples are hyperlinks to github

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,11 +28,19 @@ The core APIs above are ordered following the machine learning pipeline rather t
 
 .. toctree::
     :maxdepth: 1
-    :caption: Examples API
+    :caption: Example Projects
 
-    examples/examples.cifar_cnntransformer
-    examples/examples.cifar_isonet
-    examples/examples.digits_dann_lightn
+	.. the two dots here mean that these lines are commented out.
+	.. replaced the three doc generating lines below with links to the
+	.. actual github pages of the examples.
+	
+    .. examples/examples.cifar_cnntransformer
+    .. examples/examples.cifar_isonet
+    .. examples/examples.digits_dann_lightn
+	
+	CIFAR - CNN Transformer <https://github.com/pykale/pykale/tree/master/examples/cifar_cnntransformer>
+	CIFAR - ISONet <https://github.com/pykale/pykale/tree/master/examples/cifar_isonet>
+	Digits - Domain Adaptation <https://github.com/pykale/pykale/tree/master/examples/digits_dann_lightn>
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
# Quick Explanation

On the left menubar of our docs I have changed the buttons of the examples. Now, when you click on them they forward you to the respective github page.

I made this little pull request and readme so that you can see how to do that. In the file `docs/source/index.rst` which specifies the left menu bar organization, I just had to replace a line like `examples/examples.cifar_cnntransformer` (that normally generates the doc pages and api tree views) with 
`CIFAR - CNN Transformer <https://github.com/pykale/pykale/tree/master/examples/cifar_cnntransformer>` which instead just turns the side-heading into a link.

If we create new examples we just have to add a single line like that with a title and a link to the github page. As a last note, I didn't push anything apart from this index.rst. So, you have to `make html` the docs again to see the changes. 