### PR TITLE
Hplu/fix flake8 errors

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,8 +16,6 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 # sys.path.insert(0, os.path.abspath('.'))
 
-import sphinx_rtd_theme
-
 # -- Project information -----------------------------------------------------
 
 project = "PyKale"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,19 +12,20 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 # sys.path.insert(0, os.path.abspath('.'))
 
 import sphinx_rtd_theme
 
 # -- Project information -----------------------------------------------------
 
-project = 'PyKale'
-copyright = '2020, Haiping Lu, Shuo Zhou, Raivo Koot'
-author = 'Haiping Lu, Shuo Zhou, Raivo Koot'
+project = "PyKale"
+copyright = "2020, Haiping Lu, Shuo Zhou, Raivo Koot"
+author = "Haiping Lu, Shuo Zhou, Raivo Koot"
 
 # The full version, including alpha/beta/rc tags
-release = '0.0.1'
+release = "0.0.1"
 
 
 # -- General configuration ---------------------------------------------------
@@ -32,22 +33,24 @@ release = '0.0.1'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx_rtd_theme', 
-'sphinx.ext.napoleon',
-'sphinx.ext.autosummary',
-'sphinx.ext.intersphinx',
-'nbsphinx',
-'nbsphinx_link',
-'sphinx.ext.mathjax',
-'sphinx.ext.autodoc']
+extensions = [
+    "sphinx_rtd_theme",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.intersphinx",
+    "nbsphinx",
+    "nbsphinx_link",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.autodoc",
+]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', '**.ipynb_checkpoints']
+exclude_patterns = ["_build", "**.ipynb_checkpoints"]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -61,4 +64,4 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]

--- a/examples/action_dann_lightn/config.py
+++ b/examples/action_dann_lightn/config.py
@@ -15,19 +15,19 @@ _C = CN()
 # Dataset
 # -----------------------------------------------------------------------------
 _C.DATASET = CN()
-_C.DATASET.ROOT = 'I:/Datasets/EgoAction/'  # '/shared/tale2/Shared'
-_C.DATASET.SOURCE = 'EPIC'  # dataset choices=['EPIC', 'GTEA', 'ADL', 'KITCHEN']
-_C.DATASET.SRC_TRAINLIST = 'epic_D1_train.pkl'
-_C.DATASET.SRC_TESTLIST = 'epic_D1_test.pkl'
-_C.DATASET.TARGET = 'EPIC'  # dataset choices=['EPIC', 'GTEA', 'ADL', 'KITCHEN']
-_C.DATASET.TAR_TRAINLIST = 'epic_D2_train.pkl'
-_C.DATASET.TAR_TESTLIST = 'epic_D2_test.pkl'
-_C.DATASET.IMAGE_MODALITY = 'rgb'  # mode choices=['rgb', 'flow', 'joint']
+_C.DATASET.ROOT = "I:/Datasets/EgoAction/"  # '/shared/tale2/Shared'
+_C.DATASET.SOURCE = "EPIC"  # dataset choices=['EPIC', 'GTEA', 'ADL', 'KITCHEN']
+_C.DATASET.SRC_TRAINLIST = "epic_D1_train.pkl"
+_C.DATASET.SRC_TESTLIST = "epic_D1_test.pkl"
+_C.DATASET.TARGET = "EPIC"  # dataset choices=['EPIC', 'GTEA', 'ADL', 'KITCHEN']
+_C.DATASET.TAR_TRAINLIST = "epic_D2_train.pkl"
+_C.DATASET.TAR_TESTLIST = "epic_D2_test.pkl"
+_C.DATASET.IMAGE_MODALITY = "rgb"  # mode choices=['rgb', 'flow', 'joint']
 _C.DATASET.NUM_CLASSES = 8
 _C.DATASET.FRAMES_PER_SEGMENT = 16
 _C.DATASET.NUM_REPEAT = 5  # 10
-_C.DATASET.WEIGHT_TYPE = 'natural'
-_C.DATASET.SIZE_TYPE = 'source'
+_C.DATASET.WEIGHT_TYPE = "natural"
+_C.DATASET.SIZE_TYPE = "source"
 # ---------------------------------------------------------------------------- #
 # Solver
 # ---------------------------------------------------------------------------- #
@@ -60,19 +60,23 @@ _C.MODEL.METHOD = "r3d_18"  # choices=['r3d_18', 'r2plus1d_18', 'mc3_18', 'i3d']
 # Domain Adaptation Net (DAN) configs
 # ---------------------------------------------------------------------------- #
 _C.DAN = CN()
-_C.DAN.METHOD = 'CDAN'  # choices=['CDAN', 'CDAN-E', 'DANN', 'DAN']
+_C.DAN.METHOD = "CDAN"  # choices=['CDAN', 'CDAN-E', 'DANN', 'DAN']
 _C.DAN.USERANDOM = False
 _C.DAN.RANDOM_DIM = 1024
 # ---------------------------------------------------------------------------- #
 # Misc options
 # ---------------------------------------------------------------------------- #
 _C.OUTPUT = CN()
-_C.OUTPUT.ROOT = './outputs'  # output_dir
+_C.OUTPUT.ROOT = "./outputs"  # output_dir
 _C.OUTPUT.VERBOSE = False  # To discuss, for HPC jobs
 _C.OUTPUT.FAST_DEV_RUN = False  # True for debug
 _C.OUTPUT.PB_FRESH = 0  # 0 # 50 # 0 to disable  ; MAYBE make it a command line option
-_C.OUTPUT.DIR = os.path.join(_C.OUTPUT.ROOT, _C.DATASET.SOURCE + '2' + _C.DATASET.TARGET)
-_C.OUTPUT.TB_DIR = os.path.join('lightning_logs', _C.DATASET.SOURCE + '2' + _C.DATASET.TARGET)
+_C.OUTPUT.DIR = os.path.join(
+    _C.OUTPUT.ROOT, _C.DATASET.SOURCE + "2" + _C.DATASET.TARGET
+)
+_C.OUTPUT.TB_DIR = os.path.join(
+    "lightning_logs", _C.DATASET.SOURCE + "2" + _C.DATASET.TARGET
+)
 
 
 def get_cfg_defaults():

--- a/examples/action_dann_lightn/main.py
+++ b/examples/action_dann_lightn/main.py
@@ -6,13 +6,12 @@ Reference: https://github.com/thuml/CDAN/blob/master/pytorch/train_image.py
 import argparse
 import logging
 import os
-import sys
+# import sys
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+# sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
-from kale.utils.csv_logger import (
-    setup_logger,
-)  # np error if move this to later, not sure why
+# np error if move this to later, not sure why
+from kale.utils.csv_logger import setup_logger
 import pytorch_lightning as pl
 
 from pytorch_lightning import loggers as pl_loggers
@@ -65,9 +64,8 @@ def main():
     # Repeat multiple times to get std
     for i in range(0, cfg.DATASET.NUM_REPEAT):
         seed = cfg.SOLVER.SEED + i * 10
-        set_seed(
-            seed
-        )  # seed_everything in pytorch_lightning did not set torch.backends.cudnn
+        # seed_everything in pytorch_lightning did not set torch.backends.cudnn
+        set_seed(seed)
         print(f"==> Building model for seed {seed} ......")
         # ---- setup model and logger ----
         model, train_params = get_model(cfg, dataset, num_channels)

--- a/examples/action_dann_lightn/model.py
+++ b/examples/action_dann_lightn/model.py
@@ -35,18 +35,18 @@ def get_config(cfg):
                 "optim_params": {
                     "momentum": cfg.SOLVER.MOMENTUM,
                     "weight_decay": cfg.SOLVER.WEIGHT_DECAY,
-                    "nesterov": cfg.SOLVER.NESTEROV
-                }
-            }
+                    "nesterov": cfg.SOLVER.NESTEROV,
+                },
+            },
         },
         "data_params": {
             # "dataset_group": cfg.DATASET.NAME,
-            "dataset_name": cfg.DATASET.SOURCE + '2' + cfg.DATASET.TARGET,
+            "dataset_name": cfg.DATASET.SOURCE + "2" + cfg.DATASET.TARGET,
             "source": cfg.DATASET.SOURCE,
             "target": cfg.DATASET.TARGET,
             "size_type": cfg.DATASET.SIZE_TYPE,
-            "weight_type": cfg.DATASET.WEIGHT_TYPE
-        }
+            "weight_type": cfg.DATASET.WEIGHT_TYPE,
+        },
     }
     return config_params
 
@@ -69,18 +69,20 @@ def get_feat_extractor(model_name, num_classes, num_channels):
                     the input dimension and the network is fixed.
     """
 
-    if model_name == 'I3D':
-        pretrained_model = 'rgb_imagenet' if num_channels == 3 else 'flow_imagenet'
-        feature_network = i3d(name=pretrained_model, num_channels=num_channels, pretrained=True)
+    if model_name == "I3D":
+        pretrained_model = "rgb_imagenet" if num_channels == 3 else "flow_imagenet"
+        feature_network = i3d(
+            name=pretrained_model, num_channels=num_channels, pretrained=True
+        )
         # model.replace_logits(num_classes)
         feature_dim = 1024
-    elif model_name == 'R3D_18':
+    elif model_name == "R3D_18":
         feature_network = r3d_18(pretrained=True)
         feature_dim = 512
-    elif model_name == 'R2PLUS1D_18':
+    elif model_name == "R2PLUS1D_18":
         feature_network = r2plus1d_18(pretrained=True)
         feature_dim = 512
-    elif model_name == 'MC3_18':
+    elif model_name == "MC3_18":
         feature_network = mc3_18(pretrained=True)
         feature_dim = 512
     else:
@@ -96,11 +98,13 @@ def get_model(cfg, dataset, num_channels):
     Args:
         cfg: A YACS config object.
         dataset: A multi domain dataset consisting of source and target datasets.
-        num_channels: The number of image channels.        
+        num_channels: The number of image channels.
     """
 
     # setup feature extractor
-    feature_network, feature_dim = get_feat_extractor(cfg.MODEL.METHOD.upper(), cfg.DATASET.NUM_CLASSES, num_channels)
+    feature_network, feature_dim = get_feat_extractor(
+        cfg.MODEL.METHOD.upper(), cfg.DATASET.NUM_CLASSES, num_channels
+    )
     # setup classifier
     classifier_network = ClassNetSmallImage(feature_dim, cfg.DATASET.NUM_CLASSES)
 
@@ -130,7 +134,7 @@ def get_model(cfg, dataset, num_channels):
                 critic_input_size = feature_dim * cfg.DATASET.NUM_CLASSES
         critic_network = DomainNetSmallImage(critic_input_size)
 
-        if cfg.DAN.METHOD == 'CDAN':
+        if cfg.DAN.METHOD == "CDAN":
             method_params["use_random"] = cfg.DAN.USERANDOM
 
         # The following calls kale.loaddata.dataset_access for the first time

--- a/examples/cifar_cnntransformer/config.py
+++ b/examples/cifar_cnntransformer/config.py
@@ -9,8 +9,8 @@ _C = CN()
 # Dataset
 # -----------------------------------------------------------------------------
 _C.DATASET = CN()
-_C.DATASET.ROOT = '../data'
-_C.DATASET.NAME = 'CIFAR10'
+_C.DATASET.ROOT = "../data"
+_C.DATASET.NAME = "CIFAR10"
 _C.DATASET.NUM_CLASSES = 10
 _C.DATASET.NUM_WORKERS = 0
 
@@ -38,35 +38,44 @@ _C.SOLVER.WARMUP_EPOCHS = 5
 # CNN configs
 # ---------------------------------------------------------------------------- #
 _C.CNN = CN()
-_C.CNN.POOL_LOCATIONS = (0,3) # After which index of the below
-                              # convolutionial-layer list pooling
-                              # layers should be placed. (0,3) Applies
-                              # 2 pooling layers, resulting in an image
-                              # size of 8x8.
+_C.CNN.POOL_LOCATIONS = (0, 3)  # After which index of the below
+# convolutionial-layer list pooling
+# layers should be placed. (0,3) Applies
+# 2 pooling layers, resulting in an image
+# size of 8x8.
 
 # A tuple for each convolutional layer given as (num_channels, kernel_size)
 # (Nested lists log to file prettier than nested tuples do)
-_C.CNN.CONV_LAYERS = [[16,3], [32,3], [64,3], [32,1], [64,3], [128,3], [256,3], [64,1]]
+_C.CNN.CONV_LAYERS = [
+    [16, 3],
+    [32, 3],
+    [64, 3],
+    [32, 1],
+    [64, 3],
+    [128, 3],
+    [256, 3],
+    [64, 1],
+]
 _C.CNN.USE_BATCHNORM = True
-_C.CNN.ACTIVATION_FUN = 'relu' # one of ('relu', 'elu', 'leaky_relu')
+_C.CNN.ACTIVATION_FUN = "relu"  # one of ('relu', 'elu', 'leaky_relu')
 _C.CNN.OUTPUT_SHAPE = (-1, 64, 8, 8)
 # ---------------------------------------------------------------------------- #
 # Transformer configs
 # ---------------------------------------------------------------------------- #
 _C.TRANSFORMER = CN()
-_C.TRANSFORMER.USE_TRANSFORMER = True # Will not attach the Transformer ontop
-                                      # of the CNN in the model if False
+_C.TRANSFORMER.USE_TRANSFORMER = True  # Will not attach the Transformer ontop
+# of the CNN in the model if False
 _C.TRANSFORMER.NUM_LAYERS = 3
 _C.TRANSFORMER.NUM_HEADS = 2
 _C.TRANSFORMER.DIM_FEEDFORWARD = 128
 _C.TRANSFORMER.DROPOUT = 0.1
-_C.TRANSFORMER.OUTPUT_TYPE = 'spatial'
+_C.TRANSFORMER.OUTPUT_TYPE = "spatial"
 
 # ---------------------------------------------------------------------------- #
 # Misc options
 # ---------------------------------------------------------------------------- #
-_C.OUTPUT_DIR = './outputs'
+_C.OUTPUT_DIR = "./outputs"
 
 
 def get_cfg_defaults():
-  return _C.clone()
+    return _C.clone()

--- a/examples/cifar_cnntransformer/config.py
+++ b/examples/cifar_cnntransformer/config.py
@@ -63,8 +63,8 @@ _C.CNN.OUTPUT_SHAPE = (-1, 64, 8, 8)
 # Transformer configs
 # ---------------------------------------------------------------------------- #
 _C.TRANSFORMER = CN()
-_C.TRANSFORMER.USE_TRANSFORMER = True  # Will not attach the Transformer ontop
-# of the CNN in the model if False
+# Will not attach the Transformer on top of the CNN in the model if False
+_C.TRANSFORMER.USE_TRANSFORMER = True
 _C.TRANSFORMER.NUM_LAYERS = 3
 _C.TRANSFORMER.NUM_HEADS = 2
 _C.TRANSFORMER.DIM_FEEDFORWARD = 128

--- a/examples/cifar_cnntransformer/main.py
+++ b/examples/cifar_cnntransformer/main.py
@@ -8,7 +8,8 @@ import os
 import argparse
 import warnings
 import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 import torch
 from torchsummary import summary
@@ -23,19 +24,20 @@ import kale.utils.seed as seed
 
 
 def arg_parse():
-    parser = argparse.ArgumentParser(description='PyTorch CIFAR10 Training')
-    parser.add_argument('--cfg', required=True, help='path to config file', type=str)
-    #parser.add_argument('--output', default='default', help='folder to save output', type=str)
-    parser.add_argument('--resume', default='', type=str)
+    parser = argparse.ArgumentParser(description="PyTorch CIFAR10 Training")
+    parser.add_argument("--cfg", required=True, help="path to config file", type=str)
+    # parser.add_argument('--output', default='default', help='folder to save output', type=str)
+    parser.add_argument("--resume", default="", type=str)
     args = parser.parse_args()
     return args
+
 
 def main():
     args = arg_parse()
 
     # ---- setup device ----
-    device = 'cuda' if torch.cuda.is_available() else 'cpu'
-    print('==> Using device ' + device)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print("==> Using device " + device)
 
     # ---- setup config ----
     cfg = get_cfg_defaults()
@@ -45,51 +47,46 @@ def main():
 
     # ---- setup logger ----
     os.makedirs(cfg.OUTPUT_DIR, exist_ok=True)
-    logger = logging.construct_logger('context_cnns', cfg.OUTPUT_DIR)
-    logger.info(f'Using {device}')
-    logger.info('\n' + cfg.dump())
+    logger = logging.construct_logger("context_cnns", cfg.OUTPUT_DIR)
+    logger.info(f"Using {device}")
+    logger.info("\n" + cfg.dump())
 
     # ---- setup dataset ----
     train_loader, val_loader = get_cifar(cfg)
 
     # ---- setup model ----
-    print('==> Building model..')
+    print("==> Building model..")
     net = get_model(cfg)
     net = net.to(device)
 
     model_stats = summary(net, (3, 32, 32))
-    logger.info('\n'+str(model_stats))
+    logger.info("\n" + str(model_stats))
 
-    if device=='cuda':
+    if device == "cuda":
         net = torch.nn.DataParallel(net)
 
     # ---- setup trainers ----
