### PR TITLE
improved videoloader for usage with more diverse datasets

### DIFF
--- a/examples/video_loading/README.md
+++ b/examples/video_loading/README.md
@@ -23,7 +23,7 @@ For a demo, visit `main.py`.
 ### QuickDemo (main.py)
 ```python
 root = os.path.join(os.getcwd(), 'demo_dataset')  # Folder in which all videos lie in a specific structure
-annotation_file = os.path.join(root, 'annotations.txt')  # A row for each video sample as: (VIDEO_PATH NUM_FRAMES CLASS_INDEX)
+annotation_file = os.path.join(root, 'annotations.txt')  # A row for each video sample as: (VIDEO_PATH START_FRAME END_FRAME CLASS_INDEX)
 
 """ DEMO 1 WITHOUT IMAGE TRANSFORMS """
 dataset = VideoFrameDataset(
@@ -47,14 +47,16 @@ for image in frames:
     plt.show()
     plt.pause(1)
 ```
-
+![alt text](https://github.com/RaivoKoot/images/blob/main/Action_Video.jpg "Action Video")
 # Table of Contents
 - [1. Requirements](#1-requirements)
 - [2. Custom Dataset](#2-custom-dataset)
 - [3. Video Frame Sampling Method](#3-video-frame-sampling-method)
-- [4. Using VideoFrameDataset for Training](#4-using-videoframedataset-for-training)
-- [5. Conclusion](#5-conclusion)
-- [6. Acknowledgements](#6-acknowledgements)
+- [4. Alternate Video Frame Sampling Methods](#4-alternate-video-frame-sampling-methods)
+- [5. Using VideoFrameDataset for Training](#5-using-videoframedataset-for-training)
+- [6. Allowing Multiple Labels per Sample](#6-allowing-multiple-labels-per-sample)
+- [7. Conclusion](#7-conclusion)
+- [8. Acknowledgements](#8-acknowledgements)
 
 ### 1. Requirements
 ```
@@ -64,15 +66,19 @@ torch >= 1.7.0
 python >= 3.6
 ```
 ### 2. Custom Dataset
+	(This description explains using custom datasets where each sample has a single class label. If you want to know how to
+use a dataset where a sample can have more than a single class label, read this anyways and then read `6.` below)  
+  
 To use any dataset, two conditions must be met.
 1) The video data must be supplied as RGB frames, each frame saved as an image file. Each video must have its own folder, in which the frames of
-that video lie. The frames of a video inside its folder must be named uniformly as `img_00001.jpg` ... `img_00120.jpg`, if there are 120 frames. The filename template
-for frames is then "img_{:05d}.jpg" (python string formatting, specifying 5 digits after the underscore), and must be supplied to the 
-constructor of VideoFrameDataset as a parameter. Each video folder lies inside a `root` folder of this dataset.
+that video lie. The frames of a video inside its folder must be named uniformly with consecutive indices such as `img_00001.jpg` ... `img_00120.jpg`, if there are 120 frames. 
+   Indices can start at zero or any other number and the exact file name template can be chosen freely. The filename template 
+   for frames in this example is "img_{:05d}.jpg" (python string formatting, specifying 5 digits after the underscore), and must be supplied to the 
+   constructor of VideoFrameDataset as a parameter. Each video folder must lie inside some `root` folder.
 2) To enumerate all video samples in the dataset and their required metadata, a `.txt` annotation file must be manually created that contains a row for each
-video sample in the dataset. The training, validation, and testing datasets must have separate annotation files. Each row must be a space-separated list that contains
-`VIDEO_PATH NUM_FRAMES CLASS_INDEX`. The `VIDEO_PATH` of a video sample should be provided without the `root` prefix of this dataset.
-
+video clip sample in the dataset. The training, validation, and testing datasets must have separate annotation files. Each row must be a space-separated list that contains
+`VIDEO_PATH START_FRAME END_FRAME CLASS_INDEX`. The `VIDEO_PATH` of a video sample should be provided without the `root` prefix of this dataset.
+   
 This example project demonstrates this using a dummy dataset inside of `demo_dataset/`, which is the `root` dataset folder of this example. When you run main.py, the dataset 
 folder will be automatically downloaded to this directory. The folder structure looks as follows:
 ```
@@ -93,34 +99,78 @@ demo_dataset
 
  
 ```
-The accompanying annotation `.txt` file contains the following rows
+The accompanying annotation `.txt` file contains the following rows (PATH, START_FRAME, END_FRAME, LABEL_ID)
 ```
-jumping/0001 17 0
-jumping/0002 18 0
+jumping/0001 1 17 0
+jumping/0002 1 18 0
 ```
+Another annotations file that uses multiple clips from each video could be
+```
+jumping/0001 1 8 0
+jumping/0001 5 17 0
+jumping/0002 1 18 0
+jumping/0002 10 18 0
+```
+(END_FRAME is inclusive)  
+  
 Instantiating a VideoFrameDataset with the `root_path` parameter pointing to `demo_dataset`, the `annotationsfile_path` parameter pointing to the annotation file, and
-the `imagefile_template` parameter as "img_{:05d}.jpg" (or whatever file name template you are using), is all that it takes to start using the VideoFrameDataset class.
-
+the `imagefile_template` parameter as "img_{:05d}.jpg", is all that it takes to start using the VideoFrameDataset class.
 ### 3. Video Frame Sampling Method
 When loading a video, only a number of its frames are loaded. They are chosen in the following way:
-1. The frame indices [1,N] are divided into NUM_SEGMENTS even segments. From each segment, FRAMES_PER_SEGMENT consecutive indices are chosen at random.
+1. The frame index range [START_FRAME, END_FRAME] is divided into NUM_SEGMENTS even segments. From each segment, a random start-index is sampled from which FRAMES_PER_SEGMENT consecutive indices are loaded.
 This results in NUM_SEGMENTS*FRAMES_PER_SEGMENT chosen indices, whose frames are loaded as PIL images and put into a list and returned when calling
-`dataset[i]`.  
+`dataset[i]`.
   
 ![alt text](https://github.com/RaivoKoot/images/blob/main/Sparse_Temporal_Sampling.jpg "Sparse-Temporal-Sampling-Strategy")
-  
-### 4. Using VideoFrameDataset for training
+
+### 4. Alternate Video Frame Sampling Methods
+If you do not want to use sparse temporal sampling and instead want to sample a single N-frame continuous
+clip from a video, this is possible. Set `NUM_SEGMENTS=1` and `FRAMES_PER_SEGMENT=N`. Because VideoFrameDataset
+will chose a random start index per segment and take `NUM_SEGMENTS` continuous frames from each sampled start
+index, this will result in a single N-frame continuous clip per video that starts at a random index. 
+An example of this is in `demo.py`.  
+
+### 5. Using VideoFrameDataset for training
 As demonstrated in `main.py`, we can use PyTorch's `torch.utils.data.DataLoader` class with VideoFrameDataset to take care of shuffling, batching, and more.
 To turn the lists of PIL images returned by VideoFrameDataset into tensors, the transform `kale.prepdata.video_transform.ImglistToTensor()` can be supplied
 as the `transform` parameter to VideoFrameDataset. This turns a list of N PIL images into a batch of images/frames of shape `N x CHANNELS x HEIGHT x WIDTH`. 
-We can further chain preprocessing and augmentation functions that act on batches of images onto the end of `ImglistToTensor()`.
+We can further chain preprocessing and augmentation functions that act on batches of images onto the end of `ImglistToTensor()`, as seen in `main.py`.
   
 As of `torchvision 0.8.0`, all torchvision transforms can now also operate on batches of images, and they apply deterministic or random transformations
-on the batch identically on all images of the batch. Therefore, any torchvision transform can be used here to apply video-uniform preprocessing and augmentation.
+on the batch identically on all images of the batch. Because a single video-tensor (FRAMES x CHANNELS x HEIGHT x WIDTH) 
+has the same shape as an image batch tensor (BATCH x CHANNELS x HEIGHT x WIDTH), any torchvision transform can be used here to apply video-uniform preprocessing and augmentation.
   
 REMEMBER:  
-Pytorch transforms are applied to individual dataset samples (in this case a video frame PIL list, or a frame tensor after `ImglistToTensor()`) before
+Pytorch transforms are applied to individual dataset samples (in this case a list of PIL images of a video, or a video-frame tensor after `ImglistToTensor()`) before
 batching. So, any transforms used here must expect its input to be a frame tensor of shape `FRAMES x CHANNELS x HEIGHT x WIDTH` or a list of PIL images if `ImglistToTensor()` is not used.
+
+### 6. Allowing Multiple Labels per Sample
+Your dataset labels might be more complicated than just a single label id per sample. For example, in the EPIC-KITCHENS dataset
+each video clip has a verb class, noun class, and action class. In this case, each sample is associated with three label ids.
+To accommodate for datasets where a sample can have N integer labels, `annotation.txt` files can be used where each row
+is space separated `PATH,   FRAME_START,    FRAME_END,    LABEL_1_ID,    ...,    LABEL_N_ID`, instead of 
+`PATH,   FRAME_START,    FRAME_END,    LABEL_ID`. The VideoFrameDataset class
+can handle this type of annotation files too, without changing anything apart from the rows in your `annotations.txt`.  
+  
+The `annotations.txt` file for a dataset where multiple clip samples can come from the same video and each sample has
+three labels, would have rows like `PATH,   START_FRAME,    END_FRAME,    LABEL1,    LABEL2,    LABEL3` as seen below
+```
+jumping/0001 1 8 0 2 1
+jumping/0001 5 17 0 10 3
+jumping/0002 1 18 0 5 3
+running/0001 10 15 1 3 3
+running/0001 5 10 1 1 0
+running/0002 1 15 1 12 4
+```
+  
+When you use `torch.utils.data.DataLoader` with VideoFrameDataset to retrieve your batches during
+training, the dataloader then no longer returns batches as a `( (BATCHxFRAMESxHEIGHTxWIDTH) , (BATCH) )` tuple, where the second item is
+just a list/tensor of the batch's labels. Instead, the second item is replaced with the tuple 
+`( (BATCH) ... (BATCH) )` where the first BATCH-sized list gives label_1 for the whole batch, and the last BATCH-sized
+list gives label_n for the whole batch.  
+  
+A demo of this can be found at the end in `main.py`. It uses the dummy dataset in directory `demo_dataset_multilabel`,
+that is also automatically downloaded.
 
 ### 5. Conclusion
 A proper code-based explanation on how to use VideoFrameDataset for training is provided in `main.py`

--- a/examples/video_loading/README.md
+++ b/examples/video_loading/README.md
@@ -66,7 +66,7 @@ torch >= 1.7.0
 python >= 3.6
 ```
 ### 2. Custom Dataset
-	(This description explains using custom datasets where each sample has a single class label. If you want to know how to
+(This description explains using custom datasets where each sample has a single class label. If you want to know how to
 use a dataset where a sample can have more than a single class label, read this anyways and then read `6.` below)  
   
 To use any dataset, two conditions must be met.

--- a/examples/video_loading/main.py
+++ b/examples/video_loading/main.py
@@ -3,23 +3,25 @@ import sys
 # No need if pykale is installed
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 
-from kale.loaddata.videos import  VideoFrameDataset
+from kale.loaddata.videos import VideoFrameDataset
 from kale.prepdata.video_transform import ImglistToTensor
 from torchvision import transforms
 import torch
 import matplotlib.pyplot as plt
+from mpl_toolkits.axes_grid1 import ImageGrid
 from torchvision.datasets.utils import download_file_from_google_drive, extract_archive
 
+
 """
-Viewer, ignore this function for now and look at "main" below.
+Ignore this function and look at "main" below.
 """
 def download_dummy_dataset():
-    # Full File URL: https://drive.google.com/file/d/1aIcmhaHZ9yflqwQZOSmW7ho6FDqVVAyp/view
-    gdrive_file_id = '1aIcmhaHZ9yflqwQZOSmW7ho6FDqVVAyp'
+    # Full File URL: https://drive.google.com/file/d/1U4D23R8u8MJX9KVKb92bZZX-tbpKWtga/view?usp=sharing
+    gdrive_file_id = '1U4D23R8u8MJX9KVKb92bZZX-tbpKWtga'
     output_directory = os.path.join(os.getcwd())
-    output_file_name = 'demo_dataset.zip'
+    output_file_name = 'demo_datasets.zip'
 
-    print("Downloading Dummy Dataset")
+    print("Downloading Dummy Datasets")
     download_file_from_google_drive(gdrive_file_id, output_directory, output_file_name)
 
     if os.path.exists(os.path.join(os.getcwd(), 'demo_dataset')):
@@ -27,13 +29,41 @@ def download_dummy_dataset():
         return
 
     print("Extracting Dummy Dataset")
-    zip_file = os.path.join(os.getcwd(), 'demo_dataset.zip')
+    zip_file = os.path.join(os.getcwd(), output_file_name)
     extract_archive(zip_file)
+
+    print("Datasets downloaded and extracted. Run this program again to run the demo.")
+    exit()
+
+
+"""
+Ignore this function too
+"""
+def plot_video(rows, cols, frame_list, plot_width, plot_height):
+    fig = plt.figure(figsize=(plot_width, plot_height))
+    grid = ImageGrid(fig, 111,  # similar to subplot(111)
+                     nrows_ncols=(rows, cols),  # creates 2x2 grid of axes
+                     axes_pad=0.3,  # pad between axes in inch.
+                     )
+
+    for index, (ax, im) in enumerate(zip(grid, frame_list)):
+        # Iterating over the grid returns the Axes.
+        ax.imshow(im)
+        ax.set_title(index)
+    plt.show()
 
 if __name__ == '__main__':
     """
     This demo uses the dummy dataset inside of the folder "demo_dataset".
     It is structured just like a real dataset would need to be structured.
+    
+    TABLE OF CODE CONTENTS:
+    1. Minimal demo without image transforms
+    2. Minimal demo without sparse temporal sampling for single continuous frame clips, without image transforms
+    3. Demo with image transforms
+    4. Demo 3 continued with PyTorch dataloader
+    5. Demo of using a dataset where samples have multiple separate class labels
+    
     """
     download_dummy_dataset()
 
@@ -56,22 +86,46 @@ if __name__ == '__main__':
     frames = sample[0]  # list of PIL images
     label = sample[1]   # integer label
 
-    for image in frames:
-        plt.imshow(image)
-        plt.title(label)
-        plt.show()
-        plt.pause(1)
+    plot_video(rows=1, cols=5, frame_list=frames, plot_width=15., plot_height=3.)
 
 
-    """ DEMO 2 WITH TRANSFORMS """
+
+
+    """ DEMO 2 SINGLE CONTINUOUS FRAME CLIP INSTEAD OF SAMPLED FRAMES, WITHOUT TRANSFORMS """
+    # If you do not want to use sparse temporal sampling, and instead
+    # want to just load N consecutive frames starting from a random
+    # start index, this is easy. Simply set NUM_SEGMENTS=1 and
+    # FRAMES_PER_SEGMENT=N. Each time a sample is loaded, N
+    # frames will be loaded from a new random start index.
+    dataset = VideoFrameDataset(
+        root_path=videos_root,
+        annotationfile_path=annotation_file,
+        num_segments=1,
+        frames_per_segment=9,
+        imagefile_template='img_{:05d}.jpg',
+        transform=None,
+        random_shift=True,
+        test_mode=False
+    )
+
+    sample = dataset[1]
+    frames = sample[0]  # list of PIL images
+    label = sample[1]  # integer label
+
+    plot_video(rows=3, cols=3, frame_list=frames, plot_width=10., plot_height=5.)
+
+
+
+
+    """ DEMO 3 WITH TRANSFORMS """
     # As of torchvision 0.8.0, torchvision transforms support batches of images
     # of size (BATCH x CHANNELS x HEIGHT x WIDTH) and apply deterministic or random
     # transformations on the batch identically on all images of the batch. Any torchvision
     # transform for image augmentation can thus also be used  for video augmentation.
     preprocess = transforms.Compose([
         ImglistToTensor(),  # list of PIL images to (FRAMES x CHANNELS x HEIGHT x WIDTH) tensor
-        transforms.Resize(299),  # resize smaller edge of frames to 299
-        transforms.CenterCrop(299),  # center crop frames to square 299x299
+        transforms.Resize(299),  # image batch, resize smaller edge to 299
+        transforms.CenterCrop(299),  # image batch, center crop to square 299x299
         transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
     ])
 
@@ -87,12 +141,10 @@ if __name__ == '__main__':
     )
 
     sample = dataset[1]
-    # tensor of shape (NUM_SEGMENTS*FRAMES_PER_SEGMENT) x CHANNELS x HEIGHT x WIDTH
-    frame_tensor = sample[0]
-    print('Video Tensor Size:', frame_tensor.size())
-    # integer label
-    label = sample[1]
+    frame_tensor = sample[0]  # tensor of shape (NUM_SEGMENTS*FRAMES_PER_SEGMENT) x CHANNELS x HEIGHT x WIDTH
+    label = sample[1]  # integer label
 
+    print('Video Tensor Size:', frame_tensor.size())
     
     """
     Denormalize is just for visualization purposes, to undo the transforms applied
@@ -113,19 +165,15 @@ if __name__ == '__main__':
 
 
     frame_tensor = denormalize(frame_tensor)
-    for image in frame_tensor:
-        plt.imshow(image)
-        plt.title(label)
-        plt.show()
-        plt.pause(1)
+    plot_video(rows=1, cols=5, frame_list=frames, plot_width=15., plot_height=3.)
 
 
-    """ DEMO 2 CONTINUED: DATALOADER """
+    """ DEMO 3 CONTINUED: DATALOADER """
     dataloader = torch.utils.data.DataLoader(
         dataset=dataset,
         batch_size=2,
         shuffle=True,
-        num_workers=8,
+        num_workers=4,
         pin_memory=True
     )
 
@@ -134,7 +182,62 @@ if __name__ == '__main__':
             """
             Insert Training Code Here
             """
+            print(labels)
+            print("\nVideo Batch Tensor Size:", video_batch.size())
+            print("Batch Labels Size:", labels.size())
+            break
+        break
+
+    """ DEMO 5: SAMPLES WITH MULTIPLE LABELS """
+    """
+    Apart from supporting just a single label per sample, VideoFrameDataset also supports multi-label samples,
+    where a sample can be associated with more than just one label. EPIC-KITCHENS, for example, associates a
+    noun, verb, and action with each video clip. To support this, instead of each row in annotations.txt
+    being (VIDEO_PATH, START_FRAME, END_FRAME, LABEL_ID), each row can also be
+    (VIDEO_PATH, START_FRAME, END_FRAME, LABEL_1_ID, ..., LABEL_N_ID). An example of this can be seen in the
+    directory `demo_dataset_multilabel`.
+
+    Each sample returned by VideoFrameDataset is then ((FRAMESxCHANNELSxHEIGHTxWIDTH), (LABEL_1, ..., LABEL_N)).
+    When paired with the `torch.utils.data.DataLoader`, instead of yielding each batch as
+    ((BATCHxFRAMESxCHANNELSxHEIGHTxWIDTH), (BATCH)) where the second tuple item is the labels of the batch,
+    `torch.utils.data.DataLoader` returns a batch as ((BATCHxFRAMESxCHANNELSxHEIGHTxWIDTH), ((BATCH),...,(BATCH))
+    where the second tuple item is itself a tuple, with N BATCH-sized tensors of labels, where N is the 
+    number of labels assigned to each sample.
+    """
+    videos_root = os.path.join(os.getcwd(), 'demo_dataset_multilabel')
+    annotation_file = os.path.join(videos_root, 'annotations.txt')
+
+    dataset = VideoFrameDataset(
+        root_path=videos_root,
+        annotationfile_path=annotation_file,
+        num_segments=5,
+        frames_per_segment=1,
+        imagefile_template='img_{:05d}.jpg',
+        transform=preprocess,
+        random_shift=True,
+        test_mode=False
+    )
+
+    dataloader = torch.utils.data.DataLoader(
+        dataset=dataset,
+        batch_size=3,
+        shuffle=True,
+        num_workers=2,
+        pin_memory=True
+    )
+
+    print("\nMulti-Label Example")
+    for epoch in range(10):
+        for batch in dataloader:
+            """
+            Insert Training Code Here
+            """
+            video_batch, (labels1, labels2, labels3) = batch
+
             print("Video Batch Tensor Size:", video_batch.size())
-            print("Labels Size:", labels.size())
+            print("Labels1 Size:", labels1.size())  # == batch_size
+            print("Labels2 Size:", labels2.size())  # == batch_size
+            print("Labels3 Size:", labels3.size())  # == batch_size
+
             break
         break

--- a/kale/loaddata/videos.py
+++ b/kale/loaddata/videos.py
@@ -12,10 +12,12 @@ class VideoRecord(object):
     Args:
         root_datapath: the system path to the root folder
                        of the videos.
-        row: A list with three elements where 1) The first
+        row: A list with four or more elements where 1) The first
              element is the path to the video sample's frames excluding
-             the root_datapath prefix 2) The  second element is the number
-             of frames in the video 3) The third element is the label index.
+             the root_datapath prefix 2) The  second element is the starting frame id of the video
+             3) The third element is the inclusive ending frame id of the video
+             4) The fourth element is the label index.
+             5) any following elements are labels in the case of multi-label classification
     """
     def __init__(self, row, root_datapath):
         self._data = row
@@ -28,11 +30,23 @@ class VideoRecord(object):
 
     @property
     def num_frames(self):
+        return self.end_frame - self.start_frame + 1  # +1 because end frame is inclusive
+    @property
+    def start_frame(self):
         return int(self._data[1])
 
     @property
-    def label(self):
+    def end_frame(self):
         return int(self._data[2])
+
+    @property
+    def label(self):
+        # just one label_id
+        if len(self._data) == 4:
+            return int(self._data[3])
+        # sample associated with multiple labels
+        else:
+            return [int(label_id) for label_id in self._data[3:]]
 
 class VideoFrameDataset(torch.utils.data.Dataset):
     r"""
@@ -44,8 +58,8 @@ class VideoFrameDataset(torch.utils.data.Dataset):
     tensors where FRAMES=x if the ``kale.prepdata.video_transform.ImglistToTensor()``
     transform is used.
 
-    More specifically, the frame range [0,N] is divided into NUM_SEGMENTS
-    segments and FRAMES_PER_SEGMENT frames are taken from each segment.
+    More specifically, the frame range [START_FRAME, END_FRAME] is divided into NUM_SEGMENTS
+    segments and FRAMES_PER_SEGMENT consecutive frames are taken from each segment.
 
     Note:
         A demonstration of using this class can be seen
@@ -63,11 +77,12 @@ class VideoFrameDataset(torch.utils.data.Dataset):
         inside a ``ROOT_DATA`` folder, each video lies in its own folder,
         where each video folder contains the frames of the video as
         individual files with a naming convention such as
-        img_001.jpg ... img_059.jpg. Numbering must start at 1.
+        img_001.jpg ... img_059.jpg.
         For enumeration and annotations, this class expects to receive
-        the path to a .txt file where each video sample has a row with three
+        the path to a .txt file where each video sample has a row with four
+        (or more in the case of multi-label, see example README on Github)
         space separated values:
-        ``VIDEO_FOLDER_PATH     NUM_FRAMES      LABEL_INDEX``.
+        ``VIDEO_FOLDER_PATH     START_FRAME     END_FRAME     LABEL_INDEX``.
         ``VIDEO_FOLDER_PATH`` is expected to be the path of a video folder
         excluding the ``ROOT_DATA`` prefix. For example, ``ROOT_DATA`` might
         be ``home\data\datasetxyz\videos\``, inside of which a ``VIDEO_FOLDER_PATH``
@@ -96,10 +111,15 @@ class VideoFrameDataset(torch.utils.data.Dataset):
                    frames from segments with random_shift=False.
 
     """
-    def __init__(self, root_path, annotationfile_path,
-                 num_segments=3, frames_per_segment=1,
-                 imagefile_template='img_{:05d}.jpg', transform=None,
-                 random_shift=True, test_mode=False):
+    def __init__(self,
+                 root_path: str,
+                 annotationfile_path: str,
+                 num_segments: int = 3,
+                 frames_per_segment: int = 1,
+                 imagefile_template: str='img_{:05d}.jpg',
+                 transform = None,
+                 random_shift: bool = True,
+                 test_mode: bool = False):
         super(VideoFrameDataset, self).__init__()
 
         self.root_path = root_path
@@ -131,16 +151,16 @@ class VideoFrameDataset(torch.utils.data.Dataset):
             segment are to be loaded from.
         """
 
-        average_duration = (record.num_frames - self.frames_per_segment + 1) // self.num_segments
-        if average_duration > 0:
-            offsets = np.multiply(list(range(self.num_segments)), average_duration) + np.random.randint(average_duration, size=self.num_segments)
+        segment_duration = (record.num_frames - self.frames_per_segment + 1) // self.num_segments
+        if segment_duration > 0:
+            offsets = np.multiply(list(range(self.num_segments)), segment_duration) + np.random.randint(segment_duration, size=self.num_segments)
 
-        # edge cases for when a video only has a tiny number of frames.
-        elif record.num_frames > self.num_segments:
-            offsets = np.sort(np.random.randint(record.num_frames - self.frames_per_segment + 1, size=self.num_segments))
+        # edge cases for when a video has approximately less than (num_frames*frames_per_segment) frames.
+        # random sampling in that case, which will lead to repeated frames.
         else:
-            offsets = np.zeros((self.num_segments,))
-        return offsets + 1
+            offsets = np.sort(np.random.randint(record.num_frames, size=self.num_segments))
+
+        return offsets
 
     def _get_val_indices(self, record):
         """
@@ -156,7 +176,8 @@ class VideoFrameDataset(torch.utils.data.Dataset):
 
         # edge case for when a video does not have enough frames
         else:
-            offsets = np.zeros((self.num_segments,)) + 1
+            offsets = np.sort(np.random.randint(record.num_frames, size=self.num_segments))
+
         return offsets
 
     def _get_test_indices(self, record):
@@ -173,7 +194,7 @@ class VideoFrameDataset(torch.utils.data.Dataset):
 
         offsets = np.array([int(tick / 2.0 + tick * x) for x in range(self.num_segments)])
 
-        return offsets + 1
+        return offsets
 
     def __getitem__(self, index):
         """
@@ -211,14 +232,21 @@ class VideoFrameDataset(torch.utils.data.Dataset):
             2) An integer denoting the video label.
         """
 
+        indices = indices + record.start_frame
         images = list()
+        image_indices = list()
         for seg_ind in indices:
             frame_index = int(seg_ind)
             for i in range(self.frames_per_segment):
                 seg_img = self._load_image(record.path, frame_index)
                 images.extend(seg_img)
+                image_indices.append(frame_index)
                 if frame_index < record.num_frames:
                     frame_index += 1
+
+        # sort images by index in case of edge cases where segments overlap each other because the overall
+        # video is too short for num_segments*frames_per_segment indices.
+        _, images = (list(sorted_list) for sorted_list in zip(*sorted(zip(image_indices, images))))
 
         if self.transform is not None:
             images = self.transform(images)


### PR DESCRIPTION
# Added some functionality to videoloader
I only really made a few low level changes to the videoloader code. Its not very reviewable. Most line changes are just in the README and in code comments.

### Added
Videoloader now supports multiple labels per sample like NOUN, VERB, ACTION in EPIC-KITCHENS. Also now supports specifying START and END frame per sample like in EPIC-KITCHENS. A demo of this new functionality is also included in the demo file `main.py`  
  
These are changes that we needed so that Xianyuan could use this loader for many different datasets that he uses (and just make it more flexible in general for anyone of us). 