### PR TITLE
only ci test multiple python versions on linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,15 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8]
-
+        exclude:
+          - os: macos-latest
+            python-version: "3.6"
+          - os: macos-latest
+            python-version: "3.7"
+          - os: windows-latest
+            python-version: "3.6"
+          - os: windows-latest
+            python-version: "3.7"
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python


### PR DESCRIPTION
Fixes #96 

### Description
Removes tests on platform-python version combinations that do not justify the time and complexity.

### Status
**Ready**

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/master/docs/source) manually updated for new API.