-    optim = torch.optim.SGD(net.parameters(), lr=cfg.SOLVER.BASE_LR,
-                            momentum=cfg.SOLVER.MOMENTUM,
-                            weight_decay=cfg.SOLVER.WEIGHT_DECAY)
-
-    trainer = Trainer(
-        device,
-        train_loader,
-        val_loader,
-        net,
-        optim,
-        logger,
-        cfg
+    optim = torch.optim.SGD(
+        net.parameters(),
+        lr=cfg.SOLVER.BASE_LR,
+        momentum=cfg.SOLVER.MOMENTUM,
+        weight_decay=cfg.SOLVER.WEIGHT_DECAY,
     )
+
+    trainer = Trainer(device, train_loader, val_loader, net, optim, logger, cfg)
 
     if args.resume:
         # Load checkpoint
-        print('==> Resuming from checkpoint..')
+        print("==> Resuming from checkpoint..")
         cp = torch.load(args.resume)
-        trainer.model.load_state_dict(cp['net'])
-        trainer.optim.load_state_dict(cp['optim'])
-        trainer.epochs = cp['epoch']
-        trainer.train_acc = cp['train_accuracy']
-        trainer.val_acc = cp['test_accuracy']
+        trainer.model.load_state_dict(cp["net"])
+        trainer.optim.load_state_dict(cp["optim"])
+        trainer.epochs = cp["epoch"]
+        trainer.train_acc = cp["train_accuracy"]
+        trainer.val_acc = cp["test_accuracy"]
 
     trainer.train()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/examples/cifar_cnntransformer/trainer.py
+++ b/examples/cifar_cnntransformer/trainer.py
@@ -6,7 +6,6 @@ import torch.nn as nn
 from kale.utils.print import tprint, pprint_without_newline
 
 
-
 class Trainer(object):
     def __init__(self, device, train_loader, val_loader, model, optim, logger, cfg):
         self.device = device
@@ -61,17 +60,21 @@ class Trainer(object):
             correct += predicted.eq(targets).sum().item()
 
             self.ave_time += time.time() - iter_t
-            tprint(f'train Epoch: {self.epochs} | {batch_idx + 1} / {len(self.train_loader)} | '
-                   f'Acc: {100. * correct / total:.3f} | Loss: {self.loss / (batch_idx + 1):.3f} | '
-                   f'time: {self.ave_time / (batch_idx + 1):.3f}s')
+            tprint(
+                f"train Epoch: {self.epochs} | {batch_idx + 1} / {len(self.train_loader)} | "
+                f"Acc: {100. * correct / total:.3f} | Loss: {self.loss / (batch_idx + 1):.3f} | "
+                f"time: {self.ave_time / (batch_idx + 1):.3f}s"
+            )
 
-            info_str = f'train Epoch: {self.epochs} | Acc: {100. * correct / total:.3f} | ' \
-                       f'Loss: {self.loss / (batch_idx + 1):.3f} | ' \
-                       f'time: {time.time() - epoch_t:.2f}s |'
+            info_str = (
+                f"train Epoch: {self.epochs} | Acc: {100. * correct / total:.3f} | "
+                f"Loss: {self.loss / (batch_idx + 1):.3f} | "
+                f"time: {time.time() - epoch_t:.2f}s |"
+            )
 
         self.logger.info(info_str)
         pprint_without_newline(info_str)
-        self.train_acc.append(100. * correct / total)
+        self.train_acc.append(100.0 * correct / total)
 
     def val(self):
         self.model.eval()
@@ -91,20 +94,20 @@ class Trainer(object):
                 total += targets.size(0)
                 correct += predicted.eq(targets).sum().item()
 
-        if 100. * correct / total > self.best_val_acc:
-            self.snapshot('best')
-        self.snapshot('latest')
+        if 100.0 * correct / total > self.best_val_acc:
+            self.snapshot("best")
+        self.snapshot("latest")
 
-        self.best_val_acc = max(self.best_val_acc, 100. * correct / total)
-        info_str = f'valid | Acc: {100. * correct / total:.3f} | ' \
-                   f'Loss: {self.loss / len(self.val_loader):.3f} | ' \
-                   f'best: {self.best_val_acc:.3f} | '
+        self.best_val_acc = max(self.best_val_acc, 100.0 * correct / total)
+        info_str = (
+            f"valid | Acc: {100. * correct / total:.3f} | "
+            f"Loss: {self.loss / len(self.val_loader):.3f} | "
+            f"best: {self.best_val_acc:.3f} | "
+        )
 
         print(info_str)
         self.logger.info(info_str)
-        self.val_acc.append(100. * correct / total)
-
-
+        self.val_acc.append(100.0 * correct / total)
 
     def adjust_learning_rate(self):
         c = self.cfg
@@ -119,22 +122,21 @@ class Trainer(object):
                 if self.epochs > m_epoch:
                     lr *= c.SOLVER.LR_GAMMA
 
-
         for param_group in self.optim.param_groups:
-            param_group['lr'] = lr
-            if 'scaling' in param_group:
-                param_group['lr'] *= param_group['scaling']
+            param_group["lr"] = lr
+            if "scaling" in param_group:
+                param_group["lr"] *= param_group["scaling"]
 
     def snapshot(self, name=None):
         state = {
-            'net': self.model.state_dict(),
-            'optim': self.optim.state_dict(),
-            'epoch': self.epochs,
-            'train_accuracy': self.train_acc,
-            'test_accuracy': self.val_acc
+            "net": self.model.state_dict(),
+            "optim": self.optim.state_dict(),
+            "epoch": self.epochs,
+            "train_accuracy": self.train_acc,
+            "test_accuracy": self.val_acc,
         }
 
         if name is None:
-            torch.save(state, f'{self.cfg.OUTPUT_DIR}/epoch-{self.epochs}.pt')
+            torch.save(state, f"{self.cfg.OUTPUT_DIR}/epoch-{self.epochs}.pt")
         else:
-            torch.save(state, f'{self.cfg.OUTPUT_DIR}/{name}.pt')
+            torch.save(state, f"{self.cfg.OUTPUT_DIR}/{name}.pt")

--- a/examples/cifar_isonet/config.py
+++ b/examples/cifar_isonet/config.py
@@ -15,8 +15,8 @@ _C = CN()
 # Dataset
 # -----------------------------------------------------------------------------
 _C.DATASET = CN()
-_C.DATASET.ROOT = '../data'
-_C.DATASET.NAME = 'CIFAR10'
+_C.DATASET.ROOT = "../data"
+_C.DATASET.NAME = "CIFAR10"
 _C.DATASET.NUM_CLASSES = 10
 _C.DATASET.NUM_WORKERS = 1
 
@@ -56,13 +56,14 @@ _C.ISON.RES_MULTIPLIER = 1.0
 _C.ISON.DROPOUT = False
 _C.ISON.DROPOUT_RATE = 0.0
 
-_C.ISON.TRANS_FUN = 'basic_transform'
+_C.ISON.TRANS_FUN = "basic_transform"
 
 
 # ---------------------------------------------------------------------------- #
 # Misc options
 # ---------------------------------------------------------------------------- #
-_C.OUTPUT_DIR = './outputs'
+_C.OUTPUT_DIR = "./outputs"
+
 
 def get_cfg_defaults():
     return _C.clone()

--- a/examples/cifar_isonet/main.py
+++ b/examples/cifar_isonet/main.py
@@ -7,13 +7,15 @@ import os
 import argparse
 import warnings
 import sys
+
 # No need if pykale is installed
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 import torch
 from torchsummary import summary
 
 from config import get_cfg_defaults
+
 # from model_old import get_model
 from model import get_model
 from trainer import Trainer
@@ -22,22 +24,26 @@ from kale.loaddata.cifar_access import get_cifar
 from kale.utils.logger import construct_logger
 from kale.utils.seed import set_seed
 
+
 def arg_parse():
     """Parsing arguments"""
-    parser = argparse.ArgumentParser(description='PyTorch CIFAR10 Training')
-    parser.add_argument('--cfg', required=True, help='path to config file', type=str)
-    parser.add_argument('--output', default='default', help='folder to save output', type=str)
-    parser.add_argument('--resume', default='', type=str)
+    parser = argparse.ArgumentParser(description="PyTorch CIFAR10 Training")
+    parser.add_argument("--cfg", required=True, help="path to config file", type=str)
+    parser.add_argument(
+        "--output", default="default", help="folder to save output", type=str
+    )
+    parser.add_argument("--resume", default="", type=str)
     args = parser.parse_args()
     return args
+
 
 def main():
     """The main for this domain adapation example, showing the workflow"""
     args = arg_parse()
 
     # ---- setup device ----
-    device = 'cuda' if torch.cuda.is_available() else 'cpu'
-    print('==> Using device ' + device)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print("==> Using device " + device)
 
     # ---- setup configs ----
     cfg = get_cfg_defaults()
@@ -48,14 +54,14 @@ def main():
     # ---- setup logger and output ----
     output_dir = os.path.join(cfg.OUTPUT_DIR, cfg.DATASET.NAME, args.output)
     os.makedirs(output_dir, exist_ok=True)
-    logger = construct_logger('isonet', output_dir)
-    logger.info('Using ' + device)
-    logger.info('\n' + cfg.dump())    
-    
+    logger = construct_logger("isonet", output_dir)
+    logger.info("Using " + device)
+    logger.info("\n" + cfg.dump())
+
     # ---- setup dataset ----
     train_loader, val_loader = get_cifar(cfg)
 
-    print('==> Building model..')
+    print("==> Building model..")
     net = get_model(cfg)
     # print(net)
     net = net.to(device)
@@ -63,38 +69,34 @@ def main():
     # logger.info('\n'+str(model_stats))
 
     # Needed even for single GPU https://discuss.pytorch.org/t/attributeerror-net-object-has-no-attribute-module/45652
-    if device=='cuda':
+    if device == "cuda":
         net = torch.nn.DataParallel(net)
 
-    optim = torch.optim.SGD(net.parameters(), lr=cfg.SOLVER.BASE_LR, 
-                    momentum=cfg.SOLVER.MOMENTUM,
-                    weight_decay=cfg.SOLVER.WEIGHT_DECAY, 
-                    dampening=cfg.SOLVER.DAMPENING,
-                    nesterov=cfg.SOLVER.NESTEROV)
+    optim = torch.optim.SGD(
+        net.parameters(),
+        lr=cfg.SOLVER.BASE_LR,
+        momentum=cfg.SOLVER.MOMENTUM,
+        weight_decay=cfg.SOLVER.WEIGHT_DECAY,
+        dampening=cfg.SOLVER.DAMPENING,
+        nesterov=cfg.SOLVER.NESTEROV,
+    )
 
     trainer = Trainer(
-        device,
-        train_loader,
-        val_loader,
-        net,
-        optim,
-        logger,
-        output_dir,
-        cfg
+        device, train_loader, val_loader, net, optim, logger, output_dir, cfg
     )
 
     if args.resume:
         # Load checkpoint
-        print('==> Resuming from checkpoint..')
+        print("==> Resuming from checkpoint..")
         cp = torch.load(args.resume)
-        trainer.model.load_state_dict(cp['net'])
-        trainer.optim.load_state_dict(cp['optim'])
-        trainer.epochs = cp['epoch']
-        trainer.train_acc = cp['train_accuracy']
-        trainer.val_acc = cp['test_accuracy']
+        trainer.model.load_state_dict(cp["net"])
+        trainer.optim.load_state_dict(cp["optim"])
+        trainer.epochs = cp["epoch"]
+        trainer.train_acc = cp["train_accuracy"]
+        trainer.val_acc = cp["test_accuracy"]
 
     trainer.train()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/examples/cifar_isonet/model.py
+++ b/examples/cifar_isonet/model.py
@@ -4,6 +4,7 @@ Define the ISONet model for the CIFAR datasets.
 
 import kale.predict.isonet as isonet
 
+
 def get_config(cfg):
     """
     Sets the hypermeters (architecture) for ISONet using the config file
@@ -21,10 +22,11 @@ def get_config(cfg):
             "has_bn": cfg.ISON.HAS_BN,
             "use_srelu": cfg.ISON.SReLU,
             "transfun": cfg.ISON.TRANS_FUN,
-            "has_st": cfg.ISON.HAS_ST
+            "has_st": cfg.ISON.HAS_ST,
         }
     }
     return config_params
+
 
 # Inherite and override
 class CifarIsoNet(isonet.ISONet):
@@ -33,31 +35,40 @@ class CifarIsoNet(isonet.ISONet):
     Args:
         cfg: A YACS config object.
     """
-    
+
     def __init__(self, net_params):
         super(CifarIsoNet, self).__init__(net_params)
         # define network structures (override)
-        self._construct(net_params)        
+        self._construct(net_params)
         # initialization
-        self._network_init(net_params['use_dirac'])
+        self._network_init(net_params["use_dirac"])
 
-    def _construct(self, net_params):      
-        assert (net_params['depths'] - 2) % 6 == 0, \
-            'Model depth should be of the format 6n + 2 for cifar'  # Seems because this is a ResNet
+    def _construct(self, net_params):
+        assert (
+            net_params["depths"] - 2
+        ) % 6 == 0, "Model depth should be of the format 6n + 2 for cifar"  # Seems because this is a ResNet
         # Each stage has the same number of blocks for cifar
-        
-        d = int((net_params['depths'] - 2) / 6)
+
+        d = int((net_params["depths"] - 2) / 6)
         # Stem: (N, 3, 32, 32) -> (N, 16, 32, 32)
-        self.stem = isonet.ResStem(w_in=3, w_out=16, net_params=net_params, 
-                                    kernelsize=3, stride=1, padding=1)
+        self.stem = isonet.ResStem(
+            w_in=3, w_out=16, net_params=net_params, kernelsize=3, stride=1, padding=1
+        )
         # Stage 1: (N, 16, 32, 32) -> (N, 16, 32, 32)
-        self.s1 = isonet.ResStage(w_in=16, w_out=16, stride=1, net_params=net_params, d=d)
+        self.s1 = isonet.ResStage(
+            w_in=16, w_out=16, stride=1, net_params=net_params, d=d
+        )
         # Stage 2: (N, 16, 32, 32) -> (N, 32, 16, 16)
-        self.s2 = isonet.ResStage(w_in=16, w_out=32, stride=2, net_params=net_params, d=d)
+        self.s2 = isonet.ResStage(
+            w_in=16, w_out=32, stride=2, net_params=net_params, d=d
+        )
         # Stage 3: (N, 32, 16, 16) -> (N, 64, 8, 8)
-        self.s3 = isonet.ResStage(w_in=32, w_out=64, stride=2, net_params=net_params, d=d)
+        self.s3 = isonet.ResStage(
+            w_in=32, w_out=64, stride=2, net_params=net_params, d=d
+        )
         # Head: (N, 64, 8, 8) -> (N, num_classes)
         self.head = isonet.ResHead(w_in=64, net_params=net_params)
+
 
 def get_model(cfg):
     """
@@ -67,8 +78,8 @@ def get_model(cfg):
     Args:
         cfg: A YACS config object.
     """
-    
+
     config_params = get_config(cfg)
-    net_params = config_params["net_params"]    
+    net_params = config_params["net_params"]
     net = CifarIsoNet(net_params)
-    return net                               
+    return net

--- a/examples/cifar_isonet/trainer.py
+++ b/examples/cifar_isonet/trainer.py
@@ -8,20 +8,24 @@ import torch
 import torch.nn as nn
 from kale.utils.print import tprint, pprint_without_newline
 
+
 class Trainer(object):
     """Sets up a standard trainer
 
     Args:
         device: gpu or cpu
-        train_loader: the training data loader 
-        val_loader: the validation data loader 
+        train_loader: the training data loader
+        val_loader: the validation data loader
         model: the (network) model
         optim: the optimizer
         logger:: the logger to log info
         output_dir: the path to save info
         cfg: a YACS config object.
-    """    
-    def __init__(self, device, train_loader, val_loader, model, optim, logger, output_dir, cfg):      
+    """
+
+    def __init__(
+        self, device, train_loader, val_loader, model, optim, logger, output_dir, cfg
+    ):
         # misc
         self.device = device
         self.output_dir = output_dir
@@ -45,7 +49,7 @@ class Trainer(object):
         self.cfg = cfg
 
     def train(self):
-        """The validation step"""        
+        """The validation step"""
         while self.epochs <= self.cfg.SOLVER.MAX_EPOCHS:
             self.adjust_learning_rate()
             self.train_epoch()
@@ -53,7 +57,7 @@ class Trainer(object):
             self.epochs += 1
 
     def train_epoch(self):
-        """One training epoch"""        
+        """One training epoch"""
         self.model.train()
         self.ce_loss = 0
         self.ortho_loss = 0
@@ -78,16 +82,20 @@ class Trainer(object):
             correct += predicted.eq(targets).sum().item()
 
             self.ave_time += time.time() - iter_t
-            tprint(f'train Epoch: {self.epochs} | {batch_idx + 1} / {len(self.train_loader)} | '
-                   f'Acc: {100. * correct / total:.3f} | CE: {self.ce_loss / (batch_idx + 1):.3f} | '
-                   f'O: {self.ortho_loss / (batch_idx + 1):.3f} | time: {self.ave_time / (batch_idx + 1):.3f}s')
+            tprint(
+                f"train Epoch: {self.epochs} | {batch_idx + 1} / {len(self.train_loader)} | "
+                f"Acc: {100. * correct / total:.3f} | CE: {self.ce_loss / (batch_idx + 1):.3f} | "
+                f"O: {self.ortho_loss / (batch_idx + 1):.3f} | time: {self.ave_time / (batch_idx + 1):.3f}s"
+            )
 
-        info_str = f'train Epoch: {self.epochs} | Acc: {100. * correct / total:.3f} | ' \
-                   f'CE: {self.ce_loss / (batch_idx + 1):.3f} | ' \
-                   f'time: {time.time() - epoch_t:.2f}s |'
+        info_str = (
+            f"train Epoch: {self.epochs} | Acc: {100. * correct / total:.3f} | "
+            f"CE: {self.ce_loss / (batch_idx + 1):.3f} | "
+            f"time: {time.time() - epoch_t:.2f}s |"
+        )
         self.logger.info(info_str)
         pprint_without_newline(info_str)
-        self.train_acc.append(100. * correct / total)
+        self.train_acc.append(100.0 * correct / total)
 
     def val(self):
         """The validation step"""
@@ -106,17 +114,19 @@ class Trainer(object):
                 total += targets.size(0)
                 correct += predicted.eq(targets).sum().item()
 
-        if 100. * correct / total > self.best_valid_acc:
-            self.snapshot('best')
-        self.snapshot('latest')
-        self.best_valid_acc = max(self.best_valid_acc, 100. * correct / total)
-        info_str = f'valid | Acc: {100. * correct / total:.3f} | ' \
-                   f'CE: {self.ce_loss / len(self.val_loader):.3f} | ' \
-                   f'O: {self.ortho_loss / len(self.val_loader):.3f} | ' \
-                   f'best: {self.best_valid_acc:.3f} | '
+        if 100.0 * correct / total > self.best_valid_acc:
+            self.snapshot("best")
+        self.snapshot("latest")
+        self.best_valid_acc = max(self.best_valid_acc, 100.0 * correct / total)
+        info_str = (
+            f"valid | Acc: {100. * correct / total:.3f} | "
+            f"CE: {self.ce_loss / len(self.val_loader):.3f} | "
+            f"O: {self.ortho_loss / len(self.val_loader):.3f} | "
+            f"best: {self.best_valid_acc:.3f} | "
+        )
         print(info_str)
         self.logger.info(info_str)
-        self.val_acc.append(100. * correct / total)
+        self.val_acc.append(100.0 * correct / total)
 
     def loss(self, outputs, targets):
         """Computes the loss between learning outputs and the targets (ground truth)"""
@@ -142,20 +152,20 @@ class Trainer(object):
                     lr *= self.cfg.SOLVER.LR_GAMMA
 
         for param_group in self.optim.param_groups:
-            param_group['lr'] = lr
-            if 'scaling' in param_group:
-                param_group['lr'] *= param_group['scaling']
+            param_group["lr"] = lr
+            if "scaling" in param_group:
+                param_group["lr"] *= param_group["scaling"]
 
     def snapshot(self, name=None):
         """Saves the current model"""
         state = {
-            'net': self.model.state_dict(),
-            'optim': self.optim.state_dict(),
-            'epoch': self.epochs,
-            'train_accuracy': self.train_acc,
-            'test_accuracy': self.val_acc
+            "net": self.model.state_dict(),
+            "optim": self.optim.state_dict(),
+            "epoch": self.epochs,
+            "train_accuracy": self.train_acc,
+            "test_accuracy": self.val_acc,
         }
         if name is None:
-            torch.save(state, f'{self.output_dir}/{self.epochs}.pt')
+            torch.save(state, f"{self.output_dir}/{self.epochs}.pt")
         else:
-            torch.save(state, f'{self.output_dir}/{name}.pt')
+            torch.save(state, f"{self.output_dir}/{name}.pt")

--- a/examples/digits_dann_lightn/config.py
+++ b/examples/digits_dann_lightn/config.py
@@ -15,15 +15,15 @@ _C = CN()
 # Dataset
 # -----------------------------------------------------------------------------
 _C.DATASET = CN()
-_C.DATASET.ROOT = '../data'  # '/shared/tale2/Shared'
-_C.DATASET.NAME = 'digits'  # dset choices=['office', 'image-clef', 'office-home']
-_C.DATASET.SOURCE = 'mnist'  # s_dset_path  , help="The source dataset path list"
-_C.DATASET.TARGET = 'usps'  # s_dset_path  , help="The target dataset path list"
+_C.DATASET.ROOT = "../data"  # '/shared/tale2/Shared'
+_C.DATASET.NAME = "digits"  # dset choices=['office', 'image-clef', 'office-home']
+_C.DATASET.SOURCE = "mnist"  # s_dset_path  , help="The source dataset path list"
+_C.DATASET.TARGET = "usps"  # s_dset_path  , help="The target dataset path list"
 _C.DATASET.NUM_CLASSES = 10
 _C.DATASET.NUM_REPEAT = 10  # 10
 _C.DATASET.DIMENSION = 784
-_C.DATASET.WEIGHT_TYPE = 'natural'
-_C.DATASET.SIZE_TYPE = 'source'
+_C.DATASET.WEIGHT_TYPE = "natural"
+_C.DATASET.SIZE_TYPE = "source"
 # ---------------------------------------------------------------------------- #
 # Solver
 # ---------------------------------------------------------------------------- #
@@ -50,18 +50,19 @@ _C.SOLVER.INIT_LAMBDA = 1
 # Domain Adaptation Net (DAN) configs
 # ---------------------------------------------------------------------------- #
 _C.DAN = CN()
-_C.DAN.METHOD = 'CDAN'  # choices=['CDAN', 'CDAN-E', 'DANN']
+_C.DAN.METHOD = "CDAN"  # choices=['CDAN', 'CDAN-E', 'DANN']
 _C.DAN.USERANDOM = False
 _C.DAN.RANDOM_DIM = 1024
 # ---------------------------------------------------------------------------- #
 # Misc options
 # ---------------------------------------------------------------------------- #
 _C.OUTPUT = CN()
-_C.OUTPUT.ROOT = './outputs'  # output_dir
+_C.OUTPUT.ROOT = "./outputs"  # output_dir
 _C.OUTPUT.VERBOSE = False  # To discuss, for HPC jobs
 _C.OUTPUT.PB_FRESH = 0  # 0 # 50 # 0 to disable  ; MAYBE make it a command line option
-_C.OUTPUT.DIR = os.path.join(_C.OUTPUT.ROOT, _C.DATASET.NAME + '_' +
-                             _C.DATASET.SOURCE + '2' + _C.DATASET.TARGET)
+_C.OUTPUT.DIR = os.path.join(
+    _C.OUTPUT.ROOT, _C.DATASET.NAME + "_" + _C.DATASET.SOURCE + "2" + _C.DATASET.TARGET
+)
 
 
 def get_cfg_defaults():

--- a/examples/digits_dann_lightn/main.py
+++ b/examples/digits_dann_lightn/main.py
@@ -9,9 +9,11 @@ import warnings
 import sys
 import logging
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
-from kale.utils.csv_logger import setup_logger  # np error if move this to later, not sure why
+from kale.utils.csv_logger import (
+    setup_logger,
+)  # np error if move this to later, not sure why
 import torch
 import pytorch_lightning as pl
 
@@ -24,10 +26,12 @@ from kale.utils.seed import set_seed
 
 def arg_parse():
     """Parsing arguments"""
-    parser = argparse.ArgumentParser(description='Domain Adversarial Networks on Digits Datasets')
-    parser.add_argument('--cfg', required=True, help='path to config file', type=str)
-    parser.add_argument('--gpus', default='0', help='gpu id(s) to use', type=str)
-    parser.add_argument('--resume', default='', type=str)
+    parser = argparse.ArgumentParser(
+        description="Domain Adversarial Networks on Digits Datasets"
+    )
+    parser.add_argument("--cfg", required=True, help="path to config file", type=str)
+    parser.add_argument("--gpus", default="0", help="gpu id(s) to use", type=str)
+    parser.add_argument("--resume", default="", type=str)
     args = parser.parse_args()
     return args
 
@@ -42,29 +46,35 @@ def main():
     cfg.freeze()
     print(cfg)
 
-    # ---- setup output ----    
+    # ---- setup output ----
     os.makedirs(cfg.OUTPUT.DIR, exist_ok=True)
     format_str = "@%(asctime)s %(name)s [%(levelname)s] - (%(message)s)"
     logging.basicConfig(format=format_str)
     # ---- setup dataset ----
-    source, target, num_channels = DigitDataset.get_source_target(DigitDataset(cfg.DATASET.SOURCE.upper()),
-                                                                  DigitDataset(cfg.DATASET.TARGET.upper()),
-                                                                  cfg.DATASET.ROOT)
-    dataset = MultiDomainDatasets(source, target, config_weight_type=cfg.DATASET.WEIGHT_TYPE,
-                                  config_size_type=cfg.DATASET.SIZE_TYPE)
+    source, target, num_channels = DigitDataset.get_source_target(
+        DigitDataset(cfg.DATASET.SOURCE.upper()),
+        DigitDataset(cfg.DATASET.TARGET.upper()),
+        cfg.DATASET.ROOT,
+    )
+    dataset = MultiDomainDatasets(
+        source,
+        target,
+        config_weight_type=cfg.DATASET.WEIGHT_TYPE,
+        config_size_type=cfg.DATASET.SIZE_TYPE,
+    )
 
     # Repeat multiple times to get std
     for i in range(0, cfg.DATASET.NUM_REPEAT):
         seed = cfg.SOLVER.SEED + i * 10
         set_seed(
-            seed)  # seed_everything in pytorch_lightning did not set torch.backends.cudnn
-        print(f'==> Building model for seed {seed} ......')
-        # ---- setup model and logger ----                                                     
+            seed
+        )  # seed_everything in pytorch_lightning did not set torch.backends.cudnn
+        print(f"==> Building model for seed {seed} ......")
+        # ---- setup model and logger ----
         model, train_params = get_model(cfg, dataset, num_channels)
-        logger, results, checkpoint_callback, test_csv_file = setup_logger(train_params,
-                                                                           cfg.OUTPUT.DIR,
-                                                                           cfg.DAN.METHOD,
-                                                                           seed)
+        logger, results, checkpoint_callback, test_csv_file = setup_logger(
+            train_params, cfg.OUTPUT.DIR, cfg.DAN.METHOD, seed
+        )
         trainer = pl.Trainer(
             progress_bar_refresh_rate=cfg.OUTPUT.PB_FRESH,  # in steps
             min_epochs=cfg.SOLVER.MIN_EPOCHS,
@@ -73,7 +83,7 @@ def main():
             # resume_from_checkpoint=last_checkpoint_file,
             gpus=args.gpus,
             logger=False,  # logger,
-            # weights_summary='full',  
+            # weights_summary='full',
             fast_dev_run=True,  # True,
         )
 
@@ -96,5 +106,5 @@ def main():
         results.print_scores(cfg.DAN.METHOD)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/examples/digits_dann_lightn/main.py
+++ b/examples/digits_dann_lightn/main.py
@@ -5,16 +5,15 @@ Reference: https://github.com/thuml/CDAN/blob/master/pytorch/train_image.py
 
 import os
 import argparse
-import warnings
-import sys
+# import warnings
+# import sys
 import logging
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+# sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
-from kale.utils.csv_logger import (
-    setup_logger,
-)  # np error if move this to later, not sure why
-import torch
+# np error if move this to later, not sure why
+from kale.utils.csv_logger import setup_logger
+# import torch
 import pytorch_lightning as pl
 
 from config import get_cfg_defaults
@@ -66,9 +65,8 @@ def main():
     # Repeat multiple times to get std
     for i in range(0, cfg.DATASET.NUM_REPEAT):
         seed = cfg.SOLVER.SEED + i * 10
-        set_seed(
-            seed
-        )  # seed_everything in pytorch_lightning did not set torch.backends.cudnn
+        # seed_everything in pytorch_lightning did not set torch.backends.cudnn
+        set_seed(seed)
         print(f"==> Building model for seed {seed} ......")
         # ---- setup model and logger ----
         model, train_params = get_model(cfg, dataset, num_channels)

--- a/examples/digits_dann_lightn/model.py
+++ b/examples/digits_dann_lightn/model.py
@@ -6,8 +6,7 @@ Define the learning model and configure training parameters.
 
 from copy import deepcopy
 from kale.embed.image_cnn import SmallCNNFeature
-from kale.predict.class_domain_nets import ClassNetSmallImage, \
-    DomainNetSmallImage
+from kale.predict.class_domain_nets import ClassNetSmallImage, DomainNetSmallImage
 import kale.pipeline.domain_adapter as domain_adapter
 
 
@@ -32,18 +31,18 @@ def get_config(cfg):
                 "optim_params": {
                     "momentum": cfg.SOLVER.MOMENTUM,
                     "weight_decay": cfg.SOLVER.WEIGHT_DECAY,
-                    "nesterov": cfg.SOLVER.NESTEROV
-                }
-            }
+                    "nesterov": cfg.SOLVER.NESTEROV,
+                },
+            },
         },
         "data_params": {
             "dataset_group": cfg.DATASET.NAME,
-            "dataset_name": cfg.DATASET.SOURCE + '2' + cfg.DATASET.TARGET,
+            "dataset_name": cfg.DATASET.SOURCE + "2" + cfg.DATASET.TARGET,
             "source": cfg.DATASET.SOURCE,
             "target": cfg.DATASET.TARGET,
             "size_type": cfg.DATASET.SIZE_TYPE,
-            "weight_type": cfg.DATASET.WEIGHT_TYPE
-        }
+            "weight_type": cfg.DATASET.WEIGHT_TYPE,
+        },
     }
     return config_params
 
@@ -56,7 +55,7 @@ def get_model(cfg, dataset, num_channels):
     Args:
         cfg: A YACS config object.
         dataset: A multidomain dataset consisting of source and target datasets.
-        num_channels: The number of image channels.        
+        num_channels: The number of image channels.
     """
 
     # setup feature extractor
@@ -79,7 +78,7 @@ def get_model(cfg, dataset, num_channels):
     train_params = config_params["train_params"]
     train_params_local = deepcopy(train_params)
     method_params = {}
-    if cfg.DAN.METHOD == 'CDAN':
+    if cfg.DAN.METHOD == "CDAN":
         method_params["use_random"] = cfg.DAN.USERANDOM
 
     # The following calls kale.loaddata.dataset_access for the first time

--- a/examples/drug_gripnet/config.py
+++ b/examples/drug_gripnet/config.py
@@ -10,11 +10,11 @@ C = CfgNode()
 # Dataset
 # -----------------------------------------------------------------------------
 C.DATASET = CfgNode()
-C.DATASET.ROOT = 'examples/data'
-C.DATASET.NAME = 'PoSE'
-C.DATASET.DD = 'drug-drug.pt'
-C.DATASET.GD = 'gene-drug.pt'
-C.DATASET.GG = 'gene-gene.pt'
+C.DATASET.ROOT = "examples/data"
+C.DATASET.NAME = "PoSE"
+C.DATASET.DD = "drug-drug.pt"
+C.DATASET.GD = "gene-drug.pt"
+C.DATASET.GG = "gene-gene.pt"
 
 # ---------------------------------------------------------------------------- #
 # Solver
@@ -39,7 +39,7 @@ C.GRIPN.DD_LAYERS = [sum(C.GRIPN.GD_LAYERS), 16]
 # ---------------------------------------------------------------------------- #
 # Misc options
 # ---------------------------------------------------------------------------- #
-C.OUTPUT_DIR = './outputs'
+C.OUTPUT_DIR = "./outputs"
 
 
 def get_cfg_defaults():

--- a/examples/drug_gripnet/main.py
+++ b/examples/drug_gripnet/main.py
@@ -3,7 +3,7 @@ import argparse
 import sys
 
 # No need if pykale is installed
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 import torch
 import kale.utils.logger as lu
@@ -17,10 +17,12 @@ from trainer import Trainer
 
 
 def arg_parse():
-    parser = argparse.ArgumentParser(description='PyTorch CIFAR10 Training')
-    parser.add_argument('--cfg', required=True, help='path to config file', type=str)
-    parser.add_argument('--output', default='default', help='folder to save output', type=str)
-    parser.add_argument('--resume', default='', type=str)
+    parser = argparse.ArgumentParser(description="PyTorch CIFAR10 Training")
+    parser.add_argument("--cfg", required=True, help="path to config file", type=str)
+    parser.add_argument(
+        "--output", default="default", help="folder to save output", type=str
+    )
+    parser.add_argument("--resume", default="", type=str)
     args = parser.parse_args()
     return args
 
@@ -28,8 +30,8 @@ def arg_parse():
 def main():
     args = arg_parse()
     # ---- setup device ----
-    device = 'cuda' if torch.cuda.is_available() else 'cpu'
-    print('==> Using device ' + device)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print("==> Using device " + device)
 
     # ---- setup configs ----
     cfg = get_cfg_defaults()
@@ -39,17 +41,23 @@ def main():
     # ---- setup logger and output ----
     output_dir = os.path.join(cfg.OUTPUT_DIR, cfg.DATASET.NAME, args.output)
     os.makedirs(output_dir, exist_ok=True)
-    logger = lu.construct_logger('gripnet', output_dir)
-    logger.info('Using ' + device)
+    logger = lu.construct_logger("gripnet", output_dir)
+    logger.info("Using " + device)
     logger.info(cfg.dump())
     # ---- setup dataset ----
     data = construct_dataset(cfg)
     device = torch.device(device)
     data = data.to(device)
     # ---- setup model ----
-    print('==> Building model..')
-    model = GripNet(cfg.GRIPN.GG_LAYERS, cfg.GRIPN.GD_LAYERS, cfg.GRIPN.DD_LAYERS, data.n_d_node,
-                    data.n_g_node, data.n_dd_edge_type).to(device)
+    print("==> Building model..")
+    model = GripNet(
+        cfg.GRIPN.GG_LAYERS,
+        cfg.GRIPN.GD_LAYERS,
+        cfg.GRIPN.DD_LAYERS,
+        data.n_d_node,
+        data.n_g_node,
+        data.n_dd_edge_type,
+    ).to(device)
     # TODO Visualize model
     # ---- setup trainers ----
     optimizer = torch.optim.Adam(model.parameters(), lr=cfg.SOLVER.BASE_LR)
@@ -58,20 +66,20 @@ def main():
 
     if args.resume:
         # Load checkpoint
-        print('==> Resuming from checkpoint..')
+        print("==> Resuming from checkpoint..")
         cp = torch.load(args.resume)
-        trainer.model.load_state_dict(cp['net'])
-        trainer.optim.load_state_dict(cp['optim'])
-        trainer.epochs = cp['epoch']
-        trainer.train_auprc = cp['train_auprc']
-        trainer.val_auprc = cp['val_auprc']
-        trainer.train_auroc = cp['train_auroc']
-        trainer.val_auroc = cp['val_auroc']
-        trainer.train_ap = cp['train_ap']
-        trainer.val_ap = cp['val_ap']
+        trainer.model.load_state_dict(cp["net"])
+        trainer.optim.load_state_dict(cp["optim"])
+        trainer.epochs = cp["epoch"]
+        trainer.train_auprc = cp["train_auprc"]
+        trainer.val_auprc = cp["val_auprc"]
+        trainer.train_auroc = cp["train_auroc"]
+        trainer.val_auroc = cp["val_auroc"]
+        trainer.train_ap = cp["train_ap"]
+        trainer.val_ap = cp["val_ap"]
 
     trainer.train()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/examples/drug_gripnet/trainer.py
+++ b/examples/drug_gripnet/trainer.py
@@ -37,9 +37,16 @@ class Trainer(object):
         self.optim.zero_grad()
         self.loss = 0
         epoch_t = time.time()
-        pos_score, neg_score = self.model(self.data.g_feat, self.data.gg_edge_index, self.data.edge_weight,
-                                          self.data.gd_edge_index, self.data.train_idx, self.data.train_et,
-                                          self.data.train_range, self.device)
+        pos_score, neg_score = self.model(
+            self.data.g_feat,
+            self.data.gg_edge_index,
+            self.data.edge_weight,
+            self.data.gd_edge_index,
+            self.data.train_idx,
+            self.data.train_et,
+            self.data.train_range,
+            self.device,
+        )
         pos_loss = -torch.log(pos_score + self.EPS).mean()
         neg_loss = -torch.log(1 - neg_score + self.EPS).mean()
         loss = pos_loss + neg_loss
@@ -51,8 +58,8 @@ class Trainer(object):
         record = np.zeros((3, self.data.n_dd_edge_type))  # auprc, auroc, ap
         for i in range(self.data.train_range.shape[0]):
             [start, end] = self.data.train_range[i]
-            p_s = pos_score[start: end]
-            n_s = neg_score[start: end]
+            p_s = pos_score[start:end]
+            n_s = neg_score[start:end]
 
             pos_target = torch.ones(p_s.shape[0])
             neg_target = torch.zeros(n_s.shape[0])
@@ -64,8 +71,9 @@ class Trainer(object):
                 record[0, i], record[1, i], record[2, i] = auprc_auroc_ap(target, score)
 
         [auprc, auroc, ap] = record.mean(axis=1)
-        info_str = 'train Epoch: {:3d}\tloss: {:0.4f}\tauprc: {:0.4f}\t auroc: {:0.4f}\tap@50: {:0.4f}s\ttime: {:0.2f}'.format(
-            self.epochs, self.loss, auprc, auroc, ap, time.time() - epoch_t)
+        info_str = "train Epoch: {:3d}\tloss: {:0.4f}\tauprc: {:0.4f}\t auroc: {:0.4f}\tap@50: {:0.4f}s\ttime: {:0.2f}".format(
+            self.epochs, self.loss, auprc, auroc, ap, time.time() - epoch_t
+        )
         self.logger.info(info_str)
         print(info_str)
         self.train_auprc.append(auprc)
@@ -76,9 +84,16 @@ class Trainer(object):
         self.model.eval()
         self.loss = 0
         epoch_t = time.time()
-        pos_score, neg_score = self.model(self.data.g_feat, self.data.gg_edge_index, self.data.edge_weight,
-                                          self.data.gd_edge_index, self.data.test_idx, self.data.test_et,
-                                          self.data.test_range, self.device)
+        pos_score, neg_score = self.model(
+            self.data.g_feat,
+            self.data.gg_edge_index,
+            self.data.edge_weight,
+            self.data.gd_edge_index,
+            self.data.test_idx,
+            self.data.test_et,
+            self.data.test_range,
+            self.device,
+        )
         pos_loss = -torch.log(pos_score + EPS).mean()
         neg_loss = -torch.log(1 - neg_score + EPS).mean()
         loss = pos_loss + neg_loss
@@ -87,8 +102,8 @@ class Trainer(object):
         record = np.zeros((3, self.data.n_dd_edge_type))
         for i in range(self.data.test_range.shape[0]):
             [start, end] = self.data.test_range[i]
-            p_s = pos_score[start: end]
-            n_s = neg_score[start: end]
+            p_s = pos_score[start:end]
+            n_s = neg_score[start:end]
 
             pos_target = torch.ones(p_s.shape[0])
             neg_target = torch.zeros(n_s.shape[0])
@@ -100,12 +115,19 @@ class Trainer(object):
                 record[0, i], record[1, i], record[2, i] = auprc_auroc_ap(target, score)
         [auprc, auroc, ap] = record.mean(axis=1)
         if ap > self.best_ap:
-            self.snapshot('best')
-        self.snapshot('latest')
+            self.snapshot("best")
+        self.snapshot("latest")
 
         self.best_ap = max(self.best_ap, ap)
-        info_str = 'valid Epoch: {:3d}\tloss: {:0.4f}\tauprc: {:0.4f}\t auroc: {:0.4f}\tap@50: {:0.4f}\ttime: {:0.2f}s\tbest_ap: {:0.4f}'.format(
-            self.epochs, self.loss, auprc, auroc, ap, time.time() - epoch_t, self.best_ap)
+        info_str = "valid Epoch: {:3d}\tloss: {:0.4f}\tauprc: {:0.4f}\t auroc: {:0.4f}\tap@50: {:0.4f}\ttime: {:0.2f}s\tbest_ap: {:0.4f}".format(
+            self.epochs,
+            self.loss,
+            auprc,
+            auroc,
+            ap,
+            time.time() - epoch_t,
+            self.best_ap,
+        )
         self.logger.info(info_str)
         print(info_str)
         self.train_auprc.append(auprc)
@@ -126,24 +148,24 @@ class Trainer(object):
                     lr *= c.SOLVER.LR_GAMMA
 
         for param_group in self.optim.param_groups:
-            param_group['lr'] = lr
-            if 'scaling' in param_group:
-                param_group['lr'] *= param_group['scaling']
+            param_group["lr"] = lr
+            if "scaling" in param_group:
+                param_group["lr"] *= param_group["scaling"]
 
     def snapshot(self, name=None):
         state = {
-            'net': self.model.state_dict(),
-            'optim': self.optim.state_dict(),
-            'epoch': self.epochs,
-            'train_auprc': self.train_auprc,
-            'val_auprc': self.val_auprc,
-            'train_auroc': self.train_auroc,
-            'val_auroc': self.val_auroc,
-            'train_ap@50': self.train_ap,
-            'val_ap@50': self.val_ap,
+            "net": self.model.state_dict(),
+            "optim": self.optim.state_dict(),
+            "epoch": self.epochs,
+            "train_auprc": self.train_auprc,
+            "val_auprc": self.val_auprc,
+            "train_auroc": self.train_auroc,
+            "val_auroc": self.val_auroc,
+            "train_ap@50": self.train_ap,
+            "val_ap@50": self.val_ap,
         }
 
         if name is None:
-            torch.save(state, f'{self.cfg.OUTPUT_DIR}/epoch-{self.epochs}.pt')
+            torch.save(state, f"{self.cfg.OUTPUT_DIR}/epoch-{self.epochs}.pt")
         else:
-            torch.save(state, f'{self.cfg.OUTPUT_DIR}/{name}.pt')
+            torch.save(state, f"{self.cfg.OUTPUT_DIR}/{name}.pt")

--- a/examples/drug_gripnet/utils.py
+++ b/examples/drug_gripnet/utils.py
@@ -35,7 +35,9 @@ def auprc_auroc_ap(target_tensor, score_tensor):
 def micro_macro(target_tensor, score_tensor):
     y = target_tensor.detach().cpu().numpy()
     pred = score_tensor.detach().cpu().numpy()
-    micro, macro = metrics.f1_score(y, pred, average='micro'), metrics.f1_score(y, pred, average='macro')
+    micro, macro = metrics.f1_score(y, pred, average="micro"), metrics.f1_score(
+        y, pred, average="macro"
+    )
 
     return micro, macro
 
@@ -46,7 +48,7 @@ def acc(target_tensor, score_tensor):
     return accuracy_score(y, pred)
 
 
-def load_graph(pt_file_path='./sample_graph.pt'):
+def load_graph(pt_file_path="./sample_graph.pt"):
     """
     Parameters
     ----------
@@ -74,7 +76,7 @@ def load_graph(pt_file_path='./sample_graph.pt'):
     return torch.load(pt_file_path)
 
 
-def load_node_idx_to_id_dict(pkl_file_path='./data/pose-1/map.pkl'):
+def load_node_idx_to_id_dict(pkl_file_path="./data/pose-1/map.pkl"):
     """
     Parameters:
     -----------
@@ -84,14 +86,14 @@ def load_node_idx_to_id_dict(pkl_file_path='./data/pose-1/map.pkl'):
     --------
     a dictionary of map from node index to entity id/name
     """
-    with open(pkl_file_path, 'rb') as f:
+    with open(pkl_file_path, "rb") as f:
         out = pickle.load(f)
     return out
 
 
 def negative_sampling(pos_edge_index, num_nodes):
-    idx = (pos_edge_index[0] * num_nodes + pos_edge_index[1])
-    idx = idx.to(torch.device('cpu'))
+    idx = pos_edge_index[0] * num_nodes + pos_edge_index[1]
+    idx = idx.to(torch.device("cpu"))
 
     perm = torch.tensor(np.random.choice(num_nodes ** 2, idx.size(0)))
     mask = torch.from_numpy(np.isin(perm, idx).astype(np.uint8))
@@ -109,5 +111,5 @@ def negative_sampling(pos_edge_index, num_nodes):
 def typed_negative_sampling(pos_edge_index, num_nodes, range_list):
     tmp = []
     for start, end in range_list:
-        tmp.append(negative_sampling(pos_edge_index[:, start: end], num_nodes))
+        tmp.append(negative_sampling(pos_edge_index[:, start:end], num_nodes))
     return torch.cat(tmp, dim=1)

--- a/examples/video_loading/main.py
+++ b/examples/video_loading/main.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 # No need if pykale is installed
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 from kale.loaddata.videos import VideoFrameDataset
 from kale.prepdata.video_transform import ImglistToTensor
@@ -19,14 +19,14 @@ Ignore this function and look at "main" below.
 
 def download_dummy_dataset():
     # Full File URL: https://drive.google.com/file/d/1U4D23R8u8MJX9KVKb92bZZX-tbpKWtga/view?usp=sharing
-    gdrive_file_id = '1U4D23R8u8MJX9KVKb92bZZX-tbpKWtga'
+    gdrive_file_id = "1U4D23R8u8MJX9KVKb92bZZX-tbpKWtga"
     output_directory = os.path.join(os.getcwd())
-    output_file_name = 'demo_datasets.zip'
+    output_file_name = "demo_datasets.zip"
 
     print("Downloading Dummy Datasets")
     download_file_from_google_drive(gdrive_file_id, output_directory, output_file_name)
 
-    if os.path.exists(os.path.join(os.getcwd(), 'demo_dataset')):
+    if os.path.exists(os.path.join(os.getcwd(), "demo_dataset")):
         print("Skipping Download and Extraction")
         return
 
@@ -45,10 +45,12 @@ Ignore this function too
 
 def plot_video(rows, cols, frame_list, plot_width, plot_height):
     fig = plt.figure(figsize=(plot_width, plot_height))
-    grid = ImageGrid(fig, 111,  # similar to subplot(111)
-                     nrows_ncols=(rows, cols),  # creates 2x2 grid of axes
-                     axes_pad=0.3,  # pad between axes in inch.
-                     )
+    grid = ImageGrid(
+        fig,
+        111,  # similar to subplot(111)
+        nrows_ncols=(rows, cols),  # creates 2x2 grid of axes
+        axes_pad=0.3,  # pad between axes in inch.
+    )
 
     for index, (ax, im) in enumerate(zip(grid, frame_list)):
         # Iterating over the grid returns the Axes.
@@ -57,23 +59,23 @@ def plot_video(rows, cols, frame_list, plot_width, plot_height):
     plt.show()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     """
     This demo uses the dummy dataset inside of the folder "demo_dataset".
     It is structured just like a real dataset would need to be structured.
-    
+
     TABLE OF CODE CONTENTS:
     1. Minimal demo without image transforms
     2. Minimal demo without sparse temporal sampling for single continuous frame clips, without image transforms
     3. Demo with image transforms
     4. Demo 3 continued with PyTorch dataloader
     5. Demo of using a dataset where samples have multiple separate class labels
-    
+
     """
     download_dummy_dataset()
 
-    videos_root = os.path.join(os.getcwd(), 'demo_dataset')
-    annotation_file = os.path.join(videos_root, 'annotations.txt')
+    videos_root = os.path.join(os.getcwd(), "demo_dataset")
+    annotation_file = os.path.join(videos_root, "annotations.txt")
 
     """ DEMO 1 WITHOUT IMAGE TRANSFORMS """
     dataset = VideoFrameDataset(
@@ -81,17 +83,17 @@ if __name__ == '__main__':
         annotationfile_path=annotation_file,
         num_segments=5,
         frames_per_segment=1,
-        imagefile_template='img_{:05d}.jpg',
+        imagefile_template="img_{:05d}.jpg",
         transform=None,
         random_shift=True,
-        test_mode=False
+        test_mode=False,
     )
 
     sample = dataset[0]
     frames = sample[0]  # list of PIL images
     label = sample[1]  # integer label
 
-    plot_video(rows=1, cols=5, frame_list=frames, plot_width=15., plot_height=3.)
+    plot_video(rows=1, cols=5, frame_list=frames, plot_width=15.0, plot_height=3.0)
 
     """ DEMO 2 SINGLE CONTINUOUS FRAME CLIP INSTEAD OF SAMPLED FRAMES, WITHOUT TRANSFORMS """
     # If you do not want to use sparse temporal sampling, and instead
@@ -104,52 +106,55 @@ if __name__ == '__main__':
         annotationfile_path=annotation_file,
         num_segments=1,
         frames_per_segment=9,
-        imagefile_template='img_{:05d}.jpg',
+        imagefile_template="img_{:05d}.jpg",
         transform=None,
         random_shift=True,
-        test_mode=False
+        test_mode=False,
     )
 
     sample = dataset[1]
     frames = sample[0]  # list of PIL images
     label = sample[1]  # integer label
 
-    plot_video(rows=3, cols=3, frame_list=frames, plot_width=10., plot_height=5.)
+    plot_video(rows=3, cols=3, frame_list=frames, plot_width=10.0, plot_height=5.0)
 
     """ DEMO 3 WITH TRANSFORMS """
     # As of torchvision 0.8.0, torchvision transforms support batches of images
     # of size (BATCH x CHANNELS x HEIGHT x WIDTH) and apply deterministic or random
     # transformations on the batch identically on all images of the batch. Any torchvision
     # transform for image augmentation can thus also be used  for video augmentation.
-    preprocess = transforms.Compose([
-        ImglistToTensor(),  # list of PIL images to (FRAMES x CHANNELS x HEIGHT x WIDTH) tensor
-        transforms.Resize(299),  # image batch, resize smaller edge to 299
-        transforms.CenterCrop(299),  # image batch, center crop to square 299x299
-        transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
-    ])
+    preprocess = transforms.Compose(
+        [
+            ImglistToTensor(),  # list of PIL images to (FRAMES x CHANNELS x HEIGHT x WIDTH) tensor
+            transforms.Resize(299),  # image batch, resize smaller edge to 299
+            transforms.CenterCrop(299),  # image batch, center crop to square 299x299
+            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+        ]
+    )
 
     dataset = VideoFrameDataset(
         root_path=videos_root,
         annotationfile_path=annotation_file,
         num_segments=5,
         frames_per_segment=1,
-        imagefile_template='img_{:05d}.jpg',
+        imagefile_template="img_{:05d}.jpg",
         transform=preprocess,
         random_shift=True,
-        test_mode=False
+        test_mode=False,
     )
 
     sample = dataset[1]
-    frame_tensor = sample[0]  # tensor of shape (NUM_SEGMENTS*FRAMES_PER_SEGMENT) x CHANNELS x HEIGHT x WIDTH
+    frame_tensor = sample[
+        0
+    ]  # tensor of shape (NUM_SEGMENTS*FRAMES_PER_SEGMENT) x CHANNELS x HEIGHT x WIDTH
     label = sample[1]  # integer label
 
-    print('Video Tensor Size:', frame_tensor.size())
+    print("Video Tensor Size:", frame_tensor.size())
 
     """
     Denormalize is just for visualization purposes, to undo the transforms applied
     to the list of frames of a video.
     """
-
 
     def denormalize(video_tensor):
         """
@@ -160,21 +165,21 @@ if __name__ == '__main__':
         """
         inverse_normalize = transforms.Normalize(
             mean=[-0.485 / 0.229, -0.456 / 0.224, -0.406 / 0.225],
-            std=[1 / 0.229, 1 / 0.224, 1 / 0.225]
+            std=[1 / 0.229, 1 / 0.224, 1 / 0.225],
         )
-        return (inverse_normalize(video_tensor) * 255.).type(torch.uint8).permute(0, 2, 3, 1).numpy()
-
+        return (
+            (inverse_normalize(video_tensor) * 255.0)
+            .type(torch.uint8)
+            .permute(0, 2, 3, 1)
+            .numpy()
+        )
 
     frame_tensor = denormalize(frame_tensor)
-    plot_video(rows=1, cols=5, frame_list=frames, plot_width=15., plot_height=3.)
+    plot_video(rows=1, cols=5, frame_list=frames, plot_width=15.0, plot_height=3.0)
 
     """ DEMO 3 CONTINUED: DATALOADER """
     dataloader = torch.utils.data.DataLoader(
-        dataset=dataset,
-        batch_size=2,
-        shuffle=True,
-        num_workers=4,
-        pin_memory=True
+        dataset=dataset, batch_size=2, shuffle=True, num_workers=4, pin_memory=True
     )
 
     for epoch in range(10):
@@ -204,26 +209,22 @@ if __name__ == '__main__':
     where the second tuple item is itself a tuple, with N BATCH-sized tensors of labels, where N is the 
     number of labels assigned to each sample.
     """
-    videos_root = os.path.join(os.getcwd(), 'demo_dataset_multilabel')
-    annotation_file = os.path.join(videos_root, 'annotations.txt')
+    videos_root = os.path.join(os.getcwd(), "demo_dataset_multilabel")
+    annotation_file = os.path.join(videos_root, "annotations.txt")
 
     dataset = VideoFrameDataset(
         root_path=videos_root,
         annotationfile_path=annotation_file,
         num_segments=5,
         frames_per_segment=1,
-        imagefile_template='img_{:05d}.jpg',
+        imagefile_template="img_{:05d}.jpg",
         transform=preprocess,
         random_shift=True,
-        test_mode=False
+        test_mode=False,
     )
 
     dataloader = torch.utils.data.DataLoader(
-        dataset=dataset,
-        batch_size=3,
-        shuffle=True,
-        num_workers=2,
-        pin_memory=True
+        dataset=dataset, batch_size=3, shuffle=True, num_workers=2, pin_memory=True
     )
 
     print("\nMulti-Label Example")

--- a/kale/embed/attention_cnn.py
+++ b/kale/embed/attention_cnn.py
@@ -1,6 +1,6 @@
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
+# import torch.nn.functional as F
 from typing import Tuple
 
 from kale.prepdata.tensor_reshape import spatial_to_seq, seq_to_spatial
@@ -136,7 +136,7 @@ class CNNTransformer(ContextCNNGeneric):
         encoder_normalizer = nn.LayerNorm(num_channels)
         encoder = nn.TransformerEncoder(encoder_layer, num_layers, encoder_normalizer)
 
-        if positional_encoder == None:
+        if positional_encoder is None:
             positional_encoder = PositionalEncoding(
                 d_model=num_channels, max_len=height * width
             )

--- a/kale/embed/attention_cnn.py
+++ b/kale/embed/attention_cnn.py
@@ -3,8 +3,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from typing import Tuple
 
-from kale.prepdata.tensor_reshape import spatial_to_seq, \
-                                         seq_to_spatial
+from kale.prepdata.tensor_reshape import spatial_to_seq, seq_to_spatial
 from kale.embed.positional_encoding import PositionalEncoding
 
 
@@ -32,7 +31,7 @@ class ContextCNNGeneric(nn.Module):
                       If Sequence then the output sequence is returned as is (required).
 
     Examples:
-        >>> cnn = nn.Sequential(nn.Conv2d(3, 32, kernel_size=3), 
+        >>> cnn = nn.Sequential(nn.Conv2d(3, 32, kernel_size=3),
         >>>                     nn.Conv2d(32, 64, kernel_size=3),
         >>>                     nn.MaxPool2d(2))
         >>> cnn_output_shape = (-1, 64, 8, 8)
@@ -45,12 +44,18 @@ class ContextCNNGeneric(nn.Module):
         >>> output.size() == cnn_output_shape # True
     """
 
-    def __init__(self, cnn: nn.Module, cnn_output_shape: Tuple[int, int, int, int], contextualizer: nn.Module, 
-        output_type: str):
+    def __init__(
+        self,
+        cnn: nn.Module,
+        cnn_output_shape: Tuple[int, int, int, int],
+        contextualizer: nn.Module,
+        output_type: str,
+    ):
         super(ContextCNNGeneric, self).__init__()
-        assert output_type in ['spatial', 'sequence'], \
-            "parameter 'output_type' must be one of ('spatial', 'sequence')" +\
-            f" but is {output_type}"
+        assert output_type in ["spatial", "sequence"], (
+            "parameter 'output_type' must be one of ('spatial', 'sequence')"
+            + f" but is {output_type}"
+        )
 
         self.cnn = cnn
         self.cnn_output_shape = cnn_output_shape
@@ -69,12 +74,13 @@ class ContextCNNGeneric(nn.Module):
         seq_rep = self.contextualizer(seq_rep)
 
         output = seq_rep
-        if self.output_type == 'spatial':
+        if self.output_type == "spatial":
             desired_height = self.cnn_output_shape[2]
             desired_width = self.cnn_output_shape[3]
             output = seq_to_spatial(output, desired_height, desired_width)
 
         return output
+
 
 class CNNTransformer(ContextCNNGeneric):
     """
@@ -108,31 +114,45 @@ class CNNTransformer(ContextCNNGeneric):
         See pykale/examples/cifar_cnntransformer/model.py
     """
 
-    def __init__(self, cnn: nn.Module, cnn_output_shape: Tuple[int, int, int, int], num_layers: int, 
-                num_heads: int, dim_feedforward: int, dropout: float, output_type: str, 
-                positional_encoder: nn.Module=None):
+    def __init__(
+        self,
+        cnn: nn.Module,
+        cnn_output_shape: Tuple[int, int, int, int],
+        num_layers: int,
+        num_heads: int,
+        dim_feedforward: int,
+        dropout: float,
+        output_type: str,
+        positional_encoder: nn.Module = None,
+    ):
 
         num_channels = cnn_output_shape[1]
         height = cnn_output_shape[2]
         width = cnn_output_shape[3]
 
-        encoder_layer = nn.TransformerEncoderLayer(num_channels, num_heads, \
-                                                   dim_feedforward, dropout)
+        encoder_layer = nn.TransformerEncoderLayer(
+            num_channels, num_heads, dim_feedforward, dropout
+        )
         encoder_normalizer = nn.LayerNorm(num_channels)
         encoder = nn.TransformerEncoder(encoder_layer, num_layers, encoder_normalizer)
 
         if positional_encoder == None:
-            positional_encoder = PositionalEncoding(d_model=num_channels, max_len=height*width)
+            positional_encoder = PositionalEncoding(
+                d_model=num_channels, max_len=height * width
+            )
         else:
             # allows for passing the identity block to skip this step
             # or chosing a different encoding
             positional_encoder = positional_encoder
 
         transformer_input_dropout = nn.Dropout(dropout)
-        contextualizer = nn.Sequential(positional_encoder, transformer_input_dropout, encoder)
+        contextualizer = nn.Sequential(
+            positional_encoder, transformer_input_dropout, encoder
+        )
 
-        super(CNNTransformer, self).__init__(cnn, cnn_output_shape, \
-                                             contextualizer, output_type)
+        super(CNNTransformer, self).__init__(
+            cnn, cnn_output_shape, contextualizer, output_type
+        )
 
         # Copied from https://pytorch.org/docs/stable/_modules/torch/nn/modules/transformer.html#Transformer
         for p in encoder.parameters():

--- a/kale/embed/gcn.py
+++ b/kale/embed/gcn.py
@@ -23,7 +23,7 @@ class GCNEncoderLayer(MessagePassing):
     :math:`\hat{D}_{ii} = \sum_{j=0} \hat{A}_{ij}` its diagonal degree matrix.
 
     Note: For more information please see Pytorch Geomertic's `nn.GCNConv
-    <https://pytorch-geometric.readthedocs.io/en/latest/modules/nn.html#module-torch_geometric.nn.conv.message_passing>`_ docs.
+    <https://pytorch-geometric.readthedocs.io/en/latest/modules/nn.html#module-torch_geometric.nn.conv.message_passing>`_ docs. # noqa: E501
 
     Args:
         in_channels (int): Size of each input sample.
@@ -163,7 +163,7 @@ class RGCNEncoderLayer(MessagePassing):
     :math:`\in \{ 0, \ldots, |\mathcal{R}| - 1\}` for each edge.
 
     Note: For more information please see Pytorch Geomertic’s `nn.RGCNConv
-    <https://pytorch-geometric.readthedocs.io/en/latest/modules/nn.html#module-torch_geometric.nn.conv.message_passing>`_ docs.
+    <https://pytorch-geometric.readthedocs.io/en/latest/modules/nn.html#module-torch_geometric.nn.conv.message_passing>`_ docs. # noqa: E501
 
     Args:
         in_channels (int): Size of each input sample.

--- a/kale/embed/gcn.py
+++ b/kale/embed/gcn.py
@@ -43,14 +43,16 @@ class GCNEncoderLayer(MessagePassing):
             :class:`torch_geometric.nn.conv.MessagePassing`.
     """
 
-    def __init__(self,
-                 in_channels,
-                 out_channels,
-                 improved=False,
-                 cached=False,
-                 bias=True,
-                 **kwargs):
-        super(GCNEncoderLayer, self).__init__(aggr='add', **kwargs)
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        improved=False,
+        cached=False,
+        bias=True,
+        **kwargs
+    ):
+        super(GCNEncoderLayer, self).__init__(aggr="add", **kwargs)
 
         self.in_channels = in_channels
         self.out_channels = out_channels
@@ -63,7 +65,7 @@ class GCNEncoderLayer(MessagePassing):
         if bias:
             self.bias = Parameter(torch.Tensor(out_channels))
         else:
-            self.register_parameter('bias', None)
+            self.register_parameter("bias", None)
 
         self.reset_parameters()
 
@@ -83,18 +85,19 @@ class GCNEncoderLayer(MessagePassing):
         Add self-loops and apply symmetric normalization
         """
         if edge_weight is None:
-            edge_weight = torch.ones((edge_index.size(1),),
-                                     dtype=dtype,
-                                     device=edge_index.device)
+            edge_weight = torch.ones(
+                (edge_index.size(1),), dtype=dtype, device=edge_index.device
+            )
 
         fill_value = 1 if not improved else 2
         edge_index, edge_weight = add_remaining_self_loops(
-            edge_index, edge_weight, fill_value, num_nodes)
+            edge_index, edge_weight, fill_value, num_nodes
+        )
 
         row, col = edge_index
         deg = scatter_add(edge_weight, col, dim=0, dim_size=num_nodes)
         deg_inv_sqrt = deg.pow(-0.5)
-        deg_inv_sqrt[deg_inv_sqrt == float('inf')] = 0
+        deg_inv_sqrt[deg_inv_sqrt == float("inf")] = 0
 
         return edge_index, deg_inv_sqrt[row] * edge_weight * deg_inv_sqrt[col]
 
@@ -111,13 +114,16 @@ class GCNEncoderLayer(MessagePassing):
         if self.cached and self.cached_result is not None:
             if edge_index.size(1) != self.cached_num_edges:
                 raise RuntimeError(
-                    'Cached {} number of edges, but found {}'.format(
-                        self.cached_num_edges, edge_index.size(1)))
+                    "Cached {} number of edges, but found {}".format(
+                        self.cached_num_edges, edge_index.size(1)
+                    )
+                )
 
         if not self.cached or self.cached_result is None:
             self.cached_num_edges = edge_index.size(1)
-            edge_index, norm = self.norm(edge_index, x.size(0), edge_weight,
-                                         self.improved, x.dtype)
+            edge_index, norm = self.norm(
+                edge_index, x.size(0), edge_weight, self.improved, x.dtype
+            )
             self.cached_result = edge_index, norm
 
         edge_index, norm = self.cached_result
@@ -133,8 +139,9 @@ class GCNEncoderLayer(MessagePassing):
         return aggr_out
 
     def __repr__(self):
-        return '{}({}, {})'.format(self.__class__.__name__, self.in_channels,
-                                   self.out_channels)
+        return "{}({}, {})".format(
+            self.__class__.__name__, self.in_channels, self.out_channels
+        )
 
 
 # Copy-paste with slight modification from torch_geometric.nn.RGCNConv
@@ -170,15 +177,17 @@ class RGCNEncoderLayer(MessagePassing):
             :class:`torch_geometric.nn.conv.MessagePassing`.
     """
 
-    def __init__(self,
-                 in_channels,
-                 out_channels,
-                 num_relations,
-                 num_bases,
-                 after_relu,
-                 bias=False,
-                 **kwargs):
-        super(RGCNEncoderLayer, self).__init__(aggr='mean', **kwargs)
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        num_relations,
+        num_bases,
+        after_relu,
+        bias=False,
+        **kwargs
+    ):
+        super(RGCNEncoderLayer, self).__init__(aggr="mean", **kwargs)
 
         self.in_channels = in_channels
         self.out_channels = out_channels
