### PR TITLE
isort all (imports)

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: "3.6"
     - name: Install dependencies
       run: |
-        pip install flake8==3.8.3 pre-commit 
+        pip install flake8==3.8.3 pre-commit isort
         pre-commit install
     - name: Run linting
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,17 +25,17 @@ repos:
         args: [--diff, --color]
         # exclude: ^(build/*)
         # args: [-l 120, --diff, --color, --target-version=py38, --config=pyproject.toml]
-# -   repo: https://github.com/pre-commit/mirrors-isort
-#     rev: v4.3.21
-    # hooks:
-    # -   id: isort
-    #     name: isort
-    #     entry: python -m isort
-    #     language: system
-    #     types: [python]    
-    #     language_version: python3
-    #     # exclude: ^(build/*)
-    #     args: [--settings-path, ./pyproject.toml]
+-   repo: https://github.com/pre-commit/mirrors-isort
+    rev: v4.3.21
+    hooks:
+    -   id: isort
+        name: isort
+        entry: python -m isort
+        language: system
+        types: [python]    
+        language_version: python3
+        # exclude: ^(build/*)
+        args: [--settings-path, ./pyproject.toml]
 # -   repo: https://github.com/jumanjihouse/pre-commit-hooks
 #     rev: 1.11.0
 #     hooks:

--- a/examples/action_dann_lightn/config.py
+++ b/examples/action_dann_lightn/config.py
@@ -2,8 +2,9 @@
 Default configurations for action recognition domain adaptation
 """
 
-from yacs.config import CfgNode as CN
 import os
+
+from yacs.config import CfgNode as CN
 
 # -----------------------------------------------------------------------------
 # Config definition

--- a/examples/action_dann_lightn/main.py
+++ b/examples/action_dann_lightn/main.py
@@ -14,7 +14,7 @@ from examples.action_dann_lightn.config import get_cfg_defaults
 from examples.action_dann_lightn.model import get_model
 from kale.loaddata.multi_domain import MultiDomainDatasets
 from kale.loaddata.video_access import VideoDataset
-from kale.utils.csv_logger import setup_logger  # np error if move this to later, not sure why
+from kale.utils.csv_logger import setup_logger 
 from kale.utils.seed import set_seed
 
 # import sys

--- a/examples/action_dann_lightn/main.py
+++ b/examples/action_dann_lightn/main.py
@@ -7,19 +7,19 @@ import argparse
 import logging
 import os
 
+import pytorch_lightning as pl
+from pytorch_lightning import loggers as pl_loggers
+
+from examples.action_dann_lightn.config import get_cfg_defaults
+from examples.action_dann_lightn.model import get_model
+from kale.loaddata.multi_domain import MultiDomainDatasets
+from kale.loaddata.video_access import VideoDataset
+from kale.utils.csv_logger import setup_logger  # np error if move this to later, not sure why
+from kale.utils.seed import set_seed
+
 # import sys
 
 # sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
-
-from kale.utils.csv_logger import setup_logger  # np error if move this to later, not sure why
-import pytorch_lightning as pl
-
-from pytorch_lightning import loggers as pl_loggers
-from examples.action_dann_lightn.config import get_cfg_defaults
-from examples.action_dann_lightn.model import get_model
-from kale.loaddata.video_access import VideoDataset
-from kale.loaddata.multi_domain import MultiDomainDatasets
-from kale.utils.seed import set_seed
 
 
 def arg_parse():

--- a/examples/action_dann_lightn/model.py
+++ b/examples/action_dann_lightn/model.py
@@ -7,10 +7,10 @@ References from https://github.com/criteo-research/pytorch-ada/blob/master/adali
 
 from copy import deepcopy
 
-from kale.embed.video_i3d import i3d
-from kale.embed.video_res3d import r3d_18, r2plus1d_18, mc3_18
-from kale.predict.class_domain_nets import ClassNetSmallImage, DomainNetSmallImage
 import kale.pipeline.domain_adapter as domain_adapter
+from kale.embed.video_i3d import i3d
+from kale.embed.video_res3d import mc3_18, r2plus1d_18, r3d_18
+from kale.predict.class_domain_nets import ClassNetSmallImage, DomainNetSmallImage
 
 
 def get_config(cfg):

--- a/examples/cifar_cnntransformer/main.py
+++ b/examples/cifar_cnntransformer/main.py
@@ -4,23 +4,22 @@ for image classification on CIFAR10.
 
 Reference: See kale.embed.attention_cnn for more details.
 """
