### PR TITLE
Disable automatic docstring inheritance from parent class

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -80,8 +80,11 @@ exclude_patterns = ["_build", "**.ipynb_checkpoints"]
 # html_theme = 'alabaster'
 html_theme = "sphinx_rtd_theme"
 
-# Automatically documented members are sorted by source order
+# Automatically documented members are sorted by source order.
 autodoc_member_order = "bysource"
+
+# Disable automatic docstring inheritance from parents.
+autodoc_inherit_docstrings = False
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
### Description
Change doc config file and disable the docstring's automatic inheritance from parents.

### Status
**Ready**

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] In-line docstrings updated and documentation `docs` updated.