@@ -186,15 +195,14 @@ class RGCNEncoderLayer(MessagePassing):
         self.num_bases = num_bases
         self.after_relu = after_relu
 
-        self.basis = Parameter(
-            torch.Tensor(num_bases, in_channels, out_channels))
+        self.basis = Parameter(torch.Tensor(num_bases, in_channels, out_channels))
         self.att = Parameter(torch.Tensor(num_relations, num_bases))
         self.root = Parameter(torch.Tensor(in_channels, out_channels))
 
         if bias:
             self.bias = Parameter(torch.Tensor(out_channels))
         else:
-            self.register_parameter('bias', None)
+            self.register_parameter("bias", None)
 
         self.reset_parameters()
 
@@ -223,7 +231,8 @@ class RGCNEncoderLayer(MessagePassing):
             range_list (torch.Tensor): The index range list of each edge type with shape [num_types, 2].
         """
         return self.propagate(
-            edge_index, x=x, edge_type=edge_type, range_list=range_list)
+            edge_index, x=x, edge_type=edge_type, range_list=range_list
+        )
 
     def message(self, x_j, edge_index, edge_type, range_list):
         w = torch.matmul(self.att, self.basis.view(self.num_bases, -1))
@@ -235,7 +244,7 @@ class RGCNEncoderLayer(MessagePassing):
         for et in range(range_list.shape[0]):
             start, end = range_list[et]
 
-            tmp = torch.matmul(x_j[start: end, :], w[et])
+            tmp = torch.matmul(x_j[start:end, :], w[et])
 
             # xxx = x_j[start: end, :]
             # tmp = checkpoint(torch.matmul, xxx, w[et])
@@ -254,6 +263,9 @@ class RGCNEncoderLayer(MessagePassing):
         return out
 
     def __repr__(self):
-        return '{}({}, {}, num_relations={})'.format(
-            self.__class__.__name__, self.in_channels, self.out_channels,
-            self.num_relations)
+        return "{}({}, {}, num_relations={})".format(
+            self.__class__.__name__,
+            self.in_channels,
+            self.out_channels,
+            self.num_relations,
+        )

--- a/kale/embed/gripnet.py
+++ b/kale/embed/gripnet.py
@@ -25,7 +25,7 @@ class GripNetSuperVertex(Module):
             start point of the whole information propagation. (default :obj:`False`)
         in_channels (int, optional): Size of each input sample for start graph. (default :obj:`None`)
         multi_relational: If set to :obj: 'True', the supervertex is a multi relation graph. (default :obj:`False`)
-        num_relations (int, optional): Number of edge relations if supervertex is a multi relation graph. (default :obj:`None`)
+        num_relations (int, optional): Number of edge relations if supervertex is a multi relation graph. (default :obj:`None`) # noqa: E501
         num_bases (int, optional): Number of bases if supervertex is a multi relation graph. (default :obj:`None`)
     """
 
@@ -201,9 +201,9 @@ class TypicalGripNetEncoder(Module):
     <https://arxiv.org/abs/2010.15914>`_.
 
     Args:
-        source_channels_list (list): Channels list of source nodes' hidden layers e.g. [channel_1, channel_2, ... channel_n]
+        source_channels_list (list): Channels list of source nodes' hidden layers e.g. [channel_1, channel_2, ... channel_n] # noqa: E501
         inter_channels_list (list): Channels list of superedge between source and target node sets with length 2.
-        target_channels_list (list): Channels list of target nodes' hidden layers e.g. [channel_1, channel_2, ... channel_n]
+        target_channels_list (list): Channels list of target nodes' hidden layers e.g. [channel_1, channel_2, ... channel_n] # noqa: E501
         num_target_nodes (int): Numbers of target nodes.
         num_source_nodes (int): Numbers of source nodes.
         num_target_edge_relations (int): Number of edge relations of target supervertex.

--- a/kale/embed/gripnet.py
+++ b/kale/embed/gripnet.py
@@ -29,8 +29,16 @@ class GripNetSuperVertex(Module):
         num_bases (int, optional): Number of bases if supervertex is a multi relation graph. (default :obj:`None`)
     """
 
-    def __init__(self, channels_list, requires_grad=True, start_graph=False,
-                 in_channels=None, multi_relational=False, num_relations=None, num_bases=32):
+    def __init__(
+        self,
+        channels_list,
+        requires_grad=True,
+        start_graph=False,
+        in_channels=None,
+        multi_relational=False,
+        num_relations=None,
+        num_bases=32,
+    ):
         super(GripNetSuperVertex, self).__init__()
         self.multi_relational = multi_relational
         self.start_graph = start_graph
@@ -38,27 +46,49 @@ class GripNetSuperVertex(Module):
         self.n_cov = len(channels_list) - 1
 
         if start_graph:
-            self.embedding = torch.nn.Parameter(torch.Tensor(in_channels, channels_list[0]))
+            self.embedding = torch.nn.Parameter(
+                torch.Tensor(in_channels, channels_list[0])
+            )
             self.embedding.requires_grad = requires_grad
             self.reset_parameters()
 
         if multi_relational:
             assert num_relations is not None
-            after_relu = [False if i == 0 else True for i in
-                          range(len(channels_list) - 1)]
-            self.conv_list = torch.nn.ModuleList([
-                RGCNEncoderLayer(channels_list[i], channels_list[i + 1], num_relations, num_bases, after_relu[i])
-                for i in range(len(channels_list) - 1)])
+            after_relu = [
+                False if i == 0 else True for i in range(len(channels_list) - 1)
+            ]
+            self.conv_list = torch.nn.ModuleList(
+                [
+                    RGCNEncoderLayer(
+                        channels_list[i],
+                        channels_list[i + 1],
+                        num_relations,
+                        num_bases,
+                        after_relu[i],
+                    )
+                    for i in range(len(channels_list) - 1)
+                ]
+            )
         else:
-            self.conv_list = torch.nn.ModuleList([
-                GCNEncoderLayer(channels_list[i], channels_list[i + 1], cached=True)
-                for i in range(len(channels_list) - 1)])
+            self.conv_list = torch.nn.ModuleList(
+                [
+                    GCNEncoderLayer(channels_list[i], channels_list[i + 1], cached=True)
+                    for i in range(len(channels_list) - 1)
+                ]
+            )
 
     def reset_parameters(self):
         self.embedding.data.normal_()
 
-    def forward(self, x, homo_edge_index, edge_weight=None, edge_type=None,
-                range_list=None, if_catout=False):
+    def forward(
+        self,
+        x,
+        homo_edge_index,
+        edge_weight=None,
+        edge_type=None,
+        range_list=None,
+        if_catout=False,
+    ):
         """
         Args:
             x (torch.Tensor): the input node feature embedding.
@@ -80,16 +110,20 @@ class GripNetSuperVertex(Module):
             assert range_list is not None
 
         for net in self.conv_list[:-1]:
-            x = net(x, homo_edge_index, edge_type, range_list) \
-                if self.multi_relational \
+            x = (
+                net(x, homo_edge_index, edge_type, range_list)
+                if self.multi_relational
                 else net(x, homo_edge_index, edge_weight)
+            )
             x = F.relu(x, inplace=True)
             if if_catout:
                 tmp.append(x)
 
-        x = self.conv_list[-1](x, homo_edge_index, edge_type, range_list) \
-            if self.multi_relational \
+        x = (
+            self.conv_list[-1](x, homo_edge_index, edge_type, range_list)
+            if self.multi_relational
             else self.conv_list[-1](x, homo_edge_index, edge_weight)
+        )
 
         x = F.relu(x, inplace=True)
         if if_catout:
@@ -114,15 +148,15 @@ class GripNetSuperEdges(Module):
             (default: :obj:`True`)
     """
 
-    def __init__(self, source_dim, target_dim, n_target, target_feat_dim=32,
-                 requires_grad=True):
+    def __init__(
+        self, source_dim, target_dim, n_target, target_feat_dim=32, requires_grad=True
+    ):
         super(GripNetSuperEdges, self).__init__()
         self.source_dim = source_dim
         self.target_dim = target_dim
         self.target_feat_dim = target_feat_dim
         self.n_target = n_target
-        self.target_feat = torch.nn.Parameter(
-            torch.Tensor(n_target, target_feat_dim))
+        self.target_feat = torch.nn.Parameter(torch.Tensor(n_target, target_feat_dim))
 
         self.target_feat.requires_grad = requires_grad
 
@@ -132,7 +166,7 @@ class GripNetSuperEdges(Module):
     def reset_parameters(self):
         self.target_feat.data.normal_()
 
-    def forward(self, x, inter_edge_index, edge_weight=None, if_relu=True, mod='cat'):
+    def forward(self, x, inter_edge_index, edge_weight=None, if_relu=True, mod="cat"):
         """
         Args:
             x (torch.Tensor): the input node feature embedding.
@@ -145,12 +179,11 @@ class GripNetSuperEdges(Module):
         tmp = inter_edge_index + 0
         tmp[1, :] += n_source
 