-import os
 import argparse
-import warnings
+import os
 import sys
+import warnings
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 import torch
-from torchsummary import summary
-
 from config import get_cfg_defaults
 from model import get_model
+from torchsummary import summary
 from trainer import Trainer
-from kale.loaddata.cifar_access import get_cifar
 
 import kale.utils.logger as logging
 import kale.utils.seed as seed
+from kale.loaddata.cifar_access import get_cifar
 
 
 def arg_parse():

--- a/examples/cifar_cnntransformer/trainer.py
+++ b/examples/cifar_cnntransformer/trainer.py
@@ -1,9 +1,11 @@
 # Created by Raivo Koot from modifying https://github.com/HaozhiQi/ISONet/blob/master/isonet/trainer.py
 # Under the MIT License
 import time
+
 import torch
 import torch.nn as nn
-from kale.utils.print import tprint, pprint_without_newline
+
+from kale.utils.print import pprint_without_newline, tprint
 
 
 class Trainer(object):

--- a/examples/cifar_isonet/main.py
+++ b/examples/cifar_isonet/main.py
@@ -3,21 +3,20 @@
 Reference: https://github.com/HaozhiQi/ISONet/blob/master/train.py 
 """
 
-import os
 import argparse
-import warnings
+import os
 import sys
+import warnings
 
 # No need if pykale is installed
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 import torch
-from torchsummary import summary
-
 from config import get_cfg_defaults
 
 # from model_old import get_model
 from model import get_model
+from torchsummary import summary
 from trainer import Trainer
 
 from kale.loaddata.cifar_access import get_cifar

--- a/examples/cifar_isonet/trainer.py
+++ b/examples/cifar_isonet/trainer.py
@@ -4,9 +4,11 @@ From: https://github.com/HaozhiQi/ISONet/blob/master/isonet/trainer.py
 """
 
 import time
+
 import torch
 import torch.nn as nn
-from kale.utils.print import tprint, pprint_without_newline
+
+from kale.utils.print import pprint_without_newline, tprint
 
 
 class Trainer(object):

--- a/examples/digits_dann_lightn/config.py
+++ b/examples/digits_dann_lightn/config.py
@@ -2,8 +2,9 @@
 Default configurations for domain adaptation
 """
 
-from yacs.config import CfgNode as CN
 import os
+
+from yacs.config import CfgNode as CN
 
 # -----------------------------------------------------------------------------
 # Config definition

--- a/examples/digits_dann_lightn/main.py
+++ b/examples/digits_dann_lightn/main.py
@@ -17,7 +17,7 @@ from model import get_model
 
 from kale.loaddata.digits_access import DigitDataset
 from kale.loaddata.multi_domain import MultiDomainDatasets
-from kale.utils.csv_logger import setup_logger  # np error if move this to later, not sure why
+from kale.utils.csv_logger import setup_logger 
 from kale.utils.seed import set_seed
 
 # sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))

--- a/examples/digits_dann_lightn/main.py
+++ b/examples/digits_dann_lightn/main.py
@@ -3,23 +3,26 @@
 Reference: https://github.com/thuml/CDAN/blob/master/pytorch/train_image.py
 """
 
-import os
 import argparse
+
 # import warnings
 # import sys
 import logging
