### PR TITLE
Clean the requirements so that they are installable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,11 @@
 # We currently recommend Python 3.6 or above.
 
 # core dependencies
-torch==1.5.0
+torch==1.7.0
 numpy==1.19.0
 
 # utils
-torchvision==0.6.0
+torchvision==0.8.1
 torchsummary==1.5.0
 yacs==0.1.7
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
-# https://github.com/kornia/kornia/blob/master/requirements.txt
-# Versions used in development
+# Install these dependencies using
+# python -m pip install -r requirements.txt
+
+# We currently recommend Python 3.6 or above.
 
 # core dependencies
-pytorch==1.5.0
+torch==1.5.0
 numpy==1.19.0
-Python==3.7
 
 # utils
 torchvision==0.6.0
@@ -13,11 +14,17 @@ yacs==0.1.7
 
 # Needed only for graph
 ogb==1.2.0
+
 # Needed only for torch-geometric
-torch-cluster==1.5.4
-torch-scatter==2.0.4
-torch-sparse==0.6.5
-torch-spline-conv==1.2.0
+# torch-cluster and following won't install unless
+# torch is already installed;
+# please install with
+# python -m pip install torch-cluster torch-scatter torch-sparse torch-spline
+# if you need it
+# torch-cluster==1.5.4
+# torch-scatter==2.0.4
+# torch-sparse==0.6.5
+# torch-spline-conv==1.2.0
 torch-geometric==1.5.0
 
 


### PR DESCRIPTION
This makes it possible to install pykale with the following:

    git clone https://github.com/pykale/pykale
    cd pykale
    python -m pip install -r requirements.txt

(assuming that you have a suitable Python install already)

I've commented out the dependencies for torch-geometry because they can't be installed at the same time as `torch`, they have to be installed after `torch` is installed. But we need to address that (it's possible that switching to setup.cfg or an alternate approach would work).