-        x = torch.cat(
-            [x, torch.zeros((self.n_target, x.shape[1])).to(x.device)], dim=0)
+        x = torch.cat([x, torch.zeros((self.n_target, x.shape[1])).to(x.device)], dim=0)
         x = self.conv(x, tmp, edge_weight)[n_source:, :]
         if if_relu:
             x = F.relu(x)
-        if mod == 'cat':
+        if mod == "cat":
             x = torch.cat([x, torch.abs(self.target_feat)], dim=1)
         else:
             assert x.shape[1] == self.target_feat.shape[1]
@@ -176,17 +209,43 @@ class TypicalGripNetEncoder(Module):
         num_target_edge_relations (int): Number of edge relations of target supervertex.
     """
 
-    def __init__(self, source_channels_list, inter_channels_list, target_channels_list, num_target_nodes, num_source_nodes, num_target_edge_relations):
+    def __init__(
+        self,
+        source_channels_list,
+        inter_channels_list,
+        target_channels_list,
+        num_target_nodes,
+        num_source_nodes,
+        num_target_edge_relations,
+    ):
         super(TypicalGripNetEncoder, self).__init__()
         self.n_target_node = num_target_nodes
         self.n_source_node = num_source_nodes
-        self.source_graph = GripNetSuperVertex(source_channels_list, start_graph=True, in_channels=self.n_source_node)
-        self.s2t_graph = GripNetSuperEdges(sum(source_channels_list), inter_channels_list[0],
-                                           self.n_target_node, target_feat_dim=inter_channels_list[-1])
-        self.target_graph = GripNetSuperVertex(target_channels_list, multi_relational=True, num_relations=num_target_edge_relations)
+        self.source_graph = GripNetSuperVertex(
+            source_channels_list, start_graph=True, in_channels=self.n_source_node
+        )
+        self.s2t_graph = GripNetSuperEdges(
+            sum(source_channels_list),
+            inter_channels_list[0],
+            self.n_target_node,
+            target_feat_dim=inter_channels_list[-1],
+        )
+        self.target_graph = GripNetSuperVertex(
+            target_channels_list,
+            multi_relational=True,
+            num_relations=num_target_edge_relations,
+        )
 
-    def forward(self, source_x, source_edge_index, source_edge_weight,
-                inter_edge_index, target_edge_index, target_edge_relations, target_edge_range):
+    def forward(
+        self,
+        source_x,
+        source_edge_index,
+        source_edge_weight,
+        inter_edge_index,
+        target_edge_index,
+        target_edge_relations,
+        target_edge_range,
+    ):
         """
         Args:
             source_x (torch.Tensor): The input source node feature embedding.
@@ -199,8 +258,15 @@ class TypicalGripNetEncoder(Module):
                 :obj:`edge_index`.
             target_edge_range: The index range list of each target edge type with shape [num_types, 2].
         """
-        z = self.source_graph(source_x, source_edge_index, edge_weight=source_edge_weight, if_catout=True)
+        z = self.source_graph(
+            source_x, source_edge_index, edge_weight=source_edge_weight, if_catout=True
+        )
         z = self.s2t_graph(z, inter_edge_index)
-        z = self.target_graph(z, target_edge_index, edge_type=target_edge_relations,
-                              range_list=target_edge_range, if_catout=True)
+        z = self.target_graph(
+            z,
+            target_edge_index,
+            edge_type=target_edge_relations,
+            range_list=target_edge_range,
+            if_catout=True,
+        )
         return z

--- a/kale/embed/image_cnn.py
+++ b/kale/embed/image_cnn.py
@@ -1,11 +1,10 @@
 """
-CNNs for extracting features from small images of size 32x32 (e.g. MNIST) and regular images of size 224x224 (e.g. ImageNet). The code is based on  
-https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/models/modules.py, which is for domain adaptation.
+CNNs for extracting features from small images of size 32x32 (e.g. MNIST) and regular images of size 224x224
+(e.g. ImageNet). The code is based on
+https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/models/modules.py, which is for domain adaptation. # noqa: E501
 """
 
-import numpy as np
 import torch.nn as nn
-import torch
 from torchvision import models
 
 

--- a/kale/embed/image_cnn.py
+++ b/kale/embed/image_cnn.py
@@ -57,7 +57,7 @@ class ResNet18Feature(nn.Module):
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
 
-    Note: 
+    Note:
         Code adapted by pytorch-ada from https://github.com/thuml/Xlearn/blob/master/pytorch/src/network.py
     """
 
@@ -99,7 +99,7 @@ class ResNet34Feature(nn.Module):
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
 
-    Note: 
+    Note:
         Code adapted by pytorch-ada from https://github.com/thuml/Xlearn/blob/master/pytorch/src/network.py
     """
 
@@ -141,7 +141,7 @@ class ResNet50Feature(nn.Module):
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
 
-    Note: 
+    Note:
         Code adapted by pytorch-ada from https://github.com/thuml/Xlearn/blob/master/pytorch/src/network.py
     """
 
@@ -183,7 +183,7 @@ class ResNet101Feature(nn.Module):
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
 
-    Note: 
+    Note:
         Code adapted by pytorch-ada from https://github.com/thuml/Xlearn/blob/master/pytorch/src/network.py
     """
 
@@ -225,7 +225,7 @@ class ResNet152Feature(nn.Module):
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
 
-    Note: 
+    Note:
         Code adapted by pytorch-ada from https://github.com/thuml/Xlearn/blob/master/pytorch/src/network.py
     """
 

--- a/kale/embed/linformer.py
+++ b/kale/embed/linformer.py
@@ -535,9 +535,9 @@ def _linear_multi_head_attention_forward(
         if in_proj_bias is not None:
             q = linear(query, q_proj_weight_non_opt, in_proj_bias[0:embed_dim])
             k = linear(
-                key, k_proj_weight_non_opt, in_proj_bias[embed_dim : (embed_dim * 2)]
+                key, k_proj_weight_non_opt, in_proj_bias[embed_dim:(embed_dim * 2)]
             )
-            v = linear(value, v_proj_weight_non_opt, in_proj_bias[(embed_dim * 2) :])
+            v = linear(value, v_proj_weight_non_opt, in_proj_bias[(embed_dim * 2):])
         else:
             q = linear(query, q_proj_weight_non_opt, in_proj_bias)
             k = linear(key, k_proj_weight_non_opt, in_proj_bias)

--- a/kale/embed/linformer.py
+++ b/kale/embed/linformer.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Optional, Any
+from typing import Optional, Tuple
 
 import torch
 from torch import nn
@@ -16,6 +16,7 @@ from torch.nn import Module
 from torch.nn import Dropout
 from torch.nn import LayerNorm
 from torch.nn.functional import pad
+
 
 # Copy-paste with slight modification from torch.nn.TransformerEncoderLayer
 class LinearTransformerEncoderLayer(Module):
@@ -168,14 +169,14 @@ class LinearMultiheadAttention(nn.Module):
         vdim: total number of features in key. Default: None.
         seq_len: the sequence length. Default: 100.
         proj_k: the projected seq-dimension `k` of key and value. Default: 128.
-        param_sharing: parameter sharing mode of linformer projection: layerwise, none. headwise is not implemented. Default: none.
+        param_sharing: parameter sharing mode of linformer projection: layerwise, none. headwise is not implemented. Default: none.  # noqa: E501
 
     Examples::
         >>> multihead_attn = LinearMultiheadAttention(embed_dim, num_heads, seq_len=10000, proj_k=128)
         >>> attn_output, attn_output_weights = multihead_attn(query, key, value)
 
     Note:
-        Code taken exactly as is from https://github.com/kuixu/Linear-Multihead-Attention. Many thanks you to the author.
+        Code taken exactly as is from https://github.com/kuixu/Linear-Multihead-Attention. Many thanks you to the author. # noqa: E501
     """
     __annotations__ = {
         "bias_k": torch._jit_internal.Optional[torch.Tensor],
@@ -291,7 +292,7 @@ class LinearMultiheadAttention(nn.Module):
         need_weights=True,
         attn_mask=None,
     ):
-        # type: (Tensor, Tensor, Tensor, Optional[Tensor], bool, Optional[Tensor]) -> Tuple[Tensor, Optional[Tensor]]
+        # type: (Tensor, Tensor, Tensor, Optional[Tensor], bool, Optional[Tensor]) -> Tuple[Tensor, Optional[Tensor]] # noqa: E501
         r"""
         See PyTorch's nn.MultiheadAttention docs.
         """
@@ -379,7 +380,7 @@ def _linear_multi_head_attention_forward(
     static_k=None,  # type: Optional[Tensor]
     static_v=None,  # type: Optional[Tensor]
 ):
-    # type: (...) -> Tuple[Tensor, Optional[Tensor]]
+    # type: (...) -> Tuple[Tensor, Optional[Tensor]] # noqa: F821
     r"""
     Args:
         query, key, value: map a query and a set of key-value pairs to an output.
@@ -593,7 +594,7 @@ def _linear_multi_head_attention_forward(
     else:
         assert bias_k is None
         assert bias_v is None
-    ##======= linformer =========##
+    # ======= linformer ========= #
     k = k.transpose(0, 1).transpose(1, 2)
     k = linear(k, e_proj_weight, bias_e)
     v = v.transpose(0, 1).transpose(1, 2)

--- a/kale/embed/mpca.py
+++ b/kale/embed/mpca.py
@@ -15,6 +15,7 @@ Reference:
 
 import sys
 import numpy as np
+
 # import tensorly as tl
 from tensorly.base import unfold, fold
 from tensorly.tenalg import multi_mode_dot
@@ -59,7 +60,9 @@ def _check_dim_shape(X, ndim, shape_):
 
     """
     if not check_ndim(X, ndim) or not check_shape(X, shape_):
-        print("The given data should be consistent with the order and shape of training data")
+        print(
+            "The given data should be consistent with the order and shape of training data"
+        )
         sys.exit()
 
 
@@ -71,7 +74,7 @@ class MPCA(BaseEstimator, TransformerMixin):
             (between 0 and 1). Defaults to 0.97.
         max_iter (int, optional): Maximum number of iteration. Defaults to 1.
         vectorise (bool): Whether vectorise the transformed tensor. Defaults to Flase.
-        n_components (int): Number of components to keep. Applies only when vectorise=True. 
+        n_components (int): Number of components to keep. Applies only when vectorise=True.
             Defaults to None.
 
     Attributes:
@@ -100,12 +103,13 @@ class MPCA(BaseEstimator, TransformerMixin):
         >>> X_inverse.shape
         (20, 25, 20, 40)
     """
+
     def __init__(self, var_ratio=0.97, max_iter=1, vectorise=False, n_components=None):
         self.var_ratio = var_ratio
         if max_iter > 0 and isinstance(max_iter, int):
             self.max_iter = max_iter
         else:
-            print('Number of max iterations must be an integer and greater than 0')
+            print("Number of max iterations must be an integer and greater than 0")
             sys.exit()
         self.proj_mats = []
         self.vectorise = vectorise
@@ -116,7 +120,7 @@ class MPCA(BaseEstimator, TransformerMixin):
 
         Args
             X (ndarray): Input data, shape (I_1, I_2, ..., I_N, n_samples), where n_samples
-                is the number of samples, I_1, I_2, ..., I_N are the dimensions of 
+                is the number of samples, I_1, I_2, ..., I_N are the dimensions of
                 corresponding mode (1, 2, ..., N), respectively.
             y (None): Ignored variable.
 
@@ -140,7 +144,7 @@ class MPCA(BaseEstimator, TransformerMixin):
         eig_vecs_sorted = dict()  # dictionary of eigenvectors for all modes/orders
         lambdas = dict()  # dictionary of eigenvalues for all modes/orders
         # dictionary of cumulative distribution of eigenvalues for all modes/orders
-        cums = dict()  
+        cums = dict()
         proj_mats = []
         shape_out = ()
         for i in range(n_spl):
@@ -164,7 +168,7 @@ class MPCA(BaseEstimator, TransformerMixin):
                     break
             cums[i] = cum
 
-            proj_mats.append(eig_vecs_sorted[i][:, :shape_out[i]].T)
+            proj_mats.append(eig_vecs_sorted[i][:, : shape_out[i]].T)
 
         for i_iter in range(self.max_iter):
             Phi = dict()
@@ -173,8 +177,11 @@ class MPCA(BaseEstimator, TransformerMixin):
                     Phi[i] = 0
                 for j in range(n_spl):
                     X_j = X_[..., j]  # jth tensor/sample
-                    Xj_ = multi_mode_dot(X_j, [proj_mats[m] for m in range(self.ndim - 1) if m != i],
-                                         modes=[m for m in range(self.ndim - 1) if m != i])
+                    Xj_ = multi_mode_dot(
+                        X_j,
+                        [proj_mats[m] for m in range(self.ndim - 1) if m != i],
+                        modes=[m for m in range(self.ndim - 1) if m != i],
+                    )
                     Xj_unfold = unfold(Xj_, i)
                     Phi[i] = np.dot(Xj_unfold, Xj_unfold.T) + Phi[i]
 
@@ -182,10 +189,14 @@ class MPCA(BaseEstimator, TransformerMixin):
                 idx_sorted = eig_vals.argsort()[::-1]
                 lambdas[i] = eig_vals[idx_sorted]
                 proj_mats[i] = eig_vecs[:, idx_sorted]
-                proj_mats[i] = (proj_mats[i][:, :shape_out[i]]).T
+                proj_mats[i] = (proj_mats[i][:, : shape_out[i]]).T
 
-        x_transformed = multi_mode_dot(X, proj_mats, modes=[m for m in range(self.ndim - 1)])
-        x_trans_vec = unfold(x_transformed, mode=-1)  # vectorise the transformed features
+        x_transformed = multi_mode_dot(
+            X, proj_mats, modes=[m for m in range(self.ndim - 1)]
+        )
+        x_trans_vec = unfold(
+            x_transformed, mode=-1
+        )  # vectorise the transformed features
         # diagonal of the covariance of vectorised features
         x_trans_cov_diag = np.diag(np.dot(x_trans_vec, x_trans_vec.T))
         idx_order = x_trans_cov_diag.argsort()[::-1]
@@ -206,20 +217,24 @@ class MPCA(BaseEstimator, TransformerMixin):
             ndarray: Transformed data, shape (P_1, P_2, ..., P_N, n_samples) if self.vectorise==False.
                 If self.vectorise==True, features will be sorted based on their explained variance ratio,
                 shape (n_samples, P_1 * P_2 * ... * P_N) if self.n_components is None,
-                and shape (n_samples, n_components) if self.n_component is not None.                
+                and shape (n_samples, n_components) if self.n_component is not None.
         """
         _check_dim_shape(X, self.ndim, self.shape_in)
         n_spl = X.shape[-1]
         for i in range(n_spl):
             X[..., i] = X[..., i] - self.mean_
-        
-        X_transformed = multi_mode_dot(X, self.proj_mats, modes=[m for m in range(self.ndim - 1)])
+
+        X_transformed = multi_mode_dot(
+            X, self.proj_mats, modes=[m for m in range(self.ndim - 1)]
+        )
 
         if self.vectorise:
             X_transformed = unfold(X_transformed, mode=-1)
             X_transformed = X_transformed[:, self.idx_order]
-            if isinstance(self.n_components, int) and self.n_components <= np.prod(self.shape_out):
-                X_transformed = X_transformed[:, :self.n_components]
+            if isinstance(self.n_components, int) and self.n_components <= np.prod(
+                self.shape_out
+            ):
+                X_transformed = X_transformed[:, : self.n_components]
 
         return X_transformed
 
@@ -227,9 +242,9 @@ class MPCA(BaseEstimator, TransformerMixin):
         """Transform data in the shape of reduced dimension back to the original shape
 
         Args:
-            X (ndarray): Data to be transfromed back. If self.vectorise == Flase, shape 
-                (P_1, P_2, ..., P_N, n_samples), where P_1, P_2, ..., P_N are the reduced 
-                dimensions of of corresponding mode (1, 2, ..., N), respectively. If 
+            X (ndarray): Data to be transfromed back. If self.vectorise == Flase, shape
+                (P_1, P_2, ..., P_N, n_samples), where P_1, P_2, ..., P_N are the reduced
+                dimensions of of corresponding mode (1, 2, ..., N), respectively. If
                 self.vectorise == True, shape (n_samples, self.n_components) or shape
                 (n_samples, P_1 * P_2 * ... * P_N).
             add_mean (bool): Whether add the mean estimated from the training set to the output.
@@ -246,16 +261,18 @@ class MPCA(BaseEstimator, TransformerMixin):
             n_feat = X.shape[1]
             if n_feat <= np.prod(self.shape_out):
                 X_ = np.zeros((n_spl, np.prod(self.shape_out)))
-                X_[:, :self.idx_order[:n_feat]] = X[:]
+                X_[:, : self.idx_order[:n_feat]] = X[:]
             else:
-                print('Feature dimension exceeds the shape upper limit')
+                print("Feature dimension exceeds the shape upper limit")
                 sys.exit()
 
             X = fold(X_, -1, self.shape_out + (n_spl,))
         else:
             _check_dim_shape(X, self.ndim, self.shape_out)
 
-        X_orig = multi_mode_dot(X, self.proj_mats, modes=[m for m in range(self.ndim - 1)], transpose=True)
+        X_orig = multi_mode_dot(
+            X, self.proj_mats, modes=[m for m in range(self.ndim - 1)], transpose=True
+        )
 
         if add_mean:
             n_spl = X_orig.shape[-1]

--- a/kale/embed/mpca.py
+++ b/kale/embed/mpca.py
@@ -8,7 +8,7 @@ Includeing implementaion as a scikit-learn object and an independent function.
 
 Reference:
     Haiping Lu, K.N. Plataniotis, and A.N. Venetsanopoulos, "MPCA: Multilinear
-    Principal Component Analysis of Tensor Objects", IEEE Transactions on Neural 
+    Principal Component Analysis of Tensor Objects", IEEE Transactions on Neural
     Networks, Vol. 19, No. 1, Page: 18-39, January 2008. For initial Matlab
     implementation, please go to https://uk.mathworks.com/matlabcentral/fileexchange/26168.
 """

--- a/kale/embed/positional_encoding.py
+++ b/kale/embed/positional_encoding.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn as nn
 import math
 
+
 class PositionalEncoding(nn.Module):
     """
     Implements the positional encoding as described in the NIPS2017 paper
@@ -20,18 +21,20 @@ class PositionalEncoding(nn.Module):
                   encodings should support (required).
     """
 
-    def __init__(self, d_model: int, max_len: int=5000):
+    def __init__(self, d_model: int, max_len: int = 5000):
         super(PositionalEncoding, self).__init__()
 
         pe = torch.zeros(max_len, d_model)
         position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
 
-        div_term = torch.exp(torch.arange(0, d_model, 2).float() * (-math.log(10000.0) / d_model))
+        div_term = torch.exp(
+            torch.arange(0, d_model, 2).float() * (-math.log(10000.0) / d_model)
+        )
         pe[:, 0::2] = torch.sin(position * div_term)
         pe[:, 1::2] = torch.cos(position * div_term)
 
         pe = pe.unsqueeze(0).transpose(0, 1)
-        self.register_buffer('pe', pe)
+        self.register_buffer("pe", pe)
 
         self.scaling_term = math.sqrt(d_model)
         self.max_len = max_len
@@ -47,6 +50,8 @@ class PositionalEncoding(nn.Module):
         Args:
             x: a sequence input of shape (sequence_length, batch_size, num_features) (required).
         """
-        x = x * self.scaling_term # make embedding relatively larger than positional encoding
-        x = x + self.pe[:x.size(0), :]
+        x = (
+            x * self.scaling_term
+        )  # make embedding relatively larger than positional encoding
+        x = x + self.pe[: x.size(0), :]
         return x

--- a/kale/embed/video_i3d.py
+++ b/kale/embed/video_i3d.py
@@ -11,10 +11,10 @@ from torchvision.models.utils import load_state_dict_from_url
 
 
 model_urls = {
-    'rgb_imagenet': 'https://github.com/XianyuanLiu/pytorch-i3d/raw/master/models/rgb_imagenet.pt',
-    'flow_imagenet': 'https://github.com/XianyuanLiu/pytorch-i3d/raw/master/models/flow_imagenet.pt',
-    'rgb_charades': 'https://github.com/XianyuanLiu/pytorch-i3d/raw/master/models/rgb_charades.pt',
-    'flow_charades': 'https://github.com/XianyuanLiu/pytorch-i3d/raw/master/models/flow_charades.pt'
+    "rgb_imagenet": "https://github.com/XianyuanLiu/pytorch-i3d/raw/master/models/rgb_imagenet.pt",
+    "flow_imagenet": "https://github.com/XianyuanLiu/pytorch-i3d/raw/master/models/flow_imagenet.pt",
+    "rgb_charades": "https://github.com/XianyuanLiu/pytorch-i3d/raw/master/models/rgb_charades.pt",
+    "flow_charades": "https://github.com/XianyuanLiu/pytorch-i3d/raw/master/models/flow_charades.pt",
 }
 
 
@@ -47,7 +47,14 @@ class MaxPool3dSamePadding(nn.MaxPool3d):
         pad_w_front = pad_w // 2
         pad_w_back = pad_w - pad_w_front
 
-        pad = (pad_w_front, pad_w_back, pad_h_front, pad_h_back, pad_t_front, pad_t_back)
+        pad = (
+            pad_w_front,
+            pad_w_back,
+            pad_h_front,
+            pad_h_back,
+            pad_t_front,
+            pad_t_back,
+        )
         x = F.pad(x, pad)
         return super(MaxPool3dSamePadding, self).forward(x)
 
@@ -55,15 +62,18 @@ class MaxPool3dSamePadding(nn.MaxPool3d):
 class Unit3D(nn.Module):
     """Basic unit containing Conv3D + BatchNorm + non-linearity."""
 
-    def __init__(self, in_channels,
-                 output_channels,
-                 kernel_shape=(1, 1, 1),
-                 stride=(1, 1, 1),
-                 padding=0,
-                 activation_fn=F.relu,
-                 use_batch_norm=True,
-                 use_bias=False,
-                 name='unit_3d'):
+    def __init__(
+        self,
+        in_channels,
+        output_channels,
+        kernel_shape=(1, 1, 1),
+        stride=(1, 1, 1),
+        padding=0,
+        activation_fn=F.relu,
+        use_batch_norm=True,
+        use_bias=False,
+        name="unit_3d",
+    ):
         """Initializes Unit3D module."""
 
         super(Unit3D, self).__init__()
@@ -77,14 +87,16 @@ class Unit3D(nn.Module):
         self.name = name
         self.padding = padding
 
-        self.conv3d = nn.Conv3d(in_channels=in_channels,
-                                out_channels=self._output_channels,
-                                kernel_size=self._kernel_shape,
-                                stride=self._stride,
-                                padding=0,
-                                # we always want padding to be 0 here. We will dynamically pad based on input size in
-                                # forward function
-                                bias=self._use_bias)
+        self.conv3d = nn.Conv3d(
+            in_channels=in_channels,
+            out_channels=self._output_channels,
+            kernel_size=self._kernel_shape,
+            stride=self._stride,
+            padding=0,
+            # we always want padding to be 0 here. We will dynamically pad based on input size in
+            # forward function
+            bias=self._use_bias,
+        )
 
         if self._use_batch_norm:
             self.bn = nn.BatchNorm3d(self._output_channels, eps=0.001, momentum=0.01)
@@ -120,7 +132,14 @@ class Unit3D(nn.Module):
         pad_w_front = pad_w // 2
         pad_w_back = pad_w - pad_w_front
 
-        pad = (pad_w_front, pad_w_back, pad_h_front, pad_h_back, pad_t_front, pad_t_back)
+        pad = (
+            pad_w_front,
+            pad_w_back,
+            pad_h_front,
+            pad_h_back,
+            pad_t_front,
+            pad_t_back,
+        )
         x = F.pad(x, pad)
 
         x = self.conv3d(x)
@@ -141,20 +160,49 @@ class InceptionModule(nn.Module):
     def __init__(self, in_channels, out_channels, name):
         super(InceptionModule, self).__init__()
 
-        self.b0 = Unit3D(in_channels=in_channels, output_channels=out_channels[0], kernel_shape=[1, 1, 1], padding=0,
-                         name=name + '/Branch_0/Conv3d_0a_1x1')
-        self.b1a = Unit3D(in_channels=in_channels, output_channels=out_channels[1], kernel_shape=[1, 1, 1], padding=0,
-                          name=name + '/Branch_1/Conv3d_0a_1x1')
-        self.b1b = Unit3D(in_channels=out_channels[1], output_channels=out_channels[2], kernel_shape=[3, 3, 3],
-                          name=name + '/Branch_1/Conv3d_0b_3x3')
-        self.b2a = Unit3D(in_channels=in_channels, output_channels=out_channels[3], kernel_shape=[1, 1, 1], padding=0,
-                          name=name + '/Branch_2/Conv3d_0a_1x1')
-        self.b2b = Unit3D(in_channels=out_channels[3], output_channels=out_channels[4], kernel_shape=[3, 3, 3],
-                          name=name + '/Branch_2/Conv3d_0b_3x3')
-        self.b3a = MaxPool3dSamePadding(kernel_size=[3, 3, 3],
-                                        stride=(1, 1, 1), padding=0)
-        self.b3b = Unit3D(in_channels=in_channels, output_channels=out_channels[5], kernel_shape=[1, 1, 1], padding=0,
-                          name=name + '/Branch_3/Conv3d_0b_1x1')
+        self.b0 = Unit3D(
+            in_channels=in_channels,
+            output_channels=out_channels[0],
+            kernel_shape=[1, 1, 1],
+            padding=0,
+            name=name + "/Branch_0/Conv3d_0a_1x1",
+        )
+        self.b1a = Unit3D(
+            in_channels=in_channels,
+            output_channels=out_channels[1],
+            kernel_shape=[1, 1, 1],
+            padding=0,
+            name=name + "/Branch_1/Conv3d_0a_1x1",
+        )
+        self.b1b = Unit3D(
+            in_channels=out_channels[1],
+            output_channels=out_channels[2],
+            kernel_shape=[3, 3, 3],
+            name=name + "/Branch_1/Conv3d_0b_3x3",
+        )
+        self.b2a = Unit3D(
+            in_channels=in_channels,
+            output_channels=out_channels[3],
+            kernel_shape=[1, 1, 1],
+            padding=0,
+            name=name + "/Branch_2/Conv3d_0a_1x1",
+        )
+        self.b2b = Unit3D(
+            in_channels=out_channels[3],
+            output_channels=out_channels[4],
+            kernel_shape=[3, 3, 3],
+            name=name + "/Branch_2/Conv3d_0b_3x3",
+        )
+        self.b3a = MaxPool3dSamePadding(
+            kernel_size=[3, 3, 3], stride=(1, 1, 1), padding=0
+        )
+        self.b3b = Unit3D(
+            in_channels=in_channels,
+            output_channels=out_channels[5],
+            kernel_shape=[1, 1, 1],
+            padding=0,
+            name=name + "/Branch_3/Conv3d_0b_1x1",
+        )
         self.name = name
 
     def forward(self, x):
@@ -183,28 +231,35 @@ class InceptionI3d(nn.Module):
     # to a designated `final_endpoint` are returned in a dictionary as the
     # second return value.
     VALID_ENDPOINTS = (
-        'Conv3d_1a_7x7',
-        'MaxPool3d_2a_3x3',
-        'Conv3d_2b_1x1',
-        'Conv3d_2c_3x3',
-        'MaxPool3d_3a_3x3',
-        'Mixed_3b',
-        'Mixed_3c',
-        'MaxPool3d_4a_3x3',
-        'Mixed_4b',
-        'Mixed_4c',
-        'Mixed_4d',
-        'Mixed_4e',
-        'Mixed_4f',
-        'MaxPool3d_5a_2x2',
-        'Mixed_5b',
-        'Mixed_5c',
-        'Logits',
-        'Predictions',
+        "Conv3d_1a_7x7",
+        "MaxPool3d_2a_3x3",
+        "Conv3d_2b_1x1",
+        "Conv3d_2c_3x3",
+        "MaxPool3d_3a_3x3",
+        "Mixed_3b",
+        "Mixed_3c",
+        "MaxPool3d_4a_3x3",
+        "Mixed_4b",
+        "Mixed_4c",
+        "Mixed_4d",
+        "Mixed_4e",
+        "Mixed_4f",
+        "MaxPool3d_5a_2x2",
+        "Mixed_5b",
+        "Mixed_5c",
+        "Logits",
+        "Predictions",
     )
 
-    def __init__(self, num_classes=400, spatial_squeeze=True,
-                 final_endpoint='Logits', name='inception_i3d', in_channels=3, dropout_keep_prob=0.5):
+    def __init__(
+        self,
+        num_classes=400,
+        spatial_squeeze=True,
+        final_endpoint="Logits",
+        name="inception_i3d",
+        in_channels=3,
+        dropout_keep_prob=0.5,
+    ):
         """
         Initializes I3D model instance.
 
@@ -226,7 +281,7 @@ class InceptionI3d(nn.Module):
         """
 
         if final_endpoint not in self.VALID_ENDPOINTS:
-            raise ValueError('Unknown final endpoint %s' % final_endpoint)
+            raise ValueError("Unknown final endpoint %s" % final_endpoint)
 
         super(InceptionI3d, self).__init__()
         self._num_classes = num_classes
@@ -235,113 +290,149 @@ class InceptionI3d(nn.Module):
         self.logits = None
 
         if self._final_endpoint not in self.VALID_ENDPOINTS:
-            raise ValueError('Unknown final endpoint %s' % self._final_endpoint)
+            raise ValueError("Unknown final endpoint %s" % self._final_endpoint)
 
         """Construct I3D architecture"""
         self.end_points = {}
-        end_point = 'Conv3d_1a_7x7'
-        self.end_points[end_point] = Unit3D(in_channels=in_channels, output_channels=64, kernel_shape=[7, 7, 7],
-                                            stride=(2, 2, 2), padding=(3, 3, 3), name=name + end_point)
+        end_point = "Conv3d_1a_7x7"
+        self.end_points[end_point] = Unit3D(
+            in_channels=in_channels,
+            output_channels=64,
+            kernel_shape=[7, 7, 7],
+            stride=(2, 2, 2),
+            padding=(3, 3, 3),
+            name=name + end_point,
+        )
         if self._final_endpoint == end_point:
             return
 
-        end_point = 'MaxPool3d_2a_3x3'
-        self.end_points[end_point] = MaxPool3dSamePadding(kernel_size=[1, 3, 3], stride=(1, 2, 2),
-                                                          padding=0)
+        end_point = "MaxPool3d_2a_3x3"
+        self.end_points[end_point] = MaxPool3dSamePadding(
+            kernel_size=[1, 3, 3], stride=(1, 2, 2), padding=0
+        )
         if self._final_endpoint == end_point:
             return
 
-        end_point = 'Conv3d_2b_1x1'
-        self.end_points[end_point] = Unit3D(in_channels=64, output_channels=64, kernel_shape=[1, 1, 1], padding=0,
-                                            name=name + end_point)
+        end_point = "Conv3d_2b_1x1"
+        self.end_points[end_point] = Unit3D(
+            in_channels=64,
+            output_channels=64,
+            kernel_shape=[1, 1, 1],
+            padding=0,
+            name=name + end_point,
+        )
         if self._final_endpoint == end_point:
             return
 
-        end_point = 'Conv3d_2c_3x3'
-        self.end_points[end_point] = Unit3D(in_channels=64, output_channels=192, kernel_shape=[3, 3, 3], padding=1,
-                                            name=name + end_point)
+        end_point = "Conv3d_2c_3x3"
+        self.end_points[end_point] = Unit3D(
+            in_channels=64,
+            output_channels=192,
+            kernel_shape=[3, 3, 3],
+            padding=1,
+            name=name + end_point,
+        )
         if self._final_endpoint == end_point:
             return
 
-        end_point = 'MaxPool3d_3a_3x3'
-        self.end_points[end_point] = MaxPool3dSamePadding(kernel_size=[1, 3, 3], stride=(1, 2, 2),
-                                                          padding=0)
+        end_point = "MaxPool3d_3a_3x3"
+        self.end_points[end_point] = MaxPool3dSamePadding(
+            kernel_size=[1, 3, 3], stride=(1, 2, 2), padding=0
+        )
         if self._final_endpoint == end_point:
             return
 
-        end_point = 'Mixed_3b'
-        self.end_points[end_point] = InceptionModule(192, [64, 96, 128, 16, 32, 32], name + end_point)
+        end_point = "Mixed_3b"
+        self.end_points[end_point] = InceptionModule(
+            192, [64, 96, 128, 16, 32, 32], name + end_point
+        )
         if self._final_endpoint == end_point:
             return
 
-        end_point = 'Mixed_3c'
-        self.end_points[end_point] = InceptionModule(256, [128, 128, 192, 32, 96, 64], name + end_point)
+        end_point = "Mixed_3c"
+        self.end_points[end_point] = InceptionModule(
+            256, [128, 128, 192, 32, 96, 64], name + end_point
+        )
         if self._final_endpoint == end_point:
             return
 
-        end_point = 'MaxPool3d_4a_3x3'
-        self.end_points[end_point] = MaxPool3dSamePadding(kernel_size=[3, 3, 3], stride=(2, 2, 2),
-                                                          padding=0)
+        end_point = "MaxPool3d_4a_3x3"
+        self.end_points[end_point] = MaxPool3dSamePadding(
+            kernel_size=[3, 3, 3], stride=(2, 2, 2), padding=0
+        )
         if self._final_endpoint == end_point:
             return
 
-        end_point = 'Mixed_4b'
-        self.end_points[end_point] = InceptionModule(128 + 192 + 96 + 64, [192, 96, 208, 16, 48, 64], name + end_point)
+        end_point = "Mixed_4b"
+        self.end_points[end_point] = InceptionModule(
+            128 + 192 + 96 + 64, [192, 96, 208, 16, 48, 64], name + end_point
+        )
         if self._final_endpoint == end_point:
             return
 
-        end_point = 'Mixed_4c'
-        self.end_points[end_point] = InceptionModule(192 + 208 + 48 + 64, [160, 112, 224, 24, 64, 64], name + end_point)
+        end_point = "Mixed_4c"
+        self.end_points[end_point] = InceptionModule(
+            192 + 208 + 48 + 64, [160, 112, 224, 24, 64, 64], name + end_point
+        )
         if self._final_endpoint == end_point:
             return
 
-        end_point = 'Mixed_4d'
-        self.end_points[end_point] = InceptionModule(160 + 224 + 64 + 64, [128, 128, 256, 24, 64, 64], name + end_point)
+        end_point = "Mixed_4d"
+        self.end_points[end_point] = InceptionModule(
+            160 + 224 + 64 + 64, [128, 128, 256, 24, 64, 64], name + end_point
+        )
         if self._final_endpoint == end_point:
             return
 
-        end_point = 'Mixed_4e'
-        self.end_points[end_point] = InceptionModule(128 + 256 + 64 + 64, [112, 144, 288, 32, 64, 64], name + end_point)
+        end_point = "Mixed_4e"
+        self.end_points[end_point] = InceptionModule(
+            128 + 256 + 64 + 64, [112, 144, 288, 32, 64, 64], name + end_point
+        )
         if self._final_endpoint == end_point:
             return
 
-        end_point = 'Mixed_4f'
-        self.end_points[end_point] = InceptionModule(112 + 288 + 64 + 64, [256, 160, 320, 32, 128, 128],
-                                                     name + end_point)
+        end_point = "Mixed_4f"
+        self.end_points[end_point] = InceptionModule(
+            112 + 288 + 64 + 64, [256, 160, 320, 32, 128, 128], name + end_point
+        )
         if self._final_endpoint == end_point:
             return
 
-        end_point = 'MaxPool3d_5a_2x2'
-        self.end_points[end_point] = MaxPool3dSamePadding(kernel_size=[2, 2, 2], stride=(2, 2, 2),
-                                                          padding=0)
+        end_point = "MaxPool3d_5a_2x2"
+        self.end_points[end_point] = MaxPool3dSamePadding(
+            kernel_size=[2, 2, 2], stride=(2, 2, 2), padding=0
+        )
         if self._final_endpoint == end_point:
             return
 
-        end_point = 'Mixed_5b'
-        self.end_points[end_point] = InceptionModule(256 + 320 + 128 + 128, [256, 160, 320, 32, 128, 128],
-                                                     name + end_point)
+        end_point = "Mixed_5b"
+        self.end_points[end_point] = InceptionModule(
+            256 + 320 + 128 + 128, [256, 160, 320, 32, 128, 128], name + end_point
+        )
         if self._final_endpoint == end_point:
             return
 
-        end_point = 'Mixed_5c'
-        self.end_points[end_point] = InceptionModule(256 + 320 + 128 + 128, [384, 192, 384, 48, 128, 128],
-                                                     name + end_point)
+        end_point = "Mixed_5c"
+        self.end_points[end_point] = InceptionModule(
+            256 + 320 + 128 + 128, [384, 192, 384, 48, 128, 128], name + end_point
+        )
         if self._final_endpoint == end_point:
             return
 
-        end_point = 'Logits'
-        self.avg_pool = nn.AvgPool3d(kernel_size=[2, 7, 7],
-                                     stride=(1, 1, 1))
-        self.avg_pool_flow = nn.AvgPool3d(kernel_size=[1, 7, 7],
-                                          stride=(1, 1, 1))
+        end_point = "Logits"
+        self.avg_pool = nn.AvgPool3d(kernel_size=[2, 7, 7], stride=(1, 1, 1))
+        self.avg_pool_flow = nn.AvgPool3d(kernel_size=[1, 7, 7], stride=(1, 1, 1))
         self.dropout = nn.Dropout(dropout_keep_prob)
-        self.logits = Unit3D(in_channels=384 + 384 + 128 + 128, output_channels=self._num_classes,
-                             kernel_shape=[1, 1, 1],
-                             padding=0,
-                             activation_fn=None,
-                             use_batch_norm=False,
-                             use_bias=True,
-                             name='logits')
+        self.logits = Unit3D(
+            in_channels=384 + 384 + 128 + 128,
+            output_channels=self._num_classes,
+            kernel_shape=[1, 1, 1],
+            padding=0,
+            activation_fn=None,
+            use_batch_norm=False,
+            use_bias=True,
+            name="logits",
+        )
 
         self.build()
 
@@ -349,13 +440,16 @@ class InceptionI3d(nn.Module):
         """Update the num_classes according to the specific setting"""
 
         self._num_classes = num_classes
-        self.logits = Unit3D(in_channels=384 + 384 + 128 + 128, output_channels=self._num_classes,
-                             kernel_shape=[1, 1, 1],
-                             padding=0,
-                             activation_fn=None,
-                             use_batch_norm=False,
-                             use_bias=True,
-                             name='logits')
+        self.logits = Unit3D(
+            in_channels=384 + 384 + 128 + 128,
+            output_channels=self._num_classes,
+            kernel_shape=[1, 1, 1],
+            padding=0,
+            activation_fn=None,
+            use_batch_norm=False,
+            use_bias=True,
+            name="logits",
+        )
 
     def build(self):
         for k in self.end_points.keys():
@@ -366,7 +460,9 @@ class InceptionI3d(nn.Module):
 
         for end_point in self.VALID_ENDPOINTS:
             if end_point in self.end_points:
-                x = self._modules[end_point](x)  # use _modules to work with dataparallel
+                x = self._modules[end_point](
+                    x
+                )  # use _modules to work with dataparallel
 
         # For EPIC datasets, RGB window has 16 frames while flow has 8. We apply different avg_pool to them.
         if x.shape[2] == 2:
@@ -391,7 +487,6 @@ def i3d(name, num_channels, pretrained=False, progress=True):
     model = InceptionI3d(in_channels=num_channels)
 
     if pretrained:
-        state_dict = load_state_dict_from_url(model_urls[name],
-                                              progress=progress)
+        state_dict = load_state_dict_from_url(model_urls[name], progress=progress)
         model.load_state_dict(state_dict)
     return model

--- a/kale/embed/video_res3d.py
+++ b/kale/embed/video_res3d.py
@@ -6,31 +6,27 @@ Created by Xianyuan Liu from modifying https://github.com/pytorch/vision/blob/ma
 import torch.nn as nn
 from torchvision.models.utils import load_state_dict_from_url
 
-__all__ = ['r3d_18', 'mc3_18', 'r2plus1d_18']
+__all__ = ["r3d_18", "mc3_18", "r2plus1d_18"]
 
 model_urls = {
-    'r3d_18': 'https://download.pytorch.org/models/r3d_18-b3b3357e.pth',
-    'mc3_18': 'https://download.pytorch.org/models/mc3_18-a90a0ba3.pth',
-    'r2plus1d_18': 'https://download.pytorch.org/models/r2plus1d_18-91a641e6.pth',
+    "r3d_18": "https://download.pytorch.org/models/r3d_18-b3b3357e.pth",
+    "mc3_18": "https://download.pytorch.org/models/mc3_18-a90a0ba3.pth",
+    "r2plus1d_18": "https://download.pytorch.org/models/r2plus1d_18-91a641e6.pth",
 }
 
 
 class Conv3DSimple(nn.Conv3d):
     """3D convolutions for R3D (3x3x3 kernel)"""
 
-    def __init__(self,
-                 in_planes,
-                 out_planes,
-                 midplanes=None,
-                 stride=1,
-                 padding=1):
+    def __init__(self, in_planes, out_planes, midplanes=None, stride=1, padding=1):
         super(Conv3DSimple, self).__init__(
             in_channels=in_planes,
             out_channels=out_planes,
             kernel_size=(3, 3, 3),
             stride=stride,
             padding=padding,
-            bias=False)
+            bias=False,
+        )
 
     @staticmethod
     def get_downsample_stride(stride):
@@ -40,21 +36,27 @@ class Conv3DSimple(nn.Conv3d):
 class Conv2Plus1D(nn.Sequential):
     """(2+1)D convolutions for R2plus1D (1x3x3 kernel + 3x1x1 kernel)"""
 
-    def __init__(self,
-                 in_planes,
-                 out_planes,
-                 midplanes,
-                 stride=1,
-                 padding=1):
+    def __init__(self, in_planes, out_planes, midplanes, stride=1, padding=1):
         super(Conv2Plus1D, self).__init__(
-            nn.Conv3d(in_planes, midplanes, kernel_size=(1, 3, 3),
-                      stride=(1, stride, stride), padding=(0, padding, padding),
-                      bias=False),
+            nn.Conv3d(
+                in_planes,
+                midplanes,
+                kernel_size=(1, 3, 3),
+                stride=(1, stride, stride),
+                padding=(0, padding, padding),
+                bias=False,
+            ),
             nn.BatchNorm3d(midplanes),
             nn.ReLU(inplace=True),
-            nn.Conv3d(midplanes, out_planes, kernel_size=(3, 1, 1),
-                      stride=(stride, 1, 1), padding=(padding, 0, 0),
-                      bias=False))
+            nn.Conv3d(
+                midplanes,
+                out_planes,
+                kernel_size=(3, 1, 1),
+                stride=(stride, 1, 1),
+                padding=(padding, 0, 0),
+                bias=False,
+            ),
+        )
 
     @staticmethod
     def get_downsample_stride(stride):