+import os
+
+# import torch
+import pytorch_lightning as pl
+from config import get_cfg_defaults
+from model import get_model
+
+from kale.loaddata.digits_access import DigitDataset
+from kale.loaddata.multi_domain import MultiDomainDatasets
+from kale.utils.csv_logger import setup_logger  # np error if move this to later, not sure why
+from kale.utils.seed import set_seed
 
 # sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 
-from kale.utils.csv_logger import setup_logger  # np error if move this to later, not sure why
-# import torch
-import pytorch_lightning as pl
 
-from config import get_cfg_defaults
-from model import get_model
-from kale.loaddata.digits_access import DigitDataset
-from kale.loaddata.multi_domain import MultiDomainDatasets
-from kale.utils.seed import set_seed
 
 
 def arg_parse():

--- a/examples/digits_dann_lightn/model.py
+++ b/examples/digits_dann_lightn/model.py
@@ -5,10 +5,10 @@ Define the learning model and configure training parameters.
 # Initial Date: 27 July 2020
 
 from copy import deepcopy
-from kale.embed.image_cnn import SmallCNNFeature
-from kale.predict.class_domain_nets import ClassNetSmallImage, \
-    DomainNetSmallImage
+
 import kale.pipeline.domain_adapter as domain_adapter
+from kale.embed.image_cnn import SmallCNNFeature
+from kale.predict.class_domain_nets import ClassNetSmallImage, DomainNetSmallImage
 
 
 def get_config(cfg):

--- a/examples/drug_gripnet/main.py
+++ b/examples/drug_gripnet/main.py
@@ -1,19 +1,20 @@
-import os
 import argparse
+import os
 import sys
 
 # No need if pykale is installed
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 import torch
-import kale.utils.logger as lu
-import kale.utils.seed as seed
 from config import get_cfg_defaults
 from loaddata import construct_dataset
 from model import GripNet
-from kale.embed.gripnet import TypicalGripNetEncoder
 from torchsummary import summary
 from trainer import Trainer
+
+import kale.utils.logger as lu
+import kale.utils.seed as seed
+from kale.embed.gripnet import TypicalGripNetEncoder
 
 
 def arg_parse():

--- a/examples/drug_gripnet/model.py
+++ b/examples/drug_gripnet/model.py
@@ -1,8 +1,9 @@
-import torch
 import numpy as np
+import torch
 from torch import nn
-from kale.embed.gripnet import TypicalGripNetEncoder
 from utils import negative_sampling
+
+from kale.embed.gripnet import TypicalGripNetEncoder
 
 
 class MultiRelaInnerProductDecoder(nn.Module):

--- a/examples/drug_gripnet/trainer.py
+++ b/examples/drug_gripnet/trainer.py
@@ -1,6 +1,7 @@
-import torch
 import time
+
 import numpy as np
+import torch
 from utils import auprc_auroc_ap, EPS
 
 

--- a/examples/drug_gripnet/utils.py
+++ b/examples/drug_gripnet/utils.py
@@ -1,6 +1,7 @@
-import torch
-import numpy as np
 import pickle
+
+import numpy as np
+import torch
 from sklearn import metrics
 from sklearn.metrics import accuracy_score
 

--- a/examples/video_loading/main.py
+++ b/examples/video_loading/main.py
@@ -4,13 +4,14 @@ import sys
 # No need if pykale is installed
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
+import matplotlib.pyplot as plt
+import torch
+from mpl_toolkits.axes_grid1 import ImageGrid
+from torchvision import transforms
+from torchvision.datasets.utils import download_file_from_google_drive, extract_archive
+
 from kale.loaddata.videos import VideoFrameDataset
 from kale.prepdata.video_transform import ImglistToTensor
