### PR TITLE
Automatically sort documented members by source order

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,7 +81,7 @@ exclude_patterns = ["_build", "**.ipynb_checkpoints"]
 html_theme = "sphinx_rtd_theme"
 
 # Automatically documented members are sorted by source order
-autodoc_member_order = 'bysource'
+autodoc_member_order = "bysource"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -80,6 +80,9 @@ exclude_patterns = ["_build", "**.ipynb_checkpoints"]
 # html_theme = 'alabaster'
 html_theme = "sphinx_rtd_theme"
 
+# Automatically documented members are sorted by source order
+autodoc_member_order = 'bysource'
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".

--- a/docs/source/kale.embed.rst
+++ b/docs/source/kale.embed.rst
@@ -22,7 +22,6 @@ kale.embed.seq\_nn module
    :undoc-members:
    :show-inheritance:
    :exclude-members:
-   :member-order: bysource
 
 kale.embed.gcn module
 ----------------------------
@@ -32,7 +31,6 @@ kale.embed.gcn module
    :undoc-members:
    :show-inheritance:
    :exclude-members: message, update
-   :member-order: bysource
 
 kale.embed.gripnet module
 ----------------------------
@@ -42,7 +40,6 @@ kale.embed.gripnet module
    :undoc-members:
    :show-inheritance:
    :exclude-members: message, update
-   :member-order: bysource
 
 
 kale.embed.image\_cnn module


### PR DESCRIPTION
### Description
Change doc config file and modify the default sorted method from alphabetical to source order.
### Status
Ready

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] In-line docstrings updated and documentation `docs` updated.