@@ -64,19 +66,15 @@ class Conv2Plus1D(nn.Sequential):
 class Conv3DNoTemporal(nn.Conv3d):
     """3D convolutions without temporal dimension for MCx (1x3x3 kernel)"""
 
-    def __init__(self,
-                 in_planes,
-                 out_planes,
-                 midplanes=None,
-                 stride=1,
-                 padding=1):
+    def __init__(self, in_planes, out_planes, midplanes=None, stride=1, padding=1):
         super(Conv3DNoTemporal, self).__init__(
             in_channels=in_planes,
             out_channels=out_planes,
             kernel_size=(1, 3, 3),
             stride=(1, stride, stride),
             padding=(0, padding, padding),
-            bias=False)
+            bias=False,
+        )
 
     @staticmethod
     def get_downsample_stride(stride):
@@ -98,11 +96,10 @@ class BasicBlock(nn.Module):
         self.conv1 = nn.Sequential(
             conv_builder(inplanes, planes, midplanes, stride),
             nn.BatchNorm3d(planes),
-            nn.ReLU(inplace=True)
+            nn.ReLU(inplace=True),
         )
         self.conv2 = nn.Sequential(
-            conv_builder(planes, planes, midplanes),
-            nn.BatchNorm3d(planes)
+            conv_builder(planes, planes, midplanes), nn.BatchNorm3d(planes)
         )
         self.relu = nn.ReLU(inplace=True)
         self.downsample = downsample
@@ -127,6 +124,7 @@ class Bottleneck(nn.Module):
     BottleNeck building block. Default: No use. Each block consists of two 1*n*n and one n*n*n convolutional layers
     with a ReLU activation function after each layer and residual connections.
     """
+
     expansion = 4
 
     def __init__(self, inplanes, planes, conv_builder, stride=1, downsample=None):
@@ -137,19 +135,19 @@ class Bottleneck(nn.Module):
         self.conv1 = nn.Sequential(
             nn.Conv3d(inplanes, planes, kernel_size=1, bias=False),
             nn.BatchNorm3d(planes),
-            nn.ReLU(inplace=True)
+            nn.ReLU(inplace=True),
         )
         # Second kernel
         self.conv2 = nn.Sequential(
             conv_builder(planes, planes, midplanes, stride),
             nn.BatchNorm3d(planes),
-            nn.ReLU(inplace=True)
+            nn.ReLU(inplace=True),
         )
 
         # 1x1x1
         self.conv3 = nn.Sequential(
             nn.Conv3d(planes, planes * self.expansion, kernel_size=1, bias=False),
-            nn.BatchNorm3d(planes * self.expansion)
+            nn.BatchNorm3d(planes * self.expansion),
         )
         self.relu = nn.ReLU(inplace=True)
         self.downsample = downsample
@@ -176,10 +174,17 @@ class BasicStem(nn.Sequential):
 
     def __init__(self):
         super(BasicStem, self).__init__(
-            nn.Conv3d(3, 64, kernel_size=(3, 7, 7), stride=(1, 2, 2),
-                      padding=(1, 3, 3), bias=False),
+            nn.Conv3d(
+                3,
+                64,
+                kernel_size=(3, 7, 7),
+                stride=(1, 2, 2),
+                padding=(1, 3, 3),
+                bias=False,
+            ),
             nn.BatchNorm3d(64),
-            nn.ReLU(inplace=True))
+            nn.ReLU(inplace=True),
+        )
 
 
 class R2Plus1dStem(nn.Sequential):
@@ -190,23 +195,39 @@ class R2Plus1dStem(nn.Sequential):
 
     def __init__(self):
         super(R2Plus1dStem, self).__init__(
-            nn.Conv3d(3, 45, kernel_size=(1, 7, 7),
-                      stride=(1, 2, 2), padding=(0, 3, 3),
-                      bias=False),
+            nn.Conv3d(
+                3,
+                45,
+                kernel_size=(1, 7, 7),
+                stride=(1, 2, 2),
+                padding=(0, 3, 3),
+                bias=False,
+            ),
             nn.BatchNorm3d(45),
             nn.ReLU(inplace=True),
-            nn.Conv3d(45, 64, kernel_size=(3, 1, 1),
-                      stride=(1, 1, 1), padding=(1, 0, 0),
-                      bias=False),
+            nn.Conv3d(
+                45,
+                64,
+                kernel_size=(3, 1, 1),
+                stride=(1, 1, 1),
+                padding=(1, 0, 0),
+                bias=False,
+            ),
             nn.BatchNorm3d(64),
-            nn.ReLU(inplace=True))
+            nn.ReLU(inplace=True),
+        )
 
 
 class VideoResNet(nn.Module):
-
-    def __init__(self, block, conv_makers, layers,
-                 stem, num_classes=400,
-                 zero_init_residual=False):
+    def __init__(
+        self,
+        block,
+        conv_makers,
+        layers,
+        stem,
+        num_classes=400,
+        zero_init_residual=False,
+    ):
         """Generic resnet video generator.
         Args:
             block (nn.Module): resnet building block
@@ -258,9 +279,14 @@ class VideoResNet(nn.Module):
         if stride != 1 or self.inplanes != planes * block.expansion:
             ds_stride = conv_builder.get_downsample_stride(stride)
             downsample = nn.Sequential(
-                nn.Conv3d(self.inplanes, planes * block.expansion,
-                          kernel_size=1, stride=ds_stride, bias=False),
-                nn.BatchNorm3d(planes * block.expansion)
+                nn.Conv3d(
+                    self.inplanes,
+                    planes * block.expansion,
+                    kernel_size=1,
+                    stride=ds_stride,
+                    bias=False,
+                ),
+                nn.BatchNorm3d(planes * block.expansion),
             )
         layers = []
         layers.append(block(self.inplanes, planes, conv_builder, stride, downsample))
@@ -274,8 +300,7 @@ class VideoResNet(nn.Module):
     def _initialize_weights(self):
         for m in self.modules():
             if isinstance(m, nn.Conv3d):
-                nn.init.kaiming_normal_(m.weight, mode='fan_out',
-                                        nonlinearity='relu')
+                nn.init.kaiming_normal_(m.weight, mode="fan_out", nonlinearity="relu")
                 if m.bias is not None:
                     nn.init.constant_(m.bias, 0)
             elif isinstance(m, nn.BatchNorm3d):
@@ -290,8 +315,7 @@ def _video_resnet(arch, pretrained=False, progress=True, **kwargs):
     model = VideoResNet(**kwargs)
 
     if pretrained:
-        state_dict = load_state_dict_from_url(model_urls[arch],
-                                              progress=progress)
+        state_dict = load_state_dict_from_url(model_urls[arch], progress=progress)
         model.load_state_dict(state_dict)
     return model
 
@@ -306,12 +330,16 @@ def r3d_18(pretrained=False, progress=True, **kwargs):
         nn.Module: R3D-18 network
     """
 
-    return _video_resnet('r3d_18',
-                         pretrained, progress,
-                         block=BasicBlock,
-                         conv_makers=[Conv3DSimple] * 4,
-                         layers=[2, 2, 2, 2],
-                         stem=BasicStem, **kwargs)
+    return _video_resnet(
+        "r3d_18",
+        pretrained,
+        progress,
+        block=BasicBlock,
+        conv_makers=[Conv3DSimple] * 4,
+        layers=[2, 2, 2, 2],
+        stem=BasicStem,
+        **kwargs
+    )
 
 
 def mc3_18(pretrained=False, progress=True, **kwargs):
@@ -324,12 +352,16 @@ def mc3_18(pretrained=False, progress=True, **kwargs):
         nn.Module: MC3 Network definition
     """
 
-    return _video_resnet('mc3_18',
-                         pretrained, progress,
-                         block=BasicBlock,
-                         conv_makers=[Conv3DSimple] + [Conv3DNoTemporal] * 3,
-                         layers=[2, 2, 2, 2],
-                         stem=BasicStem, **kwargs)
+    return _video_resnet(
+        "mc3_18",
+        pretrained,
+        progress,
+        block=BasicBlock,
+        conv_makers=[Conv3DSimple] + [Conv3DNoTemporal] * 3,
+        layers=[2, 2, 2, 2],
+        stem=BasicStem,
+        **kwargs
+    )
 
 
 def r2plus1d_18(pretrained=False, progress=True, **kwargs):
@@ -342,9 +374,13 @@ def r2plus1d_18(pretrained=False, progress=True, **kwargs):
         nn.Module: R(2+1)D-18 network
     """
 
-    return _video_resnet('r2plus1d_18',
-                         pretrained, progress,
-                         block=BasicBlock,
-                         conv_makers=[Conv2Plus1D] * 4,
-                         layers=[2, 2, 2, 2],
-                         stem=R2Plus1dStem, **kwargs)
+    return _video_resnet(
+        "r2plus1d_18",
+        pretrained,
+        progress,
+        block=BasicBlock,
+        conv_makers=[Conv2Plus1D] * 4,
+        layers=[2, 2, 2, 2],
+        stem=R2Plus1dStem,
+        **kwargs
+    )

--- a/kale/loaddata/cifar_access.py
+++ b/kale/loaddata/cifar_access.py
@@ -16,13 +16,13 @@ def get_cifar(cfg):
     Args:
         cfg: A YACS config object.
     """
-    print('==> Preparing to load data ' + cfg.DATASET.NAME + ' at ' + cfg.DATASET.ROOT)
+    print("==> Preparing to load data " + cfg.DATASET.NAME + " at " + cfg.DATASET.ROOT)
     cifar_train_transform = get_transform("cifar", augment=True)
     cifar_test_transform = get_transform("cifar", augment=False)
     # transform = {
     #     'cifar_train': transforms.Compose([
     #         # Data augmentation
-    #         transforms.RandomCrop(32, padding=4), 
+    #         transforms.RandomCrop(32, padding=4),
     #         transforms.RandomHorizontalFlip(),
     #         transforms.ToTensor(),
     #         transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010)),
@@ -32,24 +32,37 @@ def get_cifar(cfg):
     #         transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010)),
     #     ])
     # }
-    if cfg.DATASET.NAME == 'CIFAR10':
-        train_set = torchvision.datasets.CIFAR10(cfg.DATASET.ROOT, train=True, download=True,
-                                                 transform=cifar_train_transform)
-        val_set = torchvision.datasets.CIFAR10(cfg.DATASET.ROOT, train=False, download=True,
-                                               transform=cifar_test_transform)
-    elif cfg.DATASET.NAME == 'CIFAR100':
-        train_set = torchvision.datasets.CIFAR100(cfg.DATASET.ROOT, train=True, download=True,
-                                                  transform=cifar_train_transform)
-        val_set = torchvision.datasets.CIFAR100(cfg.DATASET.ROOT, train=False, download=True,
-                                                transform=cifar_test_transform)
+    if cfg.DATASET.NAME == "CIFAR10":
+        train_set = torchvision.datasets.CIFAR10(
+            cfg.DATASET.ROOT, train=True, download=True, transform=cifar_train_transform
+        )
+        val_set = torchvision.datasets.CIFAR10(
+            cfg.DATASET.ROOT, train=False, download=True, transform=cifar_test_transform
+        )
+    elif cfg.DATASET.NAME == "CIFAR100":
+        train_set = torchvision.datasets.CIFAR100(
+            cfg.DATASET.ROOT, train=True, download=True, transform=cifar_train_transform
+        )
+        val_set = torchvision.datasets.CIFAR100(
+            cfg.DATASET.ROOT, train=False, download=True, transform=cifar_test_transform
+        )
     else:
         raise NotImplementedError
 
-    train_loader = torch.utils.data.DataLoader(train_set, batch_size=cfg.SOLVER.TRAIN_BATCH_SIZE,
-                                               shuffle=True, num_workers=cfg.DATASET.NUM_WORKERS,
-                                               pin_memory=True, drop_last=True)
-    val_loader = torch.utils.data.DataLoader(val_set, batch_size=cfg.SOLVER.TEST_BATCH_SIZE,
-                                             shuffle=False, num_workers=cfg.DATASET.NUM_WORKERS
-                                             , pin_memory=True)
+    train_loader = torch.utils.data.DataLoader(
+        train_set,
+        batch_size=cfg.SOLVER.TRAIN_BATCH_SIZE,
+        shuffle=True,
+        num_workers=cfg.DATASET.NUM_WORKERS,
+        pin_memory=True,
+        drop_last=True,
+    )
+    val_loader = torch.utils.data.DataLoader(
+        val_set,
+        batch_size=cfg.SOLVER.TEST_BATCH_SIZE,
+        shuffle=False,
+        num_workers=cfg.DATASET.NUM_WORKERS,
+        pin_memory=True,
+    )
 
     return train_loader, val_loader

--- a/kale/loaddata/cifar_access.py
+++ b/kale/loaddata/cifar_access.py
@@ -1,12 +1,11 @@
 """CIFAR10 or CIFAR100 dataset loading
 
-Reference: https://github.com/HaozhiQi/ISONet/blob/master/isonet/utils/dataset.py 
+Reference: https://github.com/HaozhiQi/ISONet/blob/master/isonet/utils/dataset.py
 """
 
-import os
 import torch
 import torchvision
-import torchvision.transforms as transforms
+# import torchvision.transforms as transforms
 from kale.prepdata.image_transform import get_transform
 
 

--- a/kale/loaddata/dataset_access.py
+++ b/kale/loaddata/dataset_access.py
@@ -13,7 +13,7 @@ class DatasetAccess:
 
     Args:
         n_classes: the number of classes (default=3).
-        ckernel_size: the size of the convolution kernel (default=5).    
+        ckernel_size: the size of the convolution kernel (default=5).
     """
 
     def __init__(self, n_classes):

--- a/kale/loaddata/dataset_access.py
+++ b/kale/loaddata/dataset_access.py
@@ -1,5 +1,5 @@
 """
-Dataset Access API adapted from https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/datasets/dataset_access.py
+Dataset Access API adapted from https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/datasets/dataset_access.py # noqa: E501
 """
 
 import torch

--- a/kale/loaddata/digits_access.py
+++ b/kale/loaddata/digits_access.py
@@ -61,7 +61,7 @@ class DigitDataset(Enum):
         return (
             factories[source](data_path, source_tf),
             factories[target](data_path, target_tf),
-            num_channels
+            num_channels,
         )
 
 

--- a/kale/loaddata/digits_access.py
+++ b/kale/loaddata/digits_access.py
@@ -1,5 +1,5 @@
 """
-Digits dataset (source and target domain) loading for MNIST, SVHN, MNIST-M (modified MNIST), and USPS. The code is based on 
+Digits dataset (source and target domain) loading for MNIST, SVHN, MNIST-M (modified MNIST), and USPS. The code is based on # noqa: E501
 https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/datasets/digits_dataset_access.py
 """
 

--- a/kale/loaddata/mnistm.py
+++ b/kale/loaddata/mnistm.py
@@ -1,5 +1,5 @@
 """