-from torchvision import transforms
-import torch
-import matplotlib.pyplot as plt
-from mpl_toolkits.axes_grid1 import ImageGrid
-from torchvision.datasets.utils import download_file_from_google_drive, extract_archive
 
 """
 Ignore this function and look at "main" below.

--- a/kale/embed/attention_cnn.py
+++ b/kale/embed/attention_cnn.py
@@ -1,9 +1,10 @@
-import torch
-import torch.nn as nn
 from typing import Tuple
 
-from kale.prepdata.tensor_reshape import spatial_to_seq, seq_to_spatial
+import torch
+import torch.nn as nn
+
 from kale.embed.positional_encoding import PositionalEncoding
+from kale.prepdata.tensor_reshape import seq_to_spatial, spatial_to_seq
 
 
 class ContextCNNGeneric(nn.Module):

--- a/kale/embed/gcn.py
+++ b/kale/embed/gcn.py
@@ -1,9 +1,9 @@
 import numpy as np
 import torch
-from torch_geometric.utils import add_remaining_self_loops
-from torch_geometric.nn.conv import MessagePassing
-from torch_scatter import scatter_add
 from torch.nn import Parameter
+from torch_geometric.nn.conv import MessagePassing
+from torch_geometric.utils import add_remaining_self_loops
+from torch_scatter import scatter_add
 
 
 # Copy-paste with slight modification from torch_geometric.nn.GCNConv

--- a/kale/embed/gripnet.py
+++ b/kale/embed/gripnet.py
@@ -5,9 +5,10 @@ the `GripNet
 <https://github.com/NYXFLOWER/GripNet>`_ source repo.
 """
 
-import torch.nn.functional as F
 import torch
+import torch.nn.functional as F
 from torch.nn import Module
+
 from kale.embed.gcn import GCNEncoderLayer, RGCNEncoderLayer
 
 

--- a/kale/embed/linformer.py
+++ b/kale/embed/linformer.py
@@ -2,20 +2,13 @@ import warnings
 from typing import Optional, Tuple  # Any
 
 import torch
-from torch import nn
-
-from torch.nn import Linear
-from torch.nn.parameter import Parameter
-from torch.nn.init import xavier_uniform_
-from torch.nn.init import constant_
-from torch.nn.init import xavier_normal_
-from torch.nn.functional import linear, softmax, dropout
-from torch import Tensor
-from torch.nn import functional as F
-from torch.nn import Module
+from torch import nn, Tensor
 from torch.nn import Dropout
-from torch.nn import LayerNorm
-from torch.nn.functional import pad
+from torch.nn import functional as F
+from torch.nn import LayerNorm, Linear, Module
+from torch.nn.functional import dropout, linear, pad, softmax
+from torch.nn.init import constant_, xavier_normal_, xavier_uniform_
+from torch.nn.parameter import Parameter
 
 
 # Copy-paste with slight modification from torch.nn.TransformerEncoderLayer

--- a/kale/embed/mpca.py
+++ b/kale/embed/mpca.py
@@ -14,12 +14,13 @@ Reference:
 """
 
 import sys
+
 import numpy as np
+from sklearn.base import BaseEstimator, TransformerMixin
 
 # import tensorly as tl
-from tensorly.base import unfold, fold
+from tensorly.base import fold, unfold
 from tensorly.tenalg import multi_mode_dot
-from sklearn.base import BaseEstimator, TransformerMixin
 
 
 def check_ndim(X, ndim):

--- a/kale/embed/positional_encoding.py
+++ b/kale/embed/positional_encoding.py
@@ -1,8 +1,9 @@
 # Created by Raivo Koot from modifying https://pytorch.org/tutorials/beginner/transformer_tutorial.html
 
+import math
+
 import torch
 import torch.nn as nn
-import math
 
 
 class PositionalEncoding(nn.Module):

--- a/kale/embed/video_i3d.py
+++ b/kale/embed/video_i3d.py
@@ -9,7 +9,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torchvision.models.utils import load_state_dict_from_url
 
-
 model_urls = {
     "rgb_imagenet": "https://github.com/XianyuanLiu/pytorch-i3d/raw/master/models/rgb_imagenet.pt",
     "flow_imagenet": "https://github.com/XianyuanLiu/pytorch-i3d/raw/master/models/flow_imagenet.pt",

--- a/kale/loaddata/cifar_access.py
+++ b/kale/loaddata/cifar_access.py
@@ -4,6 +4,7 @@ Reference: https://github.com/HaozhiQi/ISONet/blob/master/isonet/utils/dataset.p
 
 import torch
 import torchvision
+
 from kale.prepdata.image_transform import get_transform
 
 

--- a/kale/loaddata/digits_access.py
+++ b/kale/loaddata/digits_access.py
@@ -5,11 +5,13 @@ https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/datasets/d
 """
 
 from enum import Enum
