### PR TITLE
Remove Development Status in meta info

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,6 @@ setup(
     license="MIT",
     keywords="machine learning, pytorch, deep learning, multimodal learning, transfer learning",
     classifiers=[
-        "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "Intended Audience :: Education",
         "Intended Audience :: Healthcare Industry",


### PR DESCRIPTION
### Description
Remove _Development Status_ in meta info appearing at [pypi.org](https://pypi.org/project/pykale/) so there is no need for future update since development status is obvious from version number.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).