-Dataset setting and data loader for MNIST-M, from 
+Dataset setting and data loader for MNIST-M, from
 https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/datasets/dataset_mnistm.py
 (based on https://github.com/pytorch/vision/blob/master/torchvision/datasets/mnist.py)
 CREDIT: https://github.com/corenel

--- a/kale/loaddata/mnistm.py
+++ b/kale/loaddata/mnistm.py
@@ -46,7 +46,12 @@ class MNISTM(data.Dataset):
     test_file = "mnist_m_test.pt"
 
     def __init__(
-            self, root, train=True, transform=None, target_transform=None, download=False,
+        self,
+        root,
+        train=True,
+        transform=None,
+        target_transform=None,
+        download=False,
     ):
         """Init MNIST-M dataset."""
         super(MNISTM, self).__init__()
@@ -136,7 +141,7 @@ class MNISTM(data.Dataset):
             with open(file_path, "wb") as f:
                 f.write(data.read())
             with open(file_path.replace(".gz", ""), "wb") as out_f, gzip.GzipFile(
-                    file_path
+                file_path
             ) as zip_f:
                 out_f.write(zip_f.read())
             os.unlink(file_path)
@@ -162,11 +167,11 @@ class MNISTM(data.Dataset):
         training_set = (mnist_m_train_data, mnist_train_labels)
         test_set = (mnist_m_test_data, mnist_test_labels)
         with open(
-                os.path.join(self.root, self.processed_folder, self.training_file), "wb"
+            os.path.join(self.root, self.processed_folder, self.training_file), "wb"
         ) as f:
             torch.save(training_set, f)
         with open(
-                os.path.join(self.root, self.processed_folder, self.test_file), "wb"
+            os.path.join(self.root, self.processed_folder, self.test_file), "wb"
         ) as f:
             torch.save(test_set, f)
 

--- a/kale/loaddata/multi_domain.py
+++ b/kale/loaddata/multi_domain.py
@@ -1,5 +1,6 @@
 """
-Construct a dataset with (multiple) source and target domains, from https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/datasets/multisource.py
+Construct a dataset with (multiple) source and target domains, from
+https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/datasets/multisource.py
 """
 
 import logging
@@ -75,12 +76,12 @@ class MultiDomainDatasets(DomainsDatasetBase):
             source_access (DatasetAccess): accessor for the source dataset
             target_access (DatasetAccess): accessor for the target dataset
             val_split_ratio (float, optional): ratio for the validation part of the train dataset. Defaults to 0.1.
-            source_sampling_config (SamplingConfig, optional): How to sample from the source. Defaults to None (=> RandomSampler).
-            target_sampling_config (SamplingConfig, optional): How to sample from the target. Defaults to None (=> RandomSampler).
-            size_type (DatasetSizeType, optional): Which dataset size to use to define the number of epochs vs batch_size. Defaults to DatasetSizeType.Max.
+            source_sampling_config (SamplingConfig, optional): How to sample from the source. Defaults to None (=> RandomSampler). # noqa: E501
+            target_sampling_config (SamplingConfig, optional): How to sample from the target. Defaults to None (=> RandomSampler). # noqa: E501
+            size_type (DatasetSizeType, optional): Which dataset size to use to define the number of epochs vs batch_size. Defaults to DatasetSizeType.Max. # noqa: E501
             n_fewshot (int, optional): Number of target samples for which the label may be used,
                 to define the few-shot, semi-supervised setting. Defaults to None.
-            random_state ([int|np.random.RandomState], optional): Used for deterministic sampling/few-shot label selection. Defaults to None.
+            random_state ([int|np.random.RandomState], optional): Used for deterministic sampling/few-shot label selection. Defaults to None. # noqa: E501
         Examples::
             >>> dataset = MultiDomainDatasets(source, target)
         """

--- a/kale/loaddata/multi_domain.py
+++ b/kale/loaddata/multi_domain.py
@@ -47,9 +47,9 @@ class DomainsDatasetBase:
         Args:
             split (string, optional): ["train"|"valid"|"test"]. Which dataset to iterate on. Defaults to "train".
             batch_size (int, optional): Defaults to 32.
-        
+
         Returns:
-            MultiDataLoader: A dataloader with API similar to the torch.dataloader, but returning 
+            MultiDataLoader: A dataloader with API similar to the torch.dataloader, but returning
             batches from several domains at each iteration.
         """
         raise NotImplementedError()
@@ -57,18 +57,18 @@ class DomainsDatasetBase:
 
 class MultiDomainDatasets(DomainsDatasetBase):
     def __init__(
-            self,
-            source_access: DatasetAccess,
-            target_access: DatasetAccess,
-            config_weight_type="natural",
-            config_size_type=DatasetSizeType.Max,
-            val_split_ratio=0.1,
-            source_sampling_config=None,
-            target_sampling_config=None,
-            n_fewshot=None,
-            random_state=None,
+        self,
+        source_access: DatasetAccess,
+        target_access: DatasetAccess,
+        config_weight_type="natural",
+        config_size_type=DatasetSizeType.Max,
+        val_split_ratio=0.1,
+        source_sampling_config=None,
+        target_sampling_config=None,
+        n_fewshot=None,
+        random_state=None,
     ):
-        """The class controlling how the source and target domains are 
+        """The class controlling how the source and target domains are
             iterated over.
 
         Args:
@@ -78,7 +78,7 @@ class MultiDomainDatasets(DomainsDatasetBase):
             source_sampling_config (SamplingConfig, optional): How to sample from the source. Defaults to None (=> RandomSampler).
             target_sampling_config (SamplingConfig, optional): How to sample from the target. Defaults to None (=> RandomSampler).
             size_type (DatasetSizeType, optional): Which dataset size to use to define the number of epochs vs batch_size. Defaults to DatasetSizeType.Max.
-            n_fewshot (int, optional): Number of target samples for which the label may be used, 
+            n_fewshot (int, optional): Number of target samples for which the label may be used,
                 to define the few-shot, semi-supervised setting. Defaults to None.
             random_state ([int|np.random.RandomState], optional): Used for deterministic sampling/few-shot label selection. Defaults to None.
         Examples::

--- a/kale/loaddata/sampler.py
+++ b/kale/loaddata/sampler.py
@@ -263,4 +263,4 @@ class InfiniteSliceIterator:
             np.random.shuffle(self.array)
         i = self.i
         self.i += n
-        return self.array[i : self.i]
+        return self.array[i:self.i]

--- a/kale/loaddata/usps.py
+++ b/kale/loaddata/usps.py
@@ -54,8 +54,8 @@ class USPS(data.Dataset):
             total_num_samples = self.data.shape[0]
             indices = np.arange(total_num_samples)
             np.random.shuffle(indices)
-            self.data = self.data[indices[0 : self.dataset_size], ::]
-            self.targets = self.targets[indices[0 : self.dataset_size]]
+            self.data = self.data[indices[0:self.dataset_size], ::]
+            self.targets = self.targets[indices[0:self.dataset_size]]
         # self.train_data *= 255.0  # TODO check bug
         self.data = self.data.transpose((0, 2, 3, 1))  # convert to HWC
 

--- a/kale/loaddata/video_access.py
+++ b/kale/loaddata/video_access.py
@@ -23,7 +23,7 @@ def get_videodata_config(cfg):
             "dataset_tar_testlist": cfg.DATASET.TAR_TESTLIST,
             "dataset_image_modality": cfg.DATASET.IMAGE_MODALITY,
             "num_classes": cfg.DATASET.NUM_CLASSES,
-            "frames_per_segment": cfg.DATASET.FRAMES_PER_SEGMENT
+            "frames_per_segment": cfg.DATASET.FRAMES_PER_SEGMENT,
         }
     }
     return config_params
@@ -43,28 +43,38 @@ def generate_list(data_name, data_params_local, domain):
         test_listpath (string): test list file directory of dataset
     """
 
-    if data_name == 'EPIC':
-        dataset_path = os.path.join(data_params_local['dataset_root'], data_name, 'EPIC_KITCHENS_2018')
-        data_path = os.path.join(dataset_path, 'frames_rgb_flow')
-    elif data_name in ['ADL', 'GTEA', 'KITCHEN']:
-        dataset_path = os.path.join(data_params_local['dataset_root'], data_name)
-        data_path = os.path.join(dataset_path, 'frames_rgb_flow')
+    if data_name == "EPIC":
+        dataset_path = os.path.join(
+            data_params_local["dataset_root"], data_name, "EPIC_KITCHENS_2018"
+        )
+        data_path = os.path.join(dataset_path, "frames_rgb_flow")
+    elif data_name in ["ADL", "GTEA", "KITCHEN"]:
+        dataset_path = os.path.join(data_params_local["dataset_root"], data_name)
+        data_path = os.path.join(dataset_path, "frames_rgb_flow")
     else:
-        raise RuntimeError('Wrong dataset name. Select from [EPIC, ADL, GTEA, KITCHEN]')
+        raise RuntimeError("Wrong dataset name. Select from [EPIC, ADL, GTEA, KITCHEN]")
 
     train_listpath = os.path.join(
-        dataset_path, 'annotations', 'labels_train_test', data_params_local['dataset_{}_trainlist'.format(domain)])
+        dataset_path,
+        "annotations",
+        "labels_train_test",
+        data_params_local["dataset_{}_trainlist".format(domain)],
+    )
     test_listpath = os.path.join(
-        dataset_path, 'annotations', 'labels_train_test', data_params_local['dataset_{}_testlist'.format(domain)])
+        dataset_path,
+        "annotations",
+        "labels_train_test",
+        data_params_local["dataset_{}_testlist".format(domain)],
+    )
 
     return data_path, train_listpath, test_listpath
 
 
 class VideoDataset(Enum):
-    EPIC = 'EPIC'
-    ADL = 'ADL'
-    GTEA = 'GTEA'
-    KITCHEN = 'KITCHEN'
+    EPIC = "EPIC"
+    ADL = "ADL"
+    GTEA = "GTEA"
+    KITCHEN = "KITCHEN"
 
     @staticmethod
     def get_source_target(source: "VideoDataset", target: "VideoDataset", params):
@@ -80,17 +90,21 @@ class VideoDataset(Enum):
             >>> source, target, num_channel = get_source_target(sourcename, targetname, cfg)
         """
         config_params = get_videodata_config(params)
-        data_params = config_params['data_params']
+        data_params = config_params["data_params"]
         data_params_local = deepcopy(data_params)
-        data_src_name = data_params_local['dataset_src_name'].upper()
-        src_data_path, src_tr_listpath, src_te_listpath = generate_list(data_src_name, data_params_local, domain='src')
-        data_tar_name = data_params_local['dataset_tar_name'].upper()
-        tar_data_path, tar_tr_listpath, tar_te_listpath = generate_list(data_tar_name, data_params_local, domain='tar')
-        image_modality = data_params_local['dataset_image_modality']
-        n_classes = data_params_local['num_classes']
-        frames_per_segment = data_params_local['frames_per_segment']
+        data_src_name = data_params_local["dataset_src_name"].upper()
+        src_data_path, src_tr_listpath, src_te_listpath = generate_list(
+            data_src_name, data_params_local, domain="src"
+        )
+        data_tar_name = data_params_local["dataset_tar_name"].upper()
+        tar_data_path, tar_tr_listpath, tar_te_listpath = generate_list(
+            data_tar_name, data_params_local, domain="tar"
+        )
+        image_modality = data_params_local["dataset_image_modality"]
+        n_classes = data_params_local["num_classes"]
+        frames_per_segment = data_params_local["frames_per_segment"]
 
-        if image_modality == 'rgb':
+        if image_modality == "rgb":
             channel_numbers = {
                 VideoDataset.EPIC: 3,
                 VideoDataset.GTEA: 3,
@@ -99,12 +113,12 @@ class VideoDataset(Enum):
             }
 
             transform_names = {
-                (VideoDataset.EPIC, 3): 'epic',
-                (VideoDataset.GTEA, 3): 'gtea',
-                (VideoDataset.ADL, 3): 'adl',
-                (VideoDataset.KITCHEN, 3): 'kitchen',
+                (VideoDataset.EPIC, 3): "epic",
+                (VideoDataset.GTEA, 3): "gtea",
+                (VideoDataset.ADL, 3): "adl",
+                (VideoDataset.KITCHEN, 3): "kitchen",
             }
-        elif image_modality == 'flow':
+        elif image_modality == "flow":
             channel_numbers = {
                 VideoDataset.EPIC: 2,
                 VideoDataset.GTEA: 2,
@@ -113,10 +127,10 @@ class VideoDataset(Enum):
             }
 
             transform_names = {
-                (VideoDataset.EPIC, 2): 'epic',
-                (VideoDataset.GTEA, 2): 'gtea',
-                (VideoDataset.ADL, 2): 'adl',
-                (VideoDataset.KITCHEN, 2): 'kitchen',
+                (VideoDataset.EPIC, 2): "epic",
+                (VideoDataset.GTEA, 2): "gtea",
+                (VideoDataset.ADL, 2): "adl",
+                (VideoDataset.KITCHEN, 2): "kitchen",
             }
 
         factories = {
@@ -132,11 +146,25 @@ class VideoDataset(Enum):
         target_tf = transform_names[(target, num_channels)]
 
         return (
-            factories[source](src_data_path, src_tr_listpath, src_te_listpath, image_modality, frames_per_segment, n_classes,
-                              source_tf),
-            factories[target](tar_data_path, tar_tr_listpath, tar_te_listpath, image_modality, frames_per_segment, n_classes,
-                              target_tf),
-            num_channels
+            factories[source](
+                src_data_path,
+                src_tr_listpath,
+                src_te_listpath,
+                image_modality,
+                frames_per_segment,
+                n_classes,
+                source_tf,
+            ),
+            factories[target](
+                tar_data_path,
+                tar_tr_listpath,
+                tar_te_listpath,
+                image_modality,
+                frames_per_segment,
+                n_classes,
+                target_tf,
+            ),
+            num_channels,
         )
 
 
@@ -154,32 +182,43 @@ class VideoDatasetAccess(DatasetAccess):
         transform_kind (string): types of video transforms
     """
 
-    def __init__(self, data_path, train_list, test_list,
-                 image_modality, frames_per_segment, n_classes, transform_kind):
+    def __init__(
+        self,
+        data_path,
+        train_list,
+        test_list,
+        image_modality,
+        frames_per_segment,
+        n_classes,
+        transform_kind,
+    ):
         super().__init__(n_classes)
         self._data_path = data_path
         self._train_list = train_list
         self._test_list = test_list
         self._image_modality = image_modality
         self._frames_per_segment = frames_per_segment
-        self._transform = video_transform.get_transform(transform_kind, self._image_modality)
+        self._transform = video_transform.get_transform(
+            transform_kind, self._image_modality
+        )
 
 
 class EPICDatasetAccess(VideoDatasetAccess):
     """EPIC data loader"""
+
     def get_train(self):
         return EPIC(
             root_path=self._data_path,
             annotationfile_path=self._train_list,
             num_segments=1,
             frames_per_segment=self._frames_per_segment,
-            imagefile_template='frame_{:010d}.jpg',
-            transform=self._transform['train'],
+            imagefile_template="frame_{:010d}.jpg",
+            transform=self._transform["train"],
             random_shift=True,
             test_mode=False,
             image_modality=self._image_modality,
-            dataset_split='train',
-            n_classes=self._n_classes
+            dataset_split="train",
+            n_classes=self._n_classes,
         )
 
     def get_test(self):
@@ -188,31 +227,34 @@ class EPICDatasetAccess(VideoDatasetAccess):
             annotationfile_path=self._test_list,
             num_segments=1,
             frames_per_segment=self._frames_per_segment,
-            imagefile_template='frame_{:010d}.jpg',
-            transform=self._transform['test'],
+            imagefile_template="frame_{:010d}.jpg",
+            transform=self._transform["test"],
             random_shift=False,
             test_mode=True,
             image_modality=self._image_modality,
-            dataset_split='test',
+            dataset_split="test",
             n_classes=self._n_classes,
         )
 
 
 class GTEADatasetAccess(VideoDatasetAccess):
     """GTEA data loader"""
+
     def get_train(self):
         return BasicVideoDataset(
             root_path=self._data_path,
             annotationfile_path=self._train_list,
             num_segments=1,
             frames_per_segment=self._frames_per_segment,
-            imagefile_template='frame_{:010d}.jpg' if self._image_modality in ['rgb'] else 'flow_{}_{:010d}.jpg',
-            transform=self._transform['train'],
+            imagefile_template="frame_{:010d}.jpg"
+            if self._image_modality in ["rgb"]
+            else "flow_{}_{:010d}.jpg",
+            transform=self._transform["train"],
             random_shift=False,
             test_mode=False,
             image_modality=self._image_modality,
-            dataset_split='train',
-            n_classes=self._n_classes
+            dataset_split="train",
+            n_classes=self._n_classes,
         )
 
     def get_test(self):
@@ -221,31 +263,36 @@ class GTEADatasetAccess(VideoDatasetAccess):
             annotationfile_path=self._test_list,
             num_segments=1,
             frames_per_segment=self._frames_per_segment,
-            imagefile_template='frame_{:010d}.jpg' if self._image_modality in ['rgb'] else 'flow_{}_{:010d}.jpg',
-            transform=self._transform['test'],
+            imagefile_template="frame_{:010d}.jpg"
+            if self._image_modality in ["rgb"]
+            else "flow_{}_{:010d}.jpg",
+            transform=self._transform["test"],
             random_shift=False,
             test_mode=True,
             image_modality=self._image_modality,
-            dataset_split='test',
+            dataset_split="test",
             n_classes=self._n_classes,
         )
 
 
 class ADLDatasetAccess(VideoDatasetAccess):
     """ADL data loader"""
+
     def get_train(self):
         return BasicVideoDataset(
             root_path=self._data_path,
             annotationfile_path=self._train_list,
             num_segments=1,
             frames_per_segment=self._frames_per_segment,
-            imagefile_template='frame_{:010d}.jpg' if self._image_modality in ['rgb'] else 'flow_{}_{:010d}.jpg',
-            transform=self._transform['train'],
+            imagefile_template="frame_{:010d}.jpg"
+            if self._image_modality in ["rgb"]
+            else "flow_{}_{:010d}.jpg",
+            transform=self._transform["train"],
             random_shift=False,
             test_mode=False,
             image_modality=self._image_modality,
-            dataset_split='train',
-            n_classes=self._n_classes
+            dataset_split="train",
+            n_classes=self._n_classes,
         )
 
     def get_test(self):
@@ -254,31 +301,36 @@ class ADLDatasetAccess(VideoDatasetAccess):
             annotationfile_path=self._test_list,
             num_segments=1,
             frames_per_segment=self._frames_per_segment,
-            imagefile_template='frame_{:010d}.jpg' if self._image_modality in ['rgb'] else 'flow_{}_{:010d}.jpg',
-            transform=self._transform['test'],
+            imagefile_template="frame_{:010d}.jpg"
+            if self._image_modality in ["rgb"]
+            else "flow_{}_{:010d}.jpg",
+            transform=self._transform["test"],
             random_shift=False,
             test_mode=True,
             image_modality=self._image_modality,
-            dataset_split='test',
+            dataset_split="test",
             n_classes=self._n_classes,
         )
 
 
 class KITCHENDatasetAccess(VideoDatasetAccess):
     """KITCHEN data loader"""
+
     def get_train(self):
         return BasicVideoDataset(
             root_path=self._data_path,
             annotationfile_path=self._train_list,
             num_segments=1,
             frames_per_segment=self._frames_per_segment,
-            imagefile_template='frame_{:010d}.jpg' if self._image_modality in ['rgb'] else 'flow_{}_{:010d}.jpg',
-            transform=self._transform['train'],
+            imagefile_template="frame_{:010d}.jpg"
+            if self._image_modality in ["rgb"]
+            else "flow_{}_{:010d}.jpg",
+            transform=self._transform["train"],
             random_shift=False,
             test_mode=False,
             image_modality=self._image_modality,
-            dataset_split='train',
-            n_classes=self._n_classes
+            dataset_split="train",
+            n_classes=self._n_classes,
         )
 
     def get_test(self):
@@ -287,11 +339,13 @@ class KITCHENDatasetAccess(VideoDatasetAccess):
             annotationfile_path=self._test_list,
             num_segments=1,
             frames_per_segment=self._frames_per_segment,
-            imagefile_template='frame_{:010d}.jpg' if self._image_modality in ['rgb'] else 'flow_{}_{:010d}.jpg',
-            transform=self._transform['test'],
+            imagefile_template="frame_{:010d}.jpg"
+            if self._image_modality in ["rgb"]
+            else "flow_{}_{:010d}.jpg",
+            transform=self._transform["test"],
             random_shift=False,
             test_mode=True,
             image_modality=self._image_modality,
-            dataset_split='test',
+            dataset_split="test",
             n_classes=self._n_classes,
         )

--- a/kale/loaddata/video_datasets.py
+++ b/kale/loaddata/video_datasets.py
@@ -27,19 +27,20 @@ class BasicVideoDataset(VideoFrameDataset):
         n_classes (int): The number of classes.
     """
 
-    def __init__(self,
-                 root_path: str,
-                 annotationfile_path: str,
-                 dataset_split: str,
-                 image_modality: str,
-                 num_segments: int = 1,
-                 frames_per_segment: int = 16,
-                 imagefile_template: str = 'img_{:010d}.jpg',
-                 transform=None,
-                 random_shift: bool = True,
-                 test_mode: bool = False,
-                 n_classes: int = 8
-                 ):
+    def __init__(
+        self,
+        root_path: str,
+        annotationfile_path: str,
+        dataset_split: str,
+        image_modality: str,
+        num_segments: int = 1,
+        frames_per_segment: int = 16,
+        imagefile_template: str = "img_{:010d}.jpg",
+        transform=None,
+        random_shift: bool = True,
+        test_mode: bool = False,
+        n_classes: int = 8,
+    ):
         self.root_path = Path(root_path)
         self.image_modality = image_modality
         self.dataset = dataset_split
@@ -54,11 +55,13 @@ class BasicVideoDataset(VideoFrameDataset):
             imagefile_template,
             transform,
             random_shift,
-            test_mode
+            test_mode,
         )
 
     def _parse_list(self):
-        self.video_list = [VideoRecord(x, self.img_path) for x in list(self.make_dataset())]
+        self.video_list = [
+            VideoRecord(x, self.img_path) for x in list(self.make_dataset())
+        ]
 
     def make_dataset(self):
         """
@@ -71,7 +74,7 @@ class BasicVideoDataset(VideoFrameDataset):
 
         data = []
         i = 0
-        with open(self.annotationfile_path, 'rb') as input_file:
+        with open(self.annotationfile_path, "rb") as input_file:
             input_file = pickle.load(input_file)
             for line in input_file.values:
                 if 0 <= eval(line[5]) < self.n_classes:
@@ -86,19 +89,20 @@ class EPIC(VideoFrameDataset):
     Dataset for EPIC-Kitchen.
     """
 
-    def __init__(self,
-                 root_path: str,
-                 annotationfile_path: str,
-                 dataset_split: str,
-                 image_modality: str,
-                 num_segments: int = 1,
-                 frames_per_segment: int = 16,
-                 imagefile_template: str = 'img_{:010d}.jpg',
-                 transform=None,
-                 random_shift: bool = True,
-                 test_mode: bool = False,
-                 n_classes: int = 8
-                 ):
+    def __init__(
+        self,
+        root_path: str,
+        annotationfile_path: str,
+        dataset_split: str,
+        image_modality: str,
+        num_segments: int = 1,
+        frames_per_segment: int = 16,
+        imagefile_template: str = "img_{:010d}.jpg",
+        transform=None,
+        random_shift: bool = True,
+        test_mode: bool = False,
+        n_classes: int = 8,
+    ):
         self.root_path = Path(root_path)
         self.image_modality = image_modality
         self.dataset = dataset_split
@@ -113,19 +117,29 @@ class EPIC(VideoFrameDataset):
             imagefile_template,
             transform,
             random_shift,
-            test_mode
+            test_mode,
         )
 
     def _parse_list(self):
-        self.video_list = [VideoRecord(x, self.img_path) for x in list(self.make_dataset())]
+        self.video_list = [
+            VideoRecord(x, self.img_path) for x in list(self.make_dataset())
+        ]
 
     def _load_image(self, directory, idx):
-        if self.image_modality == 'rgb':
-            return [Image.open(os.path.join(directory, self.imagefile_template.format(idx))).convert('RGB')]
-        elif self.image_modality == 'flow':
+        if self.image_modality == "rgb":
+            return [
+                Image.open(
+                    os.path.join(directory, self.imagefile_template.format(idx))
+                ).convert("RGB")
+            ]
+        elif self.image_modality == "flow":
             idx = math.ceil(idx / 2) - 1 if idx > 2 else 1
-            u_img = Image.open(os.path.join(directory, 'u', self.imagefile_template.format(idx))).convert('L')
-            v_img = Image.open(os.path.join(directory, 'v', self.imagefile_template.format(idx))).convert('L')
+            u_img = Image.open(
+                os.path.join(directory, "u", self.imagefile_template.format(idx))
+            ).convert("L")
+            v_img = Image.open(
+                os.path.join(directory, "v", self.imagefile_template.format(idx))
+            ).convert("L")
             return [u_img, v_img]
 
     def make_dataset(self):
@@ -133,17 +147,24 @@ class EPIC(VideoFrameDataset):
         Load data from the EPIC-Kitchen list file and make them into the united format.
         Because the original list files are not the same, inherit from class BasicVideoDataset and be modified.
         """
-        
+
         data = []
         i = 0
-        with open(self.annotationfile_path, 'rb') as input_file:
+        with open(self.annotationfile_path, "rb") as input_file:
             input_file = pickle.load(input_file)
             for line in input_file.values:
-                if line[1] in ['P01', 'P08', 'P22']:
+                if line[1] in ["P01", "P08", "P22"]:
                     if 0 <= line[9] < self.n_classes:
                         if line[7] - line[6] + 1 >= self.frames_per_segment:
                             label = line[9]
-                            data.append((os.path.join(line[1], line[2]), line[6], line[7], label))
+                            data.append(
+                                (
+                                    os.path.join(line[1], line[2]),
+                                    line[6],
+                                    line[7],
+                                    label,
+                                )
+                            )
                             i = i + 1
         print("Number of {:5} action segments: {}".format(self.dataset, i))
         return data

--- a/kale/loaddata/videos.py
+++ b/kale/loaddata/videos.py
@@ -34,7 +34,9 @@ class VideoRecord(object):
 
     @property
     def num_frames(self):
-        return self.end_frame - self.start_frame + 1  # +1 because end frame is inclusive
+        return (
+            self.end_frame - self.start_frame + 1
+        )  # +1 because end frame is inclusive
 
     @property
     def start_frame(self):
@@ -119,16 +121,18 @@ class VideoFrameDataset(torch.utils.data.Dataset):
 
     """
 
-    def __init__(self,
-                 root_path: str,
-                 annotationfile_path: str,
-                 image_modality: str = 'rgb',
-                 num_segments: int = 3,
-                 frames_per_segment: int = 1,
-                 imagefile_template: str = 'img_{:05d}.jpg',
-                 transform=None,
-                 random_shift: bool = True,
-                 test_mode: bool = False):
+    def __init__(
+        self,
+        root_path: str,
+        annotationfile_path: str,
+        image_modality: str = "rgb",
+        num_segments: int = 3,
+        frames_per_segment: int = 1,
+        imagefile_template: str = "img_{:05d}.jpg",
+        transform=None,
+        random_shift: bool = True,
+        test_mode: bool = False,
+    ):
         super(VideoFrameDataset, self).__init__()
 
         self.root_path = root_path
@@ -140,22 +144,33 @@ class VideoFrameDataset(torch.utils.data.Dataset):
         self.transform = transform
         self.random_shift = random_shift
         self.test_mode = test_mode
-        if self.image_modality == 'flow' and self.frames_per_segment > 1:
+        if self.image_modality == "flow" and self.frames_per_segment > 1:
             self.frames_per_segment //= 2
 
         self._parse_list()
 
     def _load_image(self, directory, idx):
-        if self.image_modality == 'rgb':
-            return [Image.open(os.path.join(directory, self.imagefile_template.format(idx))).convert('RGB')]
-        elif self.image_modality == 'flow':
+        if self.image_modality == "rgb":
+            return [
+                Image.open(
+                    os.path.join(directory, self.imagefile_template.format(idx))
+                ).convert("RGB")
+            ]
+        elif self.image_modality == "flow":
             idx = math.ceil(idx / 2) - 1 if idx > 2 else 1
-            x_img = Image.open(os.path.join(directory, self.imagefile_template.format('x', idx))).convert('L')
-            y_img = Image.open(os.path.join(directory, self.imagefile_template.format('y', idx))).convert('L')
+            x_img = Image.open(
+                os.path.join(directory, self.imagefile_template.format("x", idx))
+            ).convert("L")
+            y_img = Image.open(
+                os.path.join(directory, self.imagefile_template.format("y", idx))
+            ).convert("L")
             return [x_img, y_img]
 
     def _parse_list(self):
-        self.video_list = [VideoRecord(x.strip().split(' '), self.root_path) for x in open(self.annotationfile_path)]
+        self.video_list = [
+            VideoRecord(x.strip().split(" "), self.root_path)
+            for x in open(self.annotationfile_path)
+        ]
 
     def _get_random_indices(self, record):
         """
@@ -168,11 +183,19 @@ class VideoFrameDataset(torch.utils.data.Dataset):
         """
 
         if record.num_frames > self.num_segments * self.frames_per_segment - 1:
-            segment_duration = (record.num_frames - self.frames_per_segment + 1) // self.num_segments
-            offsets = np.multiply(list(range(self.num_segments)), segment_duration) + np.random.randint(
-                segment_duration, size=self.num_segments)
+            segment_duration = (
+                record.num_frames - self.frames_per_segment + 1
+            ) // self.num_segments
+            offsets = np.multiply(
+                list(range(self.num_segments)), segment_duration
+            ) + np.random.randint(segment_duration, size=self.num_segments)
         else:
-            offsets = np.sort(random.sample(range(record.num_frames - self.frames_per_segment), self.num_segments))
+            offsets = np.sort(
+                random.sample(
+                    range(record.num_frames - self.frames_per_segment),
+                    self.num_segments,
+                )
+            )
         return offsets
 
     def _get_symmetric_indices(self, record):
@@ -185,9 +208,13 @@ class VideoFrameDataset(torch.utils.data.Dataset):
             List of indices of segment start frames.
         """
 
-        tick = (record.num_frames - self.frames_per_segment + 1) / float(self.num_segments)
+        tick = (record.num_frames - self.frames_per_segment + 1) / float(
+            self.num_segments
+        )
 
-        offsets = np.array([int(tick / 2.0 + tick * x) for x in range(self.num_segments)])
+        offsets = np.array(
+            [int(tick / 2.0 + tick * x) for x in range(self.num_segments)]
+        )
 
         return offsets
 
@@ -207,26 +234,48 @@ class VideoFrameDataset(torch.utils.data.Dataset):
         record = self.video_list[index]
 
         if record.num_frames < self.frames_per_segment:
-            raise RuntimeError('Path:{}, start:{}, end:{}.\n Video_length is {}, which should be larger than '
-                               'frame_per_segment {}.'.format(record.path, record.start_frame, record.end_frame,
-                                                              record.num_frames, self.frames_per_segment))
+            raise RuntimeError(
+                "Path:{}, start:{}, end:{}.\n Video_length is {}, which should be larger than "
+                "frame_per_segment {}.".format(
+                    record.path,
+                    record.start_frame,
+                    record.end_frame,
+                    record.num_frames,
+                    self.frames_per_segment,
+                )
+            )
         elif record.num_frames < self.num_segments:
-            raise RuntimeError('Path:{}, start:{}, end:{}.\n Video_length is {}, which should be larger than '
-                               'num_segments {}.'.format(record.path, record.start_frame, record.end_frame,
-                                                         record.num_frames, self.num_segments))
+            raise RuntimeError(
+                "Path:{}, start:{}, end:{}.\n Video_length is {}, which should be larger than "
+                "num_segments {}.".format(
+                    record.path,
+                    record.start_frame,
+                    record.end_frame,
+                    record.num_frames,
+                    self.num_segments,
+                )
+            )
         elif record.num_frames < self.num_segments * self.frames_per_segment:
             if self.num_segments > record.num_frames - self.frames_per_segment + 1:
-                raise RuntimeError('Path:{}, start:{}, end:{}.\n Video_length is {}, num_segments is {} and '
-                                   'frame_per_segment is {}. Please make num_segments<frame_length-frames_per_segment '
-                                   'to avoid getting too many same segments.'.format(record.path, record.start_frame,
-                                                                                     record.end_frame,
-                                                                                     record.num_frames,
-                                                                                     self.num_segments,
-                                                                                     self.frames_per_segment))
+                raise RuntimeError(
+                    "Path:{}, start:{}, end:{}.\n Video_length is {}, num_segments is {} and "
+                    "frame_per_segment is {}. Please make num_segments<frame_length-frames_per_segment "
+                    "to avoid getting too many same segments.".format(
+                        record.path,
+                        record.start_frame,
+                        record.end_frame,
+                        record.num_frames,
+                        self.num_segments,
+                        self.frames_per_segment,
+                    )
+                )
 
         if not self.test_mode:
-            segment_indices = self._get_random_indices(record) if self.random_shift else self._get_symmetric_indices(
-                record)
+            segment_indices = (
+                self._get_random_indices(record)
+                if self.random_shift
+                else self._get_symmetric_indices(record)
+            )
         else:
             segment_indices = self._get_symmetric_indices(record)
 

--- a/kale/pipeline/domain_adapter.py
+++ b/kale/pipeline/domain_adapter.py
@@ -18,12 +18,12 @@ from pytorch_memlab import profile
 
 class ReverseLayerF(Function):
     """The gradient reversal layer (GRL)