+
 from torchvision.datasets import MNIST, SVHN
+
 import kale.prepdata.image_transform as image_transform
-from kale.loaddata.usps import USPS
-from kale.loaddata.mnistm import MNISTM
 from kale.loaddata.dataset_access import DatasetAccess
+from kale.loaddata.mnistm import MNISTM
+from kale.loaddata.usps import USPS
 
 
 class DigitDataset(Enum):

--- a/kale/loaddata/mnistm.py
+++ b/kale/loaddata/mnistm.py
@@ -8,8 +8,8 @@ CREDIT: https://github.com/corenel
 from __future__ import print_function
 
 import errno
-import os
 import logging
+import os
 
 import torch
 import torch.utils.data as data
@@ -105,9 +105,10 @@ class MNISTM(data.Dataset):
     def download(self):
         """Download the MNISTM data."""
         # import essential packages
-        from six.moves import urllib
         import gzip
         import pickle
+
+        from six.moves import urllib
         from torchvision import datasets
 
         # check if dataset already exists

--- a/kale/loaddata/multi_domain.py
+++ b/kale/loaddata/multi_domain.py
@@ -4,11 +4,13 @@ Construct a dataset with (multiple) source and target domains, from https://gith
 
 import logging
 from enum import Enum
+
 import numpy as np
-from sklearn.utils import check_random_state
 import torch.utils.data
-from kale.loaddata.sampler import get_labels, MultiDataLoader, SamplingConfig
+from sklearn.utils import check_random_state
+
 from kale.loaddata.dataset_access import DatasetAccess
+from kale.loaddata.sampler import get_labels, MultiDataLoader, SamplingConfig
 
 
 class WeightingType(Enum):

--- a/kale/loaddata/sampler.py
+++ b/kale/loaddata/sampler.py
@@ -2,11 +2,12 @@
 from https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/datasets/sampler.py
 """
 
-import torchvision
-import torch.utils.data
 import logging
+
 import numpy as np
-from torch.utils.data.sampler import RandomSampler, BatchSampler
+import torch.utils.data
+import torchvision
+from torch.utils.data.sampler import BatchSampler, RandomSampler
 
 
 class SamplingConfig:

--- a/kale/loaddata/usps.py
+++ b/kale/loaddata/usps.py
@@ -4,10 +4,10 @@ https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/datasets/d
 (based on https://github.com/mingyuliutw/CoGAN/blob/master/cogan_pytorch/src/dataset_usps.py)
 """
 import gzip
+import logging
 import os
 import pickle
 import urllib
-import logging
 
 import numpy as np
 import torch

--- a/kale/loaddata/video_access.py
+++ b/kale/loaddata/video_access.py
@@ -4,11 +4,12 @@ https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/datasets/d
 """
 
 import os
+from copy import deepcopy
 from enum import Enum
+
 import kale.prepdata.video_transform as video_transform
 from kale.loaddata.dataset_access import DatasetAccess
 from kale.loaddata.video_datasets import BasicVideoDataset, EPIC
-from copy import deepcopy
 
 
 def get_videodata_config(cfg):

--- a/kale/loaddata/video_datasets.py
+++ b/kale/loaddata/video_datasets.py
@@ -2,6 +2,7 @@ import math
 import os
 import pickle
 from pathlib import Path
+
 from PIL import Image
 
 from kale.loaddata.videos import VideoFrameDataset, VideoRecord

--- a/kale/loaddata/videos.py
+++ b/kale/loaddata/videos.py
@@ -4,8 +4,8 @@ import os.path
 import random
 
 import numpy as np
-from PIL import Image
 import torch
+from PIL import Image
 
 
 class VideoRecord(object):

--- a/kale/pipeline/domain_adapter.py
+++ b/kale/pipeline/domain_adapter.py
@@ -7,12 +7,13 @@ This module uses `PyTorch Lightning <https://github.com/PyTorchLightning/pytorch
 """
 
 from enum import Enum
