### PR TITLE
Replace print in kale API with logging except print.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
     -   id: flake8
         additional_dependencies: [flake8-print]
         args: [--config=setup.cfg]
+        exclude: ^(examples/*)
     -   id: check-added-large-files
         args: ['--maxkb=300']
     -   id: check-byte-order-marker

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: v2.4.0
     hooks:
     -   id: flake8
+        additional_dependencies: [flake8-print]
         args: [--config=setup.cfg]
     -   id: check-added-large-files
         args: ['--maxkb=300']

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,7 @@ We aim to design the core `kale` modules to be highly **reusable**, generic, and
 
 - Follow the [continuous integration practice](https://docs.github.com/en/actions/guides/about-continuous-integration#about-continuous-integration) to make small changes and commit frequently with clear descriptions for others to understand what you have done. This can detect errors sooner, reduces debug need, make it easier to merge changes, and eventually save the overall time.
 - Use highly *readable* names for variables, functions, and classes. Using *verbs* is preferred when feasible for compactness.
+- Use [`logging`](https://docs.python.org/3/howto/logging.html#logging-basic-tutorial) instead of `print` to log messages. Users can choose the level via, e.g., `logging.getLogger().setLevel(logging.INFO)`. See the [benefits](https://stackoverflow.com/questions/6918493/in-python-why-use-logging-instead-of-print).
 - Include detailed docstrings in code for generating documentations, following the [Google Style Python Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
 - Highly reusable modules should go into `kale`. Highly data/example-specific code goes into `Examples`.
 - Configure learning systems using [YAML](https://en.wikipedia.org/wiki/YAML) following [YACS](https://github.com/rbgirshick/yacs). See our [examples](https://github.com/pykale/pykale/tree/master/examples).

--- a/kale/embed/mpca.py
+++ b/kale/embed/mpca.py
@@ -12,7 +12,7 @@ Reference:
     Networks, Vol. 19, No. 1, Page: 18-39, January 2008. For initial Matlab
     implementation, please go to https://uk.mathworks.com/matlabcentral/fileexchange/26168.
 """
-
+import logging
 import sys
 
 import numpy as np
@@ -61,7 +61,7 @@ def _check_dim_shape(X, ndim, shape_):
 
     """
     if not check_ndim(X, ndim) or not check_shape(X, shape_):
-        print("The given data should be consistent with the order and shape of training data")
+        logging.error("The given data should be consistent with the order and shape of training data")
         sys.exit()
 
 
@@ -108,7 +108,7 @@ class MPCA(BaseEstimator, TransformerMixin):
         if max_iter > 0 and isinstance(max_iter, int):
             self.max_iter = max_iter
         else:
-            print("Number of max iterations must be an integer and greater than 0")
+            logging.error("Number of max iterations must be an integer and greater than 0")
             sys.exit()
         self.proj_mats = []
         self.vectorise = vectorise
@@ -254,7 +254,7 @@ class MPCA(BaseEstimator, TransformerMixin):
                 X_ = np.zeros((n_spl, np.prod(self.shape_out)))
                 X_[:, : self.idx_order[:n_feat]] = X[:]
             else:
-                print("Feature dimension exceeds the shape upper limit")
+                logging.error("Feature dimension exceeds the shape upper limit")
                 sys.exit()
 
             X = fold(X_, -1, self.shape_out + (n_spl,))

--- a/kale/loaddata/cifar_access.py
+++ b/kale/loaddata/cifar_access.py
@@ -1,6 +1,7 @@
 """CIFAR10 or CIFAR100 dataset loading
 Reference: https://github.com/HaozhiQi/ISONet/blob/master/isonet/utils/dataset.py
 """
+import logging
 
 import torch
 import torchvision
@@ -14,7 +15,7 @@ def get_cifar(cfg):
     Args:
         cfg: A YACS config object.
     """
-    print("==> Preparing to load data " + cfg.DATASET.NAME + " at " + cfg.DATASET.ROOT)
+    logging.info("==> Preparing to load data " + cfg.DATASET.NAME + " at " + cfg.DATASET.ROOT)
     cifar_train_transform = get_transform("cifar", augment=True)
     cifar_test_transform = get_transform("cifar", augment=False)
     # transform = {

--- a/kale/loaddata/video_datasets.py
+++ b/kale/loaddata/video_datasets.py
@@ -1,3 +1,4 @@
+import logging
 import math
 import os
 import pickle
@@ -79,7 +80,7 @@ class BasicVideoDataset(VideoFrameDataset):
                 if 0 <= eval(line[5]) < self.n_classes:
                     data.append((line[0], eval(line[1]), eval(line[2]), eval(line[5])))
                     i = i + 1
-        print("Number of {:5} action segments: {}".format(self.dataset, i))
+        logging.info("Number of {:5} action segments: {}".format(self.dataset, i))
         return data
 
 
@@ -148,5 +149,5 @@ class EPIC(VideoFrameDataset):
                             label = line[9]
                             data.append((os.path.join(line[1], line[2]), line[6], line[7], label))
                             i = i + 1
-        print("Number of {:5} action segments: {}".format(self.dataset, i))
+        logging.info("Number of {:5} action segments: {}".format(self.dataset, i))
         return data

--- a/kale/predict/isonet.py
+++ b/kale/predict/isonet.py
@@ -292,7 +292,6 @@ class ISONet(nn.Module):
 
     # Depth for ResNet, e.g. [3, 4, 6, 3] for ResNet50
     def _construct(self, net_params):
-        print(">>>>>>>>>>>>>>>>>>>>>>>>...-----Core Con")
         # Setting for ImageNet image size. To override if different.
         # Retrieve the number of blocks per stage
         (d1, d2, d3, d4) = _IN_STAGE_DS[net_params["depths"]]  # _depths

--- a/kale/prepdata/prep_cmr.py
+++ b/kale/prepdata/prep_cmr.py
@@ -1,6 +1,7 @@
 """
 Author: Shuo Zhou, szhou20@sheffield.ac.uk
 """
+import logging
 import os
 import sys
 
@@ -12,7 +13,7 @@ from skimage import exposure, transform
 def regMRI(data, reg_df, reg_id=1):
     n_sample = data.shape[-1]
     if n_sample != reg_df.shape[0]:
-        print("Error, registration and data not match. Please check")
+        logging.error("Error, registration and data not match. Please check")
         sys.exit()
     n_landmark = int((reg_df.shape[1] - 1) / 2)
     # reg_target = data[..., 0, reg_id]
@@ -100,7 +101,7 @@ def scale_cmr_mask(mask, scale):
 
 
 def cmr_proc(basedir, db, scale, mask_id, level, save_data=True, return_data=False):
-    print("Preprocssing Data Scale: 1/%s, Mask ID: %s, Processing level: %s" % (scale, mask_id, level))
+    logging.info("Preprocssing Data Scale: 1/%s, Mask ID: %s, Processing level: %s" % (scale, mask_id, level))
     datadir = os.path.join(basedir, "DB%s/NoPrs%sDB%s.npy" % (db, scale, db))
     maskdir = os.path.join(basedir, "Prep/AllMasks.mat")
     data = np.load(datadir)

--- a/kale/utils/csv_logger.py
+++ b/kale/utils/csv_logger.py
@@ -223,7 +223,7 @@ class XpResults:
         split="Validation",
         stdout=True,
         fdout=None,
-        print_func=print,  # noqa: T002
+        print_func=logging.info,
         file_format="markdown",
     ):
         """Print out the performance scores (over multiple runs)"""
@@ -231,10 +231,7 @@ class XpResults:
         nsamples = len(mres)
         mmres = [(mres[m].mean(), mres[m].std() / np.sqrt(nsamples)) for m in self._metrics]
         if stdout:
-            print_func(split, end=" ")
-            print_func(method_name, end="")
-            print_func(" " * (10 - len(method_name)), end="")
-            print_func("\t\t".join((f"{m * 100:.1f}% +- {1.96 * s * 100:.2f} ({nsamples} runs)" for m, s in mmres)))
+            print_func("{} {}\t {}".format(split, method_name, "\t\t".join((f"{m * 100:.1f}% +- {1.96 * s * 100:.2f} ({nsamples} runs)" for m, s in mmres))))
         if fdout is not None:
             if file_format == "markdown":
                 fdout.write(f"|{method_name}|")

--- a/kale/utils/csv_logger.py
+++ b/kale/utils/csv_logger.py
@@ -223,7 +223,7 @@ class XpResults:
         split="Validation",
         stdout=True,
         fdout=None,
-        print_func=logging.info,
+        print_func=print,  # noqa: T002
         file_format="markdown",
     ):
         """Print out the performance scores (over multiple runs)"""

--- a/kale/utils/csv_logger.py
+++ b/kale/utils/csv_logger.py
@@ -172,7 +172,7 @@ class XpResults:
         return True
 
     def remove(self, method_names):
-        print(method_names)
+        logging.info(method_names)
         self._df = self._df[~self._df["method"].isin(method_names)]
 
     def update(self, is_validation, method_name, seed, metric_values):
@@ -223,7 +223,7 @@ class XpResults:
         split="Validation",
         stdout=True,
         fdout=None,
-        print_func=print,
+        print_func=logging.info,
         file_format="markdown",
     ):
         """Print out the performance scores (over multiple runs)"""
@@ -255,7 +255,7 @@ class XpResults:
             fd.write(param_to_str(test_params))
             # fd.write(xp.param_to_str(test_params))
             fd.write("\n")
-            print(" " * 10, "\t\t".join(self._metrics))
+            logging.info(" " * 10, "\t\t".join(self._metrics))
             fd.write("nseeds = ")
             fd.write(str(nseeds))
             fd.write("\n")
@@ -281,7 +281,7 @@ class XpResults:
             fd.write(param_to_str(test_params))
             # fd.write(xp.param_to_str(test_params))
             fd.write("\n")
-            print(" " * 10, "\t\t".join(self._metrics))
+            logging.info(" " * 10, "\t\t".join(self._metrics))
             fd.write("nseeds = ")
             fd.write(str(nseeds))
             fd.write("\n")

--- a/kale/utils/print.py
+++ b/kale/utils/print.py
@@ -3,17 +3,17 @@
 
 def tprint(*args):
     """Temporarily prints things on the screen so that it won't be flooded"""
-    print("\r", end="")
-    print(*args, end="")
+    print("\r", end="")  # noqa: T001
+    print(*args, end="")  # noqa: T001
 
 
-def pprint(*args):
+def pprint(*args):  # noqa: T004
     """Permanently prints things on the screen to have all info displayed"""
-    print("\r", end="")
-    print(*args)
+    print("\r", end="")  # noqa: T001
+    print(*args)  # noqa: T001
 
 
 def pprint_without_newline(*args):
     """Permanently prints things on the screen, separated by space rather than newline"""
-    print("\r", end="")
-    print(*args, end=" ")
+    print("\r", end="")  # noqa: T001
+    print(*args, end=" ")  # noqa: T001

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,8 +6,7 @@ universal=1
 
 [flake8]
 max-line-length = 120
-exclude = build #,examples
-# select = E,W,F  # Not to check, e.g. T001 print found
+exclude = build,examples
 ignore =
     E203  # whitespace before ':'. Opposite convention enforced by black
     E501  # line too long. Long-line code is reformated by black; remaining long lines in docstrings are OK

--- a/tests/context.py
+++ b/tests/context.py
@@ -11,7 +11,7 @@
 # from kale.predict import class_domain_nets, isonet, losses
 # from kale.prepdata import image_transform, prep_cmr, tensor_reshape, video_transform
 # from kale.utils import csv_logger, logger, seed
-
+import logging
 
 from kale.utils import seed
 
@@ -20,4 +20,5 @@ seed.set_seed(2020)
 """ These only work with the optional graph modules
 from kale.embed import gcn, gripnet
 """
-print("kale imported")
+logging.getLogger().setLevel(logging.INFO)
+logging.info("kale imported")


### PR DESCRIPTION
Fixes [card on flake8-print](https://github.com/pykale/pykale/projects/9#card-52928591)

### Description
As discussed, this PR replaces all `print` statements in `kale` API.
- Exception: `print` statements in `kale.utils.print` are kept. This module is purely a print utility so it will only be used when the user wants to `print`. What do you think?
- 8 .py files have changed and will need you to review whether the usage is proper (from [debug, info, warning, error and critical](https://docs.python.org/3/howto/logging.html#when-to-use-logging)), as assigned as below:
  - @sz144 : mpca.py, prep_cmr.py
  - @RaivoKoot : cifar_access.py, video_datasets.py
  - @XianyuanLiu : csv_logger.py, print.py
  - @pz-white : general checking please
  - context.py in `tests` will be replaced in future with more complete test modules.
  - flake8-print should be automatically installed by pre-commit. I will keep an eye on it.
- The contribution guidelines and configuration files have been updated respectively.
- `print` statements in `Examples` are NOT checked as discussed.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).