-    
+
     This is defined in the DANN paper http://jmlr.org/papers/volume17/15-239/15-239.pdf
 
     Forward pass: identity transformation.
     Backward propagation: flip the sign of the gradient.
-    
+
     From https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/models/layers.py
     """
 
@@ -48,8 +48,7 @@ def set_requires_grad(model, requires_grad=True):
 
 
 def get_aggregated_metrics(metric_name_list, metric_outputs):
-    """Get a dictionary of the mean metric values (to log) from metric names and their values
-    """
+    """Get a dictionary of the mean metric values (to log) from metric names and their values"""
     metric_dict = {}
     for metric_name in metric_name_list:
         metric_dim = len(metric_outputs[0][metric_name].shape)
@@ -64,8 +63,7 @@ def get_aggregated_metrics(metric_name_list, metric_outputs):
 
 
 def get_aggregated_metrics_from_dict(input_metric_dict):
-    """Get a dictionary of the mean metric values (to log) from a dictionary of metric values
-    """
+    """Get a dictionary of the mean metric values (to log) from a dictionary of metric values"""
     metric_dict = {}
     for metric_name, metric_value in input_metric_dict.items():
         metric_dim = len(metric_value.shape)
@@ -78,8 +76,7 @@ def get_aggregated_metrics_from_dict(input_metric_dict):
 
 # multi-GPUs: mandatory to convert float values into tensors
 def get_metrics_from_parameter_dict(parameter_dict, device):
-    """Get a key-value pair from the hyperparameter dictionary
-    """
+    """Get a key-value pair from the hyperparameter dictionary"""
     return {k: torch.tensor(v, device=device) for k, v in parameter_dict.items()}
 
 
@@ -117,10 +114,9 @@ class Method(Enum):
 
 
 def create_mmd_based(
-        method: Method, dataset, feature_extractor, task_classifier, **train_params
+    method: Method, dataset, feature_extractor, task_classifier, **train_params
 ):
-    """MMD-based deep learning methods for domain adaptation: DAN and JAN
-    """
+    """MMD-based deep learning methods for domain adaptation: DAN and JAN"""
     if not method.is_mmd_method():
         raise ValueError(f"Unsupported MMD method: {method}")
     if method is Method.DAN:
@@ -140,10 +136,9 @@ def create_mmd_based(
 
 
 def create_dann_like(
-        method: Method, dataset, feature_extractor, task_classifier, critic, **train_params
+    method: Method, dataset, feature_extractor, task_classifier, critic, **train_params
 ):
-    """DANN-based deep learning methods for domain adaptation: DANN, CDAN, CDAN+E
-    """
+    """DANN-based deep learning methods for domain adaptation: DANN, CDAN, CDAN+E"""
     if dataset.is_semi_supervised():
         return create_fewshot_trainer(
             method, dataset, feature_extractor, task_classifier, critic, **train_params
@@ -193,10 +188,9 @@ def create_dann_like(
 
 
 def create_fewshot_trainer(
-        method: Method, dataset, feature_extractor, task_classifier, critic, **train_params
+    method: Method, dataset, feature_extractor, task_classifier, critic, **train_params
 ):
-    """DANN-based few-shot deep learning methods for domain adaptation: FSDANN, MME
-    """
+    """DANN-based few-shot deep learning methods for domain adaptation: FSDANN, MME"""
     if not dataset.is_semi_supervised():
         raise ValueError(f"Dataset must be semi-supervised for few-shot methods.")
 
@@ -217,19 +211,19 @@ def create_fewshot_trainer(
 
 class BaseAdaptTrainer(pl.LightningModule):
     def __init__(
-            self,
-            dataset,
-            feature_extractor,
-            task_classifier,
-            method=None,
-            lambda_init=1.0,
-            adapt_lambda=True,
-            adapt_lr=True,
-            nb_init_epochs=10,
-            nb_adapt_epochs=50,
-            batch_size=32,
-            init_lr=1e-3,
-            optimizer=None,
+        self,
+        dataset,
+        feature_extractor,
+        task_classifier,
+        method=None,
+        lambda_init=1.0,
+        adapt_lambda=True,
+        adapt_lr=True,
+        nb_init_epochs=10,
+        nb_adapt_epochs=50,
+        batch_size=32,
+        init_lr=1e-3,
+        optimizer=None,
     ):
         r"""Base class for all domain adaptation architectures.
 
@@ -240,7 +234,7 @@ class BaseAdaptTrainer(pl.LightningModule):
          - a `compute_loss` function that returns the task loss :math:`\mathcal{L}_c` and adaptation loss :math:`\mathcal{L}_a`, as well as
            a dictionary for summary statistics and other metrics you may want to have access to.
 
-        The default training step uses only the task loss :math:`\mathcal{L}_c` during warmup, 
+        The default training step uses only the task loss :math:`\mathcal{L}_c` during warmup,
         then uses the loss defined as:
 
         :math:`\mathcal{L} = \mathcal{L}_c + \lambda \mathcal{L}_a`,
@@ -260,7 +254,7 @@ class BaseAdaptTrainer(pl.LightningModule):
             method (Method, optional): the method implemented by the class. Defaults to None.
                 Mostly useful when several methods may be implemented using the same class.
             lambda_init (float, optional): Weight attributed to the adaptation part of the loss. Defaults to 1.0.
-            adapt_lambda (bool, optional): Whether to make lambda grow from 0 to 1 following the schedule from 
+            adapt_lambda (bool, optional): Whether to make lambda grow from 0 to 1 following the schedule from
                 the DANN paper. Defaults to True.
             adapt_lr (bool, optional): Whether to use the schedule for the learning rate as defined
                 in the DANN paper. Defaults to True.
@@ -303,7 +297,7 @@ class BaseAdaptTrainer(pl.LightningModule):
         if self.current_epoch >= self._init_epochs:
             delta_epoch = self.current_epoch - self._init_epochs
             p = (batch_id + delta_epoch * self._nb_training_batches) / (
-                    self._non_init_epochs * self._nb_training_batches
+                self._non_init_epochs * self._nb_training_batches
             )
             self._grow_fact = 2.0 / (1.0 + np.exp(-10 * p)) - 1
 
@@ -330,7 +324,7 @@ class BaseAdaptTrainer(pl.LightningModule):
 
         Args:
             batch (tuple): batches returned by the MultiDomainLoader.
-            split_name (str, optional): learning stage (one of ["T", "V", "Te"]). 
+            split_name (str, optional): learning stage (one of ["T", "V", "Te"]).
                 Defaults to "V" for validation. "T" is for training and "Te" for test.
                 This is currently used only for naming the metrics used for logging.
 
@@ -444,17 +438,24 @@ class BaseAdaptTrainer(pl.LightningModule):
     def _configure_optimizer(self, parameters):
         if self._optimizer_params is None:
             optimizer = torch.optim.Adam(
-                parameters, lr=self._init_lr, betas=(0.8, 0.999), weight_decay=1e-5,
+                parameters,
+                lr=self._init_lr,
+                betas=(0.8, 0.999),
+                weight_decay=1e-5,
             )
             return [optimizer]
         if self._optimizer_params["type"] == "Adam":
             optimizer = torch.optim.Adam(
-                parameters, lr=self._init_lr, **self._optimizer_params["optim_params"],
+                parameters,
+                lr=self._init_lr,
+                **self._optimizer_params["optim_params"],
             )
             return [optimizer]
         if self._optimizer_params["type"] == "SGD":
             optimizer = torch.optim.SGD(
-                parameters, lr=self._init_lr, **self._optimizer_params["optim_params"],
+                parameters,
+                lr=self._init_lr,
+                **self._optimizer_params["optim_params"],
             )
 
             if self._adapt_lr:
@@ -490,19 +491,18 @@ class BaseAdaptTrainer(pl.LightningModule):
 
 class BaseDANNLike(BaseAdaptTrainer):
     def __init__(
-            self,
-            dataset,
-            feature_extractor,
-            task_classifier,
-            critic,
-            alpha=1.0,
-            entropy_reg=0.0,  # not used
-            adapt_reg=True,  # not used
-            batch_reweighting=False,  # not used
-            **base_params,
+        self,
+        dataset,
+        feature_extractor,
+        task_classifier,
+        critic,
+        alpha=1.0,
+        entropy_reg=0.0,  # not used
+        adapt_reg=True,  # not used
+        batch_reweighting=False,  # not used
+        **base_params,
     ):
-        """Common API for DANN-based methods: DANN, CDAN, CDAN+E, WDGRL, MME, FSDANN
-        """
+        """Common API for DANN-based methods: DANN, CDAN, CDAN+E, WDGRL, MME, FSDANN"""
 
         super().__init__(dataset, feature_extractor, task_classifier, **base_params)
 
@@ -601,13 +601,13 @@ class DANNtrainer(BaseDANNLike):
     """
 
     def __init__(
-            self,
-            dataset,
-            feature_extractor,
-            task_classifier,
-            critic,
-            method=None,
-            **base_params,
+        self,
+        dataset,
+        feature_extractor,
+        task_classifier,
+        critic,
+        method=None,
+        **base_params,
     ):
         super().__init__(
             dataset, feature_extractor, task_classifier, critic, **base_params
@@ -633,20 +633,20 @@ class DANNtrainer(BaseDANNLike):
 class CDANtrainer(BaseDANNLike):
     """
     Implements CDAN: Long, Mingsheng, et al. "Conditional adversarial domain adaptation."
-    Advances in Neural Information Processing Systems. 2018. 
+    Advances in Neural Information Processing Systems. 2018.
     https://papers.nips.cc/paper/7436-conditional-adversarial-domain-adaptation.pdf
     """
 
     def __init__(
-            self,
-            dataset,
-            feature_extractor,
-            task_classifier,
-            critic,
-            use_entropy=False,
-            use_random=False,
-            random_dim=1024,
-            **base_params,
+        self,
+        dataset,
+        feature_extractor,
+        task_classifier,
+        critic,
+        use_entropy=False,
+        use_random=False,
+        random_dim=1024,
+        **base_params,
     ):
         super().__init__(
             dataset, feature_extractor, task_classifier, critic, **base_params
@@ -737,10 +737,10 @@ class CDANtrainer(BaseDANNLike):
 
 class WDGRLtrainer(BaseDANNLike):
     """
-    Implements WDGRL as described in 
-    Shen, Jian, et al. 
+    Implements WDGRL as described in
+    Shen, Jian, et al.
     "Wasserstein distance guided representation learning for domain adaptation."
-    Thirty-Second AAAI Conference on Artificial Intelligence. 2018. 
+    Thirty-Second AAAI Conference on Artificial Intelligence. 2018.
     https://arxiv.org/pdf/1707.01217.pdf
 
     This class also implements the asymmetric ($\beta$) variant described in:
@@ -751,15 +751,15 @@ class WDGRLtrainer(BaseDANNLike):
     """
 
     def __init__(
-            self,
-            dataset,
-            feature_extractor,
-            task_classifier,
-            critic,
-            k_critic=5,
-            gamma=10,
-            beta_ratio=0,
-            **base_params,
+        self,
+        dataset,
+        feature_extractor,
+        task_classifier,
+        critic,
+        k_critic=5,
+        gamma=10,
+        beta_ratio=0,
+        **base_params,
     ):
         """
         parameters:
@@ -828,7 +828,7 @@ class WDGRLtrainer(BaseDANNLike):
             critic_s = self.domain_classifier(h_s)
             critic_t = self.domain_classifier(h_t)
             wasserstein_distance = (
-                    critic_s.mean() - (1 + self._beta_ratio) * critic_t.mean()
+                critic_s.mean() - (1 + self._beta_ratio) * critic_t.mean()
             )
 
             critic_cost = -wasserstein_distance + self._gamma * gp
@@ -898,10 +898,10 @@ class WDGRLtrainer(BaseDANNLike):
 
 class WDGRLtrainerMod(WDGRLtrainer):
     """
-    Implements a modified version WDGRL as described in 
-    Shen, Jian, et al. 
+    Implements a modified version WDGRL as described in
+    Shen, Jian, et al.
     "Wasserstein distance guided representation learning for domain adaptation."
-    Thirty-Second AAAI Conference on Artificial Intelligence. 2018. 
+    Thirty-Second AAAI Conference on Artificial Intelligence. 2018.
     https://arxiv.org/pdf/1707.01217.pdf
 
     This class also implements the asymmetric ($\beta$) variant described in:
@@ -912,15 +912,15 @@ class WDGRLtrainerMod(WDGRLtrainer):
     """
 
     def __init__(
-            self,
-            dataset,
-            feature_extractor,
-            task_classifier,
-            critic,
-            k_critic=5,
-            gamma=10,
-            beta_ratio=0,
-            **base_params,
+        self,
+        dataset,
+        feature_extractor,
+        task_classifier,
+        critic,
+        k_critic=5,
+        gamma=10,
+        beta_ratio=0,
+        **base_params,
     ):
         """
         parameters:
@@ -945,7 +945,7 @@ class WDGRLtrainerMod(WDGRLtrainer):
         critic_s = self.domain_classifier(h_s)
         critic_t = self.domain_classifier(h_t)
         wasserstein_distance = (
-                critic_s.mean() - (1 + self._beta_ratio) * critic_t.mean()
+            critic_s.mean() - (1 + self._beta_ratio) * critic_t.mean()
         )
 
         critic_cost = -wasserstein_distance + self._gamma * gp
@@ -991,7 +991,7 @@ class WDGRLtrainerMod(WDGRLtrainer):
         }
 
     def optimizer_step(
-            self, current_epoch, batch_nb, optimizer, optimizer_i, second_order_closure=None
+        self, current_epoch, batch_nb, optimizer, optimizer_i, second_order_closure=None
     ):
         if current_epoch < self._init_epochs:
             # do not update critic
@@ -1033,12 +1033,12 @@ class FewShotDANNtrainer(BaseDANNLike):
     MME: immplements Saito, Kuniaki, et al.
     "Semi-supervised domain adaptation via minimax entropy."
     Proceedings of the IEEE International Conference on Computer Vision. 2019
-    https://arxiv.org/pdf/1904.06487.pdf 
-    
+    https://arxiv.org/pdf/1904.06487.pdf
+
     """
 
     def __init__(
-            self, dataset, feature_extractor, task_classifier, critic, method, **base_params
+        self, dataset, feature_extractor, task_classifier, critic, method, **base_params
     ):
         super().__init__(
             dataset, feature_extractor, task_classifier, critic, **base_params
@@ -1076,7 +1076,7 @@ class FewShotDANNtrainer(BaseDANNLike):
             task_loss = loss_cls_s
         else:
             task_loss = (batch_size * loss_cls_s + len(y_tl) * loss_cls_tl) / (
-                    batch_size + len(y_tl)
+                batch_size + len(y_tl)
             )
 
         loss_dmn_src, dok_src = losses.cross_entropy_logits(
@@ -1105,16 +1105,15 @@ class FewShotDANNtrainer(BaseDANNLike):
 
 class BaseMMDLike(BaseAdaptTrainer):
     def __init__(
-            self,
-            dataset,
-            feature_extractor,
-            task_classifier,
-            kernel_mul=2.0,
-            kernel_num=5,
-            **base_params,
+        self,
+        dataset,
+        feature_extractor,
+        task_classifier,
+        kernel_mul=2.0,
+        kernel_num=5,
+        **base_params,
     ):
-        """Common API for MME-based deep learning DA methods: DAN, JAN
-        """
+        """Common API for MME-based deep learning DA methods: DAN, JAN"""
 
         super().__init__(dataset, feature_extractor, task_classifier, **base_params)
 
@@ -1186,7 +1185,7 @@ class DANtrainer(BaseMMDLike):
     Long, Mingsheng, et al.
     "Learning Transferable Features with Deep Adaptation Networks."
     International Conference on Machine Learning. 2015.
-    http://proceedings.mlr.press/v37/long15.pdf 
+    http://proceedings.mlr.press/v37/long15.pdf
     code based on https://github.com/thuml/Xlearn.
     """
 
@@ -1196,7 +1195,10 @@ class DANtrainer(BaseMMDLike):
     def _compute_mmd(self, phi_s, phi_t, y_hat, y_t_hat):
         batch_size = int(phi_s.size()[0])
         kernels = losses.gaussian_kernel(
-            phi_s, phi_t, kernel_mul=self._kernel_mul, kernel_num=self._kernel_num,
+            phi_s,
+            phi_t,
+            kernel_mul=self._kernel_mul,
+            kernel_num=self._kernel_num,
         )
         return losses.compute_mmd_loss(kernels, batch_size)
 
@@ -1204,7 +1206,7 @@ class DANtrainer(BaseMMDLike):
 class JANtrainer(BaseMMDLike):
     """
     This is an implementation of JAN
-    Long, Mingsheng, et al. 
+    Long, Mingsheng, et al.
     "Deep transfer learning with joint adaptation networks."
     International Conference on Machine Learning, 2017.
     https://arxiv.org/pdf/1605.06636.pdf
@@ -1212,13 +1214,13 @@ class JANtrainer(BaseMMDLike):
     """
 
     def __init__(
-            self,
-            dataset,
-            feature_extractor,
-            task_classifier,
-            kernel_mul=(2.0, 2.0),
-            kernel_num=(5, 1),
-            **base_params,
+        self,
+        dataset,
+        feature_extractor,
+        task_classifier,
+        kernel_mul=(2.0, 2.0),
+        kernel_num=(5, 1),
+        **base_params,
     ):
         super().__init__(
             dataset,
@@ -1237,7 +1239,7 @@ class JANtrainer(BaseMMDLike):
 
         joint_kernels = None
         for source, target, k_mul, k_num, sigma in zip(
-                source_list, target_list, self._kernel_mul, self._kernel_num, [None, 1.68]
+            source_list, target_list, self._kernel_mul, self._kernel_num, [None, 1.68]
         ):
             kernels = losses.gaussian_kernel(
                 source, target, kernel_mul=k_mul, kernel_num=k_num, fix_sigma=sigma

--- a/kale/pipeline/domain_adapter.py
+++ b/kale/pipeline/domain_adapter.py
@@ -1,6 +1,6 @@
 """Domain adaptation systems (pipelines) with three types of architectures
 
-This module takes individual modules as input and organises them into an architecture. This is taken directly from 
+This module takes individual modules as input and organises them into an architecture. This is taken directly from
 https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/models/architectures.py with minor changes.
 
 This module uses `PyTorch Lightning <https://github.com/PyTorchLightning/pytorch-lightning>`_ to standardize the flow.
@@ -13,7 +13,7 @@ from torch.autograd import Function
 import kale.predict.losses as losses
 
 import pytorch_lightning as pl
-from pytorch_memlab import profile
+# from pytorch_memlab import profile
 
 
 class ReverseLayerF(Function):
@@ -192,7 +192,7 @@ def create_fewshot_trainer(
 ):
     """DANN-based few-shot deep learning methods for domain adaptation: FSDANN, MME"""
     if not dataset.is_semi_supervised():
-        raise ValueError(f"Dataset must be semi-supervised for few-shot methods.")
+        raise ValueError("Dataset must be semi-supervised for few-shot methods.")
 
     if method.is_fewshot_method():
         alpha = 0 if method is Method.Source else 1
@@ -231,8 +231,9 @@ class BaseAdaptTrainer(pl.LightningModule):
         for domain adaptation.
         If you inherit from this class, you will have to implement only:
          - a forward pass
-         - a `compute_loss` function that returns the task loss :math:`\mathcal{L}_c` and adaptation loss :math:`\mathcal{L}_a`, as well as
-           a dictionary for summary statistics and other metrics you may want to have access to.
+         - a `compute_loss` function that returns the task loss :math:`\mathcal{L}_c` and adaptation loss
+          :math:`\mathcal{L}_a`, as well as a dictionary for summary statistics and other metrics you may
+          want to have access to.
 
         The default training step uses only the task loss :math:`\mathcal{L}_c` during warmup,
         then uses the loss defined as:
@@ -247,8 +248,8 @@ class BaseAdaptTrainer(pl.LightningModule):
         Args:
             dataset (kale.loaddata.multi_domain): the multi-domain datasets to be used
                 for train, validation, and tests.
-            feature_extractor (torch.nn.Module): the feature extractor network (mapping inputs :math:`x\in\mathcal{X}` to
-                a latent space :math:`\mathcal{Z}`,)
+            feature_extractor (torch.nn.Module): the feature extractor network (mapping inputs :math:`x\in\mathcal{X}`
+            to a latent space :math:`\mathcal{Z}`,)
             task_classifier (torch.nn.Module): the task classifier network that learns to predict labels
                 :math:`y \in \mathcal{Y}` from latent vectors,
             method (Method, optional): the method implemented by the class. Defaults to None.
@@ -258,7 +259,7 @@ class BaseAdaptTrainer(pl.LightningModule):
                 the DANN paper. Defaults to True.
             adapt_lr (bool, optional): Whether to use the schedule for the learning rate as defined
                 in the DANN paper. Defaults to True.
-            nb_init_epochs (int, optional): Number of warmup epochs (during which lambda=0, training only on the source). Defaults to 10.
+            nb_init_epochs (int, optional): Number of warmup epochs (during which lambda=0, training only on the source). Defaults to 10. # noqa: E501
             nb_adapt_epochs (int, optional): Number of training epochs. Defaults to 50.
             batch_size (int, optional): Defaults to 32.
             init_lr (float, optional): Initial learning rate. Defaults to 1e-3.
@@ -346,7 +347,7 @@ class BaseAdaptTrainer(pl.LightningModule):
         Args:
             batch (tuple): the batch as returned by the MultiDomainLoader dataloader iterator:
                 2 tuples: (x_source, y_source), (x_target, y_target) in the unsupervised setting
-                3 tuples: (x_source, y_source), (x_target_labeled, y_target_labeled), (x_target_unlabeled, y_target_unlabeled) in the semi-supervised setting
+                3 tuples: (x_source, y_source), (x_target_labeled, y_target_labeled), (x_target_unlabeled, y_target_unlabeled) in the semi-supervised setting # noqa: E501
             batch_nb (int): id of the current batch.
 
         Returns:

--- a/kale/pipeline/video_transformer.py
+++ b/kale/pipeline/video_transformer.py
@@ -16,31 +16,31 @@ class VideoTransformer(pl.LightningModule):
     of each frame after unrolling their remaining spatial dimensions into a sequence.\n
     3. A Transformer-Encoder that is applied after concatenating each frame's sequence
     into one big sequence. \n\n
-    
-    So, first the VideoTransformer extracts per-frame features through a CNN, then 
+
+    So, first the VideoTransformer extracts per-frame features through a CNN, then
     per-frame contextualizes these features with self-attention, and finally globally
     contextualizes these features, as a whole, with self-attention.
 
     Note:
         This module is a video-to-sequence model where a custom head
         can be used ontop to customize this model for different types of tasks (or just
-        classification), in the same way BERT's output sequences can be used for 
+        classification), in the same way BERT's output sequences can be used for
         various tasks.
 
     Args:
         fram_per_vid: the number of frames each input video has. This must always
                       be the same during training and inference (required).
         cnntransformer: a feature extractor built from kale.embed.attention_cnn
-                        consisting of a cnn with a transformer-encoder stacked ontop 
+                        consisting of a cnn with a transformer-encoder stacked ontop
                         to process images (required).
-        cnntrans_out_shape: the shape that the cnntransformer will output in 
+        cnntrans_out_shape: the shape that the cnntransformer will output in
                             the format (seq_len, batch_size, channels) (required).
         nheads: number of attention heads in the `step 3` transformer-encoder (required).
         linformer_k: number of down projection dimensions of the `step 3`
-                     transformer-encoder. See `Linformer` https://arxiv.org/abs/2006.04768 
+                     transformer-encoder. See `Linformer` https://arxiv.org/abs/2006.04768
                      for more details (required).
         dim_feedforward: number of neurons in the intermediate dense layer of
-                         each `step 3` Transformer-Encoder feedforward block (required). 
+                         each `step 3` Transformer-Encoder feedforward block (required).
         num_layers: number of attention layers in the `step 3` Transformer-Encoder (required).
         dropout: dropout rate of the `step 3` Transformer-Encoder layers (default=0.1).
         activation: 'relu' or 'gelu' for the `step 3` Transformer-Encoder (default='relu).
@@ -54,7 +54,7 @@ class VideoTransformer(pl.LightningModule):
         >>> channels = 3
         >>> input_shape = (-1, fram_per_vid, channels, 16, 16)
         >>>
-        >>> cnn = nn.Sequential(nn.Conv2d(3, 32, kernel_size=3), 
+        >>> cnn = nn.Sequential(nn.Conv2d(3, 32, kernel_size=3),
         >>>                     nn.Conv2d(32, 64, kernel_size=3),
         >>>                     nn.MaxPool2d(2))
         >>> cnn_output_shape = (-1, 64, 8, 8)
@@ -72,28 +72,43 @@ class VideoTransformer(pl.LightningModule):
         >>> model(input).size() == (fram_per_vid*8*8, batch_size, 64)  # True
     """
 
-    def __init__(self, fram_per_vid: int, cnntransformer: ContextCNNGeneric, 
-                cnntrans_out_shape: Tuple[int, int, int],
-                nheads: int, linformer_k: int, dim_feedforward: int, num_layers: int,
-                dropout: float=0.1, activation: str='relu', pos_encoding: nn.Module=None):
+    def __init__(
+        self,
+        fram_per_vid: int,
+        cnntransformer: ContextCNNGeneric,
+        cnntrans_out_shape: Tuple[int, int, int],
+        nheads: int,
+        linformer_k: int,
+        dim_feedforward: int,
+        num_layers: int,
+        dropout: float = 0.1,
+        activation: str = "relu",
+        pos_encoding: nn.Module = None,
+    ):
         super(VideoTransformer, self).__init__()
 
         self.cnntransformer = cnntransformer
         self.fram_per_vid = fram_per_vid
-        
+
         out_channels = cnntrans_out_shape[2]
         final_seq_len = cnntrans_out_shape[0] * fram_per_vid
-        encoder_layer = LinearTransformerEncoderLayer(d_model=out_channels, 
-                                                      nhead=nheads, 
-                                                      seq_len=final_seq_len, 
-                                                      proj_k=linformer_k,
-                                                      dim_feedforward=dim_feedforward,
-                                                      dropout=dropout,
-                                                      activation=activation)
-        self.linformer = nn.TransformerEncoder(encoder_layer=encoder_layer, num_layers=num_layers)
+        encoder_layer = LinearTransformerEncoderLayer(
+            d_model=out_channels,
+            nhead=nheads,
+            seq_len=final_seq_len,
+            proj_k=linformer_k,
+            dim_feedforward=dim_feedforward,
+            dropout=dropout,
+            activation=activation,
+        )
+        self.linformer = nn.TransformerEncoder(
+            encoder_layer=encoder_layer, num_layers=num_layers
+        )
 
         if pos_encoding is None:
-            pos_encoding = PositionalEncoding(d_model=out_channels, max_len=final_seq_len)
+            pos_encoding = PositionalEncoding(
+                d_model=out_channels, max_len=final_seq_len
+            )
         self.pos_enc = pos_encoding
 
         # Copied from https://pytorch.org/docs/stable/_modules/torch/nn/modules/transformer.html#Transformer
@@ -107,10 +122,10 @@ class VideoTransformer(pl.LightningModule):
         each video and then concatenates the resulting sequence representations
         of each video's frames together into one long sequence per video
         and applies a linformer-encoder to further contextualize each video
-        sequence. 
+        sequence.
 
         Args:
-            x: a batch of videos with shape 
+            x: a batch of videos with shape
                (batch_size, fram_per_vid, channels, height, width)
 
         Output Shape:
@@ -129,14 +144,16 @@ class VideoTransformer(pl.LightningModule):
 
         seq_len = x.size(0)
         num_dim = x.size(2)
-        
+
         # put the Batch dimension in front
-        x = x.permute((1,0,2)) 
+        x = x.permute((1, 0, 2))
         # fold batch back into batch and frames
         x = x.view((batch_size, self.fram_per_vid, seq_len, num_dim))
-        x = torch.flatten(x.permute((1,2,0,3)), end_dim=1) # flatten frame and seq dimension
-                                                           # into one long seq
+        x = torch.flatten(
+            x.permute((1, 2, 0, 3)), end_dim=1
+        )  # flatten frame and seq dimension
+        # into one long seq
 
         x = self.pos_enc(x)
         x = self.linformer(x)
-        return x.permute(1,0,2) # put the batch dimension first
+        return x.permute(1, 0, 2)  # put the batch dimension first

--- a/kale/predict/class_domain_nets.py
+++ b/kale/predict/class_domain_nets.py
@@ -24,13 +24,13 @@ class SoftmaxNet(nn.Module):
     """
 
     def __init__(
-            self,
-            input_dim=15,
-            n_classes=2,
-            name="c",
-            hidden=(),
-            activation_fn=nn.ReLU,
-            **activation_args,
+        self,
+        input_dim=15,
+        n_classes=2,
+        name="c",
+        hidden=(),
+        activation_fn=nn.ReLU,
+        **activation_args,
     ):
 
         super(SoftmaxNet, self).__init__()

--- a/kale/predict/class_domain_nets.py
+++ b/kale/predict/class_domain_nets.py
@@ -1,14 +1,14 @@
 """Classification of data or domain
 
-Modules for typical classification tasks (into class labels) and 
+Modules for typical classification tasks (into class labels) and
 adversarial discrimination of source vs target domains, from
 https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/models/modules.py
 """
 
-import numpy as np
+# import numpy as np
 import torch.nn as nn
-import torch
-from torchvision import models
+# import torch
+# from torchvision import models
 
 
 # Previously FFSoftmaxClassifier

--- a/kale/predict/isonet.py
+++ b/kale/predict/isonet.py
@@ -1,5 +1,5 @@
-""" 
-The ISONet module, which is based on the ResNet module, 
+"""
+The ISONet module, which is based on the ResNet module,
 from https://github.com/HaozhiQi/ISONet/blob/master/isonet/models/isonet.py
 (based on https://github.com/facebookresearch/pycls/blob/master/pycls/models/resnet.py)
 """
@@ -142,7 +142,7 @@ class BottleneckTransform(nn.Module):
             kernel_size=1,
             stride=str1x1,
             padding=0,
-            bias=not self.has_bn and notself.use_srelu,
+            bias=not self.has_bn and not self.use_srelu,
         )
         if self.has_bn:
             self.a_bn = nn.BatchNorm2d(w_b)

--- a/kale/predict/losses.py
+++ b/kale/predict/losses.py
@@ -9,12 +9,12 @@ from torch.autograd import grad
 
 
 def cross_entropy_logits(linear_output, label, weights=None):
-    """Computes cross entropy with logits 
-    
+    """Computes cross entropy with logits
+
     Examples:
-        See DANN, WDGRL, and MMD trainers in kale.pipeline.domain_adapter  
-    """    
-    
+        See DANN, WDGRL, and MMD trainers in kale.pipeline.domain_adapter
+    """
+
     class_output = F.log_softmax(linear_output, dim=1)
     max_class = class_output.max(1)
     y_hat = max_class[1]  # get the index of the max log-probability
@@ -31,10 +31,10 @@ def cross_entropy_logits(linear_output, label, weights=None):
 
 def entropy_logits(linear_output):
     """Computes entropy logits in CDAN with entropy conditioning (CDAN+E)
-    
+
     Examples:
-        See CDANtrainer in kale.pipeline.domain_adapter  
-    """    
+        See CDANtrainer in kale.pipeline.domain_adapter
+    """
     p = F.softmax(linear_output, dim=1)
     loss_ent = -torch.sum(p * (torch.log(p + 1e-5)), dim=1)
     return loss_ent
@@ -42,20 +42,20 @@ def entropy_logits(linear_output):
 
 def entropy_logits_loss(linear_output):
     """Computes entropy logits loss in semi-supervised or few-shot domain adapatation
-    
+
     Examples:
-        See FewShotDANNtrainer in kale.pipeline.domain_adapter  
-    """    
+        See FewShotDANNtrainer in kale.pipeline.domain_adapter
+    """
     return torch.mean(entropy_logits(linear_output))
 
 
 def gradient_penalty(critic, h_s, h_t):
     """Computes gradient penelty in Wasserstein distance guided representation learning
-    
+
     Examples:
-        See WDGRLtrainer and WDGRLtrainerMod in kale.pipeline.domain_adapter  
+        See WDGRLtrainer and WDGRLtrainerMod in kale.pipeline.domain_adapter
     """
-    
+
     alpha = torch.rand(h_s.size(0), 1)
     alpha = alpha.expand(h_s.size()).type_as(h_s)
     try:

--- a/kale/predict/losses.py
+++ b/kale/predict/losses.py
@@ -1,4 +1,4 @@
-"""Commonly used losses, from domain adaptation package 
+"""Commonly used losses, from domain adaptation package
 https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/models/losses.py
 """
 
@@ -58,24 +58,24 @@ def gradient_penalty(critic, h_s, h_t):
 
     alpha = torch.rand(h_s.size(0), 1)
     alpha = alpha.expand(h_s.size()).type_as(h_s)
-    try:
-        differences = h_t - h_s
+    # try:
+    differences = h_t - h_s
 
-        interpolates = h_s + (alpha * differences)
-        interpolates = torch.cat((interpolates, h_s, h_t), dim=0).requires_grad_()
+    interpolates = h_s + (alpha * differences)
+    interpolates = torch.cat((interpolates, h_s, h_t), dim=0).requires_grad_()
 
-        preds = critic(interpolates)
-        gradients = grad(
-            preds,
-            interpolates,
-            grad_outputs=torch.ones_like(preds),
-            retain_graph=True,
-            create_graph=True,
-        )[0]
-        gradient_norm = gradients.norm(2, dim=1)
-        gradient_penalty = ((gradient_norm - 1) ** 2).mean()
-    except:
-        gradient_penalty = 0
+    preds = critic(interpolates)
+    gradients = grad(
+        preds,
+        interpolates,
+        grad_outputs=torch.ones_like(preds),
+        retain_graph=True,
+        create_graph=True,
+    )[0]
+    gradient_norm = gradients.norm(2, dim=1)
+    gradient_penalty = ((gradient_norm - 1) ** 2).mean()
+    # except:
+    # gradient_penalty = 0
 
     return gradient_penalty
 

--- a/kale/prepdata/image_transform.py
+++ b/kale/prepdata/image_transform.py
@@ -81,7 +81,9 @@ def get_transform(kind, augment=False):
             [
                 transform_aug,
                 transforms.ToTensor(),
-                transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010)),
+                transforms.Normalize(
+                    (0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010)
+                ),
             ]
         )
     elif kind == "office":
@@ -90,15 +92,11 @@ def get_transform(kind, augment=False):
                 [
                     transforms.Resize(256),
                     transforms.RandomResizedCrop(224),
-                    transforms.RandomHorizontalFlip()
+                    transforms.RandomHorizontalFlip(),
                 ]
             )
         else:
-            transform_aug = transforms.Compose(
-                [
-                    transforms.Resize(256)
-                ]
-            )
+            transform_aug = transforms.Compose([transforms.Resize(256)])
         transform = transforms.Compose(
             [
                 transform_aug,

--- a/kale/prepdata/image_transform.py
+++ b/kale/prepdata/image_transform.py
@@ -12,7 +12,7 @@ def get_transform(kind, augment=False):
 
     Args:
         kind ([type]): the dataset (transformation) name
-        augment (bool, optional): whether to do data augmentation (random crop and flipping). Defaults to False. (Not implemented for digits yet.)
+        augment (bool, optional): whether to do data augmentation (random crop and flipping). Defaults to False. (Not implemented for digits yet.) # noqa: E501
 
     """
     if kind == "mnist32":

--- a/kale/prepdata/prep_cmr.py
+++ b/kale/prepdata/prep_cmr.py
@@ -11,7 +11,7 @@ from skimage import exposure, transform
 def regMRI(data, reg_df, reg_id=1):
     n_sample = data.shape[-1]
     if n_sample != reg_df.shape[0]:
-        print('Error, registration and data not match. Please check')
+        print("Error, registration and data not match. Please check")
         sys.exit()
     n_landmark = int((reg_df.shape[1] - 1) / 2)
     # reg_target = data[..., 0, reg_id]
@@ -26,9 +26,9 @@ def regMRI(data, reg_df, reg_id=1):
             _src = reg_df.iloc[i, 2:].values
             _src = _src.reshape((n_landmark, 2))
             idx_valid = np.isnan(_src[:, 0])
-            tform = transform.estimate_transform(ttype='similarity',
-                                                 src=_src[~idx_valid, :],
-                                                 dst=_dst[~idx_valid, :])
+            tform = transform.estimate_transform(
+                ttype="similarity", src=_src[~idx_valid, :], dst=_dst[~idx_valid, :]
+            )
             # forward transform used here, inverse transform used for warp
             src_tform = tform(_src[~idx_valid, :])
             dist = np.linalg.norm(src_tform - _dst[~idx_valid, :], axis=1)
@@ -36,8 +36,9 @@ def regMRI(data, reg_df, reg_id=1):
 
             for j in range(data[..., i].shape[-1]):
                 src_img = data[..., j, i].copy()
-                warped = transform.warp(src_img, inverse_map=tform.inverse,
-                                        preserve_range=True)
+                warped = transform.warp(
+                    src_img, inverse_map=tform.inverse, preserve_range=True
+                )
                 data[..., j, i] = warped
 
     return data, max_dist
@@ -46,7 +47,7 @@ def regMRI(data, reg_df, reg_id=1):
 def rescale_cmr(data, scale=16):
     n_sub = data.shape[-1]
     n_time = data.shape[-2]
-    scale_ = 1/scale
+    scale_ = 1 / scale
     data_all = []
     for i in range(n_sub):
         data_sub = []
@@ -54,9 +55,9 @@ def rescale_cmr(data, scale=16):
             img = data[:, :, j, i]
             img_ = transform.rescale(img, scale_, preserve_range=True)
             # preserve_range should be true otherwise the output will be normalised values
-            data_sub.append(img_.reshape(img_.shape+(1,)))
+            data_sub.append(img_.reshape(img_.shape + (1,)))
         data_sub = np.concatenate(data_sub, axis=-1)
-        data_all.append(data_sub.reshape(data_sub.shape+(1,)))
+        data_all.append(data_sub.reshape(data_sub.shape + (1,)))
     data_all = np.concatenate(data_all, axis=-1)
 
     return data_all
@@ -89,7 +90,7 @@ def preproc(data, mask, level=1):
 
 
 def scale_cmr_mask(mask, scale):
-    mask = transform.rescale(mask.astype('bool_'), 1/scale, anti_aliasing=False)
+    mask = transform.rescale(mask.astype("bool_"), 1 / scale, anti_aliasing=False)
     # change mask dtype to bool to ensure the output values are 0 and 1
     # anti_aliasing False otherwise the output might be all 0s
     # the following three lines should be equivalent
@@ -102,19 +103,23 @@ def scale_cmr_mask(mask, scale):
 
 
 def cmr_proc(basedir, db, scale, mask_id, level, save_data=True, return_data=False):
-    print('Preprocssing Data Scale: 1/%s, Mask ID: %s, Processing level: %s'
-          % (scale, mask_id, level))
-    datadir = os.path.join(basedir, 'DB%s/NoPrs%sDB%s.npy' % (db, scale, db))
-    maskdir = os.path.join(basedir, 'Prep/AllMasks.mat')
+    print(
+        "Preprocssing Data Scale: 1/%s, Mask ID: %s, Processing level: %s"
+        % (scale, mask_id, level)
+    )
+    datadir = os.path.join(basedir, "DB%s/NoPrs%sDB%s.npy" % (db, scale, db))
+    maskdir = os.path.join(basedir, "Prep/AllMasks.mat")
     data = np.load(datadir)
-    masks = loadmat(maskdir)['masks']
-    mask = masks[mask_id-1, db-1]
+    masks = loadmat(maskdir)["masks"]
+    mask = masks[mask_id - 1, db - 1]
     mask = scale_cmr_mask(mask, scale)
     data_proc = preproc(data, mask, level)
 
     if save_data:
-        out_path = os.path.join(basedir, 'DB%s/PrepData/PrS%sM%sL%sDB%s.npy' 
-                                % (db, scale, mask_id, level, db))
+        out_path = os.path.join(
+            basedir,
+            "DB%s/PrepData/PrS%sM%sL%sDB%s.npy" % (db, scale, mask_id, level, db),
+        )
         np.save(out_path, data_proc)
     if return_data:
         return data_proc

--- a/kale/prepdata/tensor_reshape.py
+++ b/kale/prepdata/tensor_reshape.py
@@ -8,6 +8,7 @@ SPATIAL_WIDTH_DIMENSION = 3
 
 NUMBER_OF_DIMENSIONS = 4
 
+
 def spatial_to_seq(image_tensor: torch.Tensor):
     """
     Takes a torch tensor of shape (batch_size, channels, height, width)
@@ -27,13 +28,16 @@ def spatial_to_seq(image_tensor: torch.Tensor):
     spatial_height = original_size[SPATIAL_HEIGHT_DIMENSION]
     spatial_width = original_size[SPATIAL_WIDTH_DIMENSION]
 
-    permuted_tensor = image_tensor.permute(SPATIAL_HEIGHT_DIMENSION, \
-                                           SPATIAL_WIDTH_DIMENSION, \
-                                           SPATIAL_BATCH_DIMENSION, \
-                                           SPATIAL_CHANNEL_DIMENSION)
+    permuted_tensor = image_tensor.permute(
+        SPATIAL_HEIGHT_DIMENSION,
+        SPATIAL_WIDTH_DIMENSION,
+        SPATIAL_BATCH_DIMENSION,
+        SPATIAL_CHANNEL_DIMENSION,
+    )
 
-    sequence_tensor = permuted_tensor.view(spatial_height*spatial_width, \
-                                           batch_size, num_channels)
+    sequence_tensor = permuted_tensor.view(
+        spatial_height * spatial_width, batch_size, num_channels
+    )
 
     return sequence_tensor
 
@@ -45,7 +49,10 @@ SEQUENCE_FEATURE_DIMENSION = 2
 
 SEQUENCE_NUMBER_OF_DIMENSIONS = 3
 
-def seq_to_spatial(sequence_tensor: torch.Tensor, desired_height: int, desired_width: int):
+
+def seq_to_spatial(
+    sequence_tensor: torch.Tensor, desired_height: int, desired_width: int
+):
     """Takes a torch tensor of shape (sequence_length, batch_size, num_features)
     as used and outputted by Transformers and creates a view of shape
     (batch_size, num_features, height, width) as used and outputted by CNNs.
@@ -58,17 +65,18 @@ def seq_to_spatial(sequence_tensor: torch.Tensor, desired_height: int, desired_w
         desired_height: the height into which the sequence length should be rolled into (required).
         desired_width: the width into which the sequence length should be rolled into (required).
 
-    """ 
+    """
     original_size = sequence_tensor.size()
 
     batch_size = original_size[SEQUENCE_BATCH_DIMENSION]
     num_channels = original_size[SEQUENCE_FEATURE_DIMENSION]
 
-    permuted_tensor = sequence_tensor.permute(SEQUENCE_BATCH_DIMENSION, \
-                                              SEQUENCE_FEATURE_DIMENSION, \
-                                              SEQUENCE_LENGTH_DIMENSION)
+    permuted_tensor = sequence_tensor.permute(
+        SEQUENCE_BATCH_DIMENSION, SEQUENCE_FEATURE_DIMENSION, SEQUENCE_LENGTH_DIMENSION
+    )
 
-    spatial_tensor = permuted_tensor.view(batch_size, num_channels, \
-                                          desired_height, desired_width)
+    spatial_tensor = permuted_tensor.view(
+        batch_size, num_channels, desired_height, desired_width
+    )
 
     return spatial_tensor

--- a/kale/prepdata/video_transform.py
+++ b/kale/prepdata/video_transform.py
@@ -14,56 +14,68 @@ def get_transform(kind, modality):
 
     if kind in ["epic", "gtea", "adl", "kitchen"]:
         transform = dict()
-        if modality == 'rgb':
+        if modality == "rgb":
             transform = {
-                'train': transforms.Compose([
-                    ImglistToTensor(),
-                    transforms.Resize(size=256),
-                    transforms.RandomCrop(size=224),
-                    transforms.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
-                    TensorPermute(),
-                ]),
-                'valid': transforms.Compose([
-                    ImglistToTensor(),
-                    transforms.Resize(size=256),
-                    transforms.CenterCrop(size=224),
-                    transforms.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
-                    TensorPermute(),
-                ]),
-                'test': transforms.Compose([
-                    ImglistToTensor(),
-                    transforms.Resize(size=256),
-                    transforms.CenterCrop(size=224),
-                    transforms.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
-                    TensorPermute(),
-                ])
+                "train": transforms.Compose(
+                    [
+                        ImglistToTensor(),
+                        transforms.Resize(size=256),
+                        transforms.RandomCrop(size=224),
+                        transforms.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
+                        TensorPermute(),
+                    ]
+                ),
+                "valid": transforms.Compose(
+                    [
+                        ImglistToTensor(),
+                        transforms.Resize(size=256),
+                        transforms.CenterCrop(size=224),
+                        transforms.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
+                        TensorPermute(),
+                    ]
+                ),
+                "test": transforms.Compose(
+                    [
+                        ImglistToTensor(),
+                        transforms.Resize(size=256),
+                        transforms.CenterCrop(size=224),
+                        transforms.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
+                        TensorPermute(),
+                    ]
+                ),
             }
-        elif modality == 'flow':
+        elif modality == "flow":
             transform = {
-                'train': transforms.Compose([
-                    # Stack(),
-                    ImglistToTensor(),
-                    transforms.Resize(size=256),
-                    transforms.RandomCrop(size=224),
-                    transforms.Normalize(mean=[0.5, 0.5], std=[0.5, 0.5]),
-                    TensorPermute(),
-                ]),
-                'valid': transforms.Compose([
-                    # Stack(),
-                    ImglistToTensor(),
-                    transforms.Resize(size=256),
-                    transforms.CenterCrop(size=224),
-                    transforms.Normalize(mean=[0.5, 0.5], std=[0.5, 0.5]),
-                    TensorPermute(),
-                ]),
-                'test': transforms.Compose([
-                    # Stack(),
-                    ImglistToTensor(),
-                    transforms.Resize(size=256),
-                    transforms.CenterCrop(size=224),
-                    transforms.Normalize(mean=[0.5, 0.5], std=[0.5, 0.5]),
-                    TensorPermute(),
-                ])
+                "train": transforms.Compose(
+                    [
+                        # Stack(),
+                        ImglistToTensor(),
+                        transforms.Resize(size=256),
+                        transforms.RandomCrop(size=224),
+                        transforms.Normalize(mean=[0.5, 0.5], std=[0.5, 0.5]),
+                        TensorPermute(),
+                    ]
+                ),
+                "valid": transforms.Compose(
+                    [
+                        # Stack(),
+                        ImglistToTensor(),
+                        transforms.Resize(size=256),
+                        transforms.CenterCrop(size=224),
+                        transforms.Normalize(mean=[0.5, 0.5], std=[0.5, 0.5]),
+                        TensorPermute(),
+                    ]
+                ),
+                "test": transforms.Compose(
+                    [
+                        # Stack(),
+                        ImglistToTensor(),
+                        transforms.Resize(size=256),
+                        transforms.CenterCrop(size=224),
+                        transforms.Normalize(mean=[0.5, 0.5], std=[0.5, 0.5]),
+                        TensorPermute(),
+                    ]
+                ),
             }
 
     else:
@@ -93,13 +105,15 @@ class ImglistToTensor(torch.nn.Module):
             tensor of size `` NUM_IMAGES x CHANNELS x HEIGHT x WIDTH``
         """
         img_t = torch.stack([transforms.functional.to_tensor(pic) for pic in img_list])
-        if img_list[0].mode == 'RGB':
+        if img_list[0].mode == "RGB":
             return img_t
-        elif img_list[0].mode == 'L':
-            img_f = torch.reshape(img_t, shape=(img_t.shape[0] // 2, 2, img_t.shape[2], img_t.shape[3]))
+        elif img_list[0].mode == "L":
+            img_f = torch.reshape(
+                img_t, shape=(img_t.shape[0] // 2, 2, img_t.shape[2], img_t.shape[3])
+            )
             return img_f
         else:
-            raise RuntimeError('Image modality is not in [rgb, flow].')
+            raise RuntimeError("Image modality is not in [rgb, flow].")
 
 
 class TensorPermute(torch.nn.Module):

--- a/kale/prepdata/video_transform.py
+++ b/kale/prepdata/video_transform.py
@@ -1,6 +1,6 @@
 import torch
 from torchvision import transforms
-import numpy as np
+# import numpy as np
 
 
 def get_transform(kind, modality):

--- a/kale/utils/csv_logger.py
+++ b/kale/utils/csv_logger.py
@@ -1,5 +1,6 @@
 """
-Logging functions, including saving results from multiple runs to CSV, from https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/utils/experimentation.py and 
+Logging functions, including saving results from multiple runs to CSV,
+from https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/utils/experimentation.py and
 https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/utils/experimentation_results.py
 """
 import os.path
@@ -9,11 +10,11 @@ import pandas as pd
 import numpy as np
 import json
 import hashlib
-import glob
+# import glob
 import re
 from datetime import datetime
 from pytorch_lightning.callbacks import ModelCheckpoint
-from pytorch_lightning.loggers import TensorBoardLogger
+# from pytorch_lightning.loggers import TensorBoardLogger
 
 
 def param_to_str(param_dict):

--- a/kale/utils/logger.py
+++ b/kale/utils/logger.py
@@ -7,9 +7,9 @@ import logging
 import datetime
 import subprocess
 
+
 def git_hash():
-    """Gets a hash for different runs to have unique logfile names.
-    """
+    """Gets a hash for different runs to have unique logfile names."""
     cmd = 'git log -n 1 --pretty="%h"'
     ret = subprocess.check_output(shlex.split(cmd)).strip()
     if isinstance(ret, bytes):
@@ -29,8 +29,10 @@ def construct_logger(name, save_dir):
     logger = logging.getLogger(name)
     logger.setLevel(logging.DEBUG)
 
-    date = str(datetime.datetime.now().strftime('%m%d%H'))
-    fh = logging.FileHandler(os.path.join(save_dir, f'log-{date}-{git_hash()}.txt'), encoding='utf-8')
+    date = str(datetime.datetime.now().strftime("%m%d%H"))
+    fh = logging.FileHandler(
+        os.path.join(save_dir, f"log-{date}-{git_hash()}.txt"), encoding="utf-8"
+    )
     fh.setLevel(logging.DEBUG)
     formatter = logging.Formatter("%(asctime)s %(name)s %(levelname)s: %(message)s")
     fh.setFormatter(formatter)

--- a/kale/utils/logger.py
+++ b/kale/utils/logger.py
@@ -1,7 +1,7 @@
 """Screen printing functions, from https://github.com/HaozhiQi/ISONet/blob/master/isonet/utils/logger.py"""
 
 import os
-import sys
+# import sys
 import shlex
 import logging
 import datetime

--- a/kale/utils/print.py
+++ b/kale/utils/print.py
@@ -1,5 +1,6 @@
 """Screen printing functions, from https://github.com/HaozhiQi/ISONet/blob/master/isonet/utils/misc.py"""
 
+
 def tprint(*args):
     """Temporarily prints things on the screen so that it won't be flooded"""
     print("\r", end="")
@@ -14,5 +15,5 @@ def pprint(*args):
 
 def pprint_without_newline(*args):
     """Permanently prints things on the screen, separated by space rather than newline"""
-    print('\r', end='')
-    print(*args, end=' ')
+    print("\r", end="")
+    print(*args, end=" ")

--- a/kale/utils/seed.py
+++ b/kale/utils/seed.py
@@ -11,8 +11,10 @@ import numpy as np
 def set_seed(seed=1000):
     """Sets the seed for generating random numbers to get (as) reproducible (as possible) results.
 
-    The CuDNN options are set according to the official PyTorch guidance on reproducibility: https://pytorch.org/docs/stable/notes/randomness.html.
-    Another reference is https://discuss.pytorch.org/t/difference-between-torch-manual-seed-and-torch-cuda-manual-seed/13848/6
+    The CuDNN options are set according to the official PyTorch guidance on reproducibility:
+    https://pytorch.org/docs/stable/notes/randomness.html.
+    Another reference is
+    https://discuss.pytorch.org/t/difference-between-torch-manual-seed-and-torch-cuda-manual-seed/13848/6
 
     Args:
         seed (int, optional): The desired seed. Defaults to 1000.

--- a/kale/utils/seed.py
+++ b/kale/utils/seed.py
@@ -11,14 +11,14 @@ import numpy as np
 def set_seed(seed=1000):
     """Sets the seed for generating random numbers to get (as) reproducible (as possible) results.
 
-    The CuDNN options are set according to the official PyTorch guidance on reproducibility: https://pytorch.org/docs/stable/notes/randomness.html. 
+    The CuDNN options are set according to the official PyTorch guidance on reproducibility: https://pytorch.org/docs/stable/notes/randomness.html.
     Another reference is https://discuss.pytorch.org/t/difference-between-torch-manual-seed-and-torch-cuda-manual-seed/13848/6
 
     Args:
         seed (int, optional): The desired seed. Defaults to 1000.
     """
     # 1. Set `PYTHONHASHSEED` environment variable at a fixed value
-    os.environ['PYTHONHASHSEED'] = str(seed)
+    os.environ["PYTHONHASHSEED"] = str(seed)
     # 2. Set `python` built-in pseudo-random generator at a fixed value
     random.seed(seed)
     # 3. Set `numpy` pseudo-random generator at a fixed value

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,9 +6,9 @@ max-line-length = 120
 
 [flake8]
 max-line-length = 120
-ignore = E203, F403, F405, E731, W503, W605
+# ignore = E203, F403, F405, E731, W503, W605
 exclude =
-  build,examples
+  build #,examples
 
 [build_sphinx]
 all-files = 1

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,10 @@ from setuptools import find_packages, setup
 
 # Get version
 def read(*names, **kwargs):
-    with io.open(os.path.join(os.path.dirname(__file__), *names), encoding=kwargs.get("encoding", "utf8")) as fp:
+    with io.open(
+        os.path.join(os.path.dirname(__file__), *names),
+        encoding=kwargs.get("encoding", "utf8"),
+    ) as fp:
         return fp.read()
 
 
@@ -38,22 +41,22 @@ setup(
         "Documentation": "https://pykale.readthedocs.io",
         "Source": "https://github.com/pykale/pykale",
     },
-    keywords='machine learning, pytorch, dimensionality reduction, deep learning, multimodal learning, transfer learning',
+    keywords="machine learning, pytorch, dimensionality reduction, deep learning, multimodal learning, transfer learning",
     license="MIT",
     classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: Developers',
-        'Intended Audience :: Education',
-        'Intended Audience :: Healthcare Industry',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Education",
+        "Intended Audience :: Healthcare Industry",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        'Topic :: Scientific/Engineering :: Artificial Intelligence',
-        'Topic :: Scientific/Engineering :: Medical Science Apps.',
-        'Topic :: Software Development :: Libraries',        
-        'Natural Language :: English',
-    ],    
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        "Topic :: Scientific/Engineering :: Medical Science Apps.",
+        "Topic :: Software Development :: Libraries",
+        "Natural Language :: English",
+    ],
     packages=find_packages(),
     python_requires=">=3.6",
     # install_requires = [">=".join(["torch", torch_min]), "scikit-learn", "numpy", "pytorch-lightning", "tensorly", "torchvision"]
@@ -61,17 +64,24 @@ setup(
         # if you add any additional libraries, please also
         # add them to `docs/requirements.txt`
         # numpy is necessary for some functionality of PyTorch
-        'numpy>=1.18.0',
-        'torch>=1.7.0',
-        'torchvision>=0.8.1',
+        "numpy>=1.18.0",
+        "torch>=1.7.0",
+        "torchvision>=0.8.1",
         # 'scikit-image',
         # 'scikit-learn>=0.23,!=0.24.0',
-        'tensorly',
+        "tensorly",
     ],
     extras_require={
         "dev": ["black", "twine", "pre-commit"],
         "pipeline": ["pytorch-lightning"],
-        "docs": ["ipython", "ipykernel", "sphinx", "sphinx_rtd_theme", "nbsphinx", "m2r"],
+        "docs": [
+            "ipython",
+            "ipykernel",
+            "sphinx",
+            "sphinx_rtd_theme",
+            "nbsphinx",
+            "m2r",
+        ],
         "utils": ["matplotlib", "tqdm", "torchsummary>=1.5.0", "yacs>=0.1.7"],
         "test": ["flake8", "flake8-print", "pytest", "nbval"],
     },

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "Documentation": "https://pykale.readthedocs.io",
         "Source": "https://github.com/pykale/pykale",
     },
-    keywords="machine learning, pytorch, dimensionality reduction, deep learning, multimodal learning, transfer learning",
+    keywords="machine learning, pytorch, deep learning, multimodal learning, transfer learning",
     license="MIT",
     classifiers=[
         "Development Status :: 3 - Alpha",
@@ -59,7 +59,6 @@ setup(
     ],
     packages=find_packages(),
     python_requires=">=3.6",
-    # install_requires = [">=".join(["torch", torch_min]), "scikit-learn", "numpy", "pytorch-lightning", "tensorly", "torchvision"]
     install_requires=[
         # if you add any additional libraries, please also
         # add them to `docs/requirements.txt`

--- a/test/context.py
+++ b/test/context.py
@@ -1,10 +1,21 @@
 import os
 import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import kale
 from kale.embed import image_cnn, mpca, positional_encoding, attention_cnn
-from kale.loaddata import cifar_access, dataset_access, digits_access, mnistm, multi_domain, sampler, usps, videos
+from kale.loaddata import (
+    cifar_access,
+    dataset_access,
+    digits_access,
+    mnistm,
+    multi_domain,
+    sampler,
+    usps,
+    videos,
+)
+
 # from kale.pipeline import domain_adapter # need pytorch-lightning
 from kale.predict import class_domain_nets, isonet, losses
 from kale.prepdata import image_transform, prep_cmr, tensor_reshape, video_transform
@@ -13,4 +24,4 @@ from kale.utils import csv_logger, logger, seed
 """ These only work with the optional graph modules
 from kale.embed import gcn, gripnet
 """
-print('kale imported')
+print("kale imported")

--- a/test/context.py
+++ b/test/context.py
@@ -1,25 +1,27 @@
-import os
-import sys
+# import os
+# import sys
+# import kale
+# sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
-import kale
-from kale.embed import image_cnn, mpca, positional_encoding, attention_cnn
-from kale.loaddata import (
-    cifar_access,
-    dataset_access,
-    digits_access,
-    mnistm,
-    multi_domain,
-    sampler,
-    usps,
-    videos,
-)
+# from kale.embed import image_cnn, mpca, positional_encoding, attention_cnn
+# from kale.loaddata import (
+#     cifar_access,
+#     dataset_access,
+#     digits_access,
+#     mnistm,
+#     multi_domain,
+#     sampler,
+#     usps,
+#     videos,
+# )
 
 # from kale.pipeline import domain_adapter # need pytorch-lightning
-from kale.predict import class_domain_nets, isonet, losses
-from kale.prepdata import image_transform, prep_cmr, tensor_reshape, video_transform
-from kale.utils import csv_logger, logger, seed
+# from kale.predict import class_domain_nets, isonet, losses
+# from kale.prepdata import image_transform, prep_cmr, tensor_reshape, video_transform
+# from kale.utils import csv_logger, logger, seed
+from kale.utils import seed
+
+seed.set_seed(2020)
 
 """ These only work with the optional graph modules
 from kale.embed import gcn, gripnet


### PR DESCRIPTION
Fixes flake8 linting errors.

### Description
- Black
  - Run `black` to autoformat everything. 53 files were reformatted, 16 files were left unchanged. 
  - Before: flake8 reported 314 errors. After: flake8 reported 89 errors. I examined about 20 out of 53 files and did not find any problem so I did not check all 53 files one by one. 
- Manual 1
  - Manually fix the remaining 89 errors. 
  - Those errors due to overlength docstrings were ignored via adding ` # noqa: E501` at the end individually because I think it is not necessary to break docstrings into multiple lines in such cases. Docstrings are mainly for documentation so they will be automatically broken into lines.
  - 23 files have been changes in total.
  - Not to ignore test. Instead, we should write more complete test cases (rather than just import) in future.
  - These manual fixes (the second commit) may need more review than the black autoformatting. Reviewing by examining this commit may be easier than reviewing the changes in all files altogether due to the large number of changes made.
- Manual 2
  - Flake8 ignores have been removed, which just led to 5 E203 whitespace before ':' errors that have been fixed.
  - Not to exclude `Examples`. Checking `Examples` did not lead to more errors.
- After review, this will be merged into the master and linting CI will be turned on.
### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).