+
 import numpy as np
+import pytorch_lightning as pl
 import torch
 from torch.autograd import Function
-import kale.predict.losses as losses
 
-import pytorch_lightning as pl
+import kale.predict.losses as losses
 
 
 class ReverseLayerF(Function):

--- a/kale/pipeline/video_transformer.py
+++ b/kale/pipeline/video_transformer.py
@@ -1,10 +1,12 @@
 from typing import Tuple
+
+import pytorch_lightning as pl
 import torch
 import torch.nn as nn
-import pytorch_lightning as pl
+
 from ..embed.attention_cnn import ContextCNNGeneric
-from ..embed.positional_encoding import PositionalEncoding
 from ..embed.linformer import LinearTransformerEncoderLayer
+from ..embed.positional_encoding import PositionalEncoding
 
 
 class VideoTransformer(pl.LightningModule):

--- a/kale/predict/isonet.py
+++ b/kale/predict/isonet.py
@@ -5,7 +5,6 @@ from https://github.com/HaozhiQi/ISONet/blob/master/isonet/models/isonet.py
 """
 
 import numpy as np
-
 import torch
 import torch.nn as nn
 import torch.nn.functional as F

--- a/kale/predict/losses.py
+++ b/kale/predict/losses.py
@@ -4,8 +4,8 @@ https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/models/los
 
 import torch
 import torch.nn as nn
-from torch.nn import functional as F
 from torch.autograd import grad
+from torch.nn import functional as F
 
 
 def cross_entropy_logits(linear_output, label, weights=None):

--- a/kale/prepdata/prep_cmr.py
+++ b/kale/prepdata/prep_cmr.py
@@ -3,6 +3,7 @@ Author: Shuo Zhou, szhou20@sheffield.ac.uk
 """
 import os
 import sys
+
 import numpy as np
 from scipy.io import loadmat
 from skimage import exposure, transform

--- a/kale/utils/csv_logger.py
+++ b/kale/utils/csv_logger.py
@@ -2,15 +2,16 @@
 Logging functions, including saving results from multiple runs to CSV, from https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/utils/experimentation.py and
 https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/utils/experimentation_results.py
 """
-import os.path
-import logging
-import shutil
-import pandas as pd
-import numpy as np
-import json
 import hashlib
+import json
+import logging
+import os.path
 import re
+import shutil
 from datetime import datetime
+
+import numpy as np
+import pandas as pd
 from pytorch_lightning.callbacks import ModelCheckpoint
 
 

--- a/kale/utils/logger.py
+++ b/kale/utils/logger.py
@@ -1,9 +1,9 @@
 """Screen printing functions, from https://github.com/HaozhiQi/ISONet/blob/master/isonet/utils/logger.py"""
 
+import datetime
+import logging
 import os
 import shlex
-import logging
-import datetime
 import subprocess
 
 

--- a/kale/utils/seed.py
+++ b/kale/utils/seed.py
@@ -2,8 +2,9 @@
 
 import os
 import random
-import torch
+
 import numpy as np
+import torch
 
 
 # Results can be software/hardware-dependent


### PR DESCRIPTION
## Fixes `isort` utility 

### Description
- Run `isort` on all files to sort the imports (skipped 4 files, changed 39 files, Flake8 checked).
- Switch on `isort` pre-commit and hope it can work well. Even if not, I should be able to fix it.
- I will try to fix some other pre-commits if feasible. 

These changes are light, affecting only the format of the imports so a quick check by you is much appreciate before merging. Thanks.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).