### PR TITLE
Update reference to pykale master to pykale main

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,11 +13,11 @@
 [Review & merge](#review-and-merge-pull-requests) |
 [Release & management](#release-and-management)
 
-Thank you for your interest! You can contribute to the PyKale project in a wide range of ways listed above, from light to heavy involvements. You can also reach us via <a href="mailto:pykale-group&#64;sheffield.ac.uk">email</a> if needed. The participation in this open source project is subject to [Code of Conduct](https://github.com/pykale/pykale/blob/master/CODE_OF_CONDUCT.md).
+Thank you for your interest! You can contribute to the PyKale project in a wide range of ways listed above, from light to heavy involvements. You can also reach us via <a href="mailto:pykale-group&#64;sheffield.ac.uk">email</a> if needed. The participation in this open source project is subject to [Code of Conduct](https://github.com/pykale/pykale/blob/main/CODE_OF_CONDUCT.md).
 
 ## Light involvements (viewers/users)
 
-See the [ReadMe](https://github.com/pykale/pykale/blob/master/README.md) for installation instructions. Your contribution can start as light as asking questions.
+See the [ReadMe](https://github.com/pykale/pykale/blob/main/README.md) for installation instructions. Your contribution can start as light as asking questions.
 
 ### Ask questions
 
@@ -42,20 +42,20 @@ A maintainer with *write* access can [create a branch](https://docs.github.com/e
 Anyone can use the [*fork and pull* model](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-collaborative-development-models) to contribute code to PyKale:
 
 - [**Fork**](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) pykale (also see the [guide on forking projects](https://guides.github.com/activities/forking/)).
-  - Keep the fork master branch synced with `pykale:master` by [syncing a fork](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/syncing-a-fork).
+  - Keep the fork main branch synced with `pykale:main` by [syncing a fork](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/syncing-a-fork).
   - Install `pre-commit` to enforce style via `pip install pre-commit` and `pre-commit install` at the root.
-- [Create a branch](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-and-deleting-branches-within-your-repository) based on the *latest master* in your fork with a *descriptive* name on what you plan to do, e.g. to fix an issue, starting with the issue ticket number.
+- [Create a branch](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-and-deleting-branches-within-your-repository) based on the *latest main* in your fork with a *descriptive* name on what you plan to do, e.g. to fix an issue, starting with the issue ticket number.
   - Make changes to this branch using detailed commit messages and following the [coding style](#coding-style) below. In particular, do [**frequent commits**](https://docs.github.com/en/actions/guides/about-continuous-integration#about-continuous-integration) and **small-scale pull requests** to make them more focused and easier to review.
-  - [Sync your branch](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/syncing-your-branch) with the master frequently so that potential problems can be identified earlier.
-  - Document the update in [Google Style Python Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html). Update `docs` following [docs update steps](https://github.com/pykale/pykale/tree/master/docs). Build `docs` via `make html` and verify locally built documentations under `docs\build\html`.
+  - [Sync your branch](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/syncing-your-branch) with the main frequently so that potential problems can be identified earlier.
+  - Document the update in [Google Style Python Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html). Update `docs` following [docs update steps](https://github.com/pykale/pykale/tree/main/docs). Build `docs` via `make html` and verify locally built documentations under `docs\build\html`.
   - Build tests and do tests (not enforced yet, to be done).
-- Create a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) or [pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) or from the task branch above to the master branch `pykale:master` explaining the changes and choose reviewers, using a [template](#pull-request-template).
+- Create a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) or [pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) or from the task branch above to the main branch `pykale:main` explaining the changes and choose reviewers, using a [template](#pull-request-template).
   - A draft pull request helps start a conversation with collaborators in a draft state. It will not be reviewed or merged until you change the status to “Ready for review” near the bottom of your pull request.
   - View the [continuous integration (CI) status checks](https://github.com/pykale/pykale/actions). When the check messages say files are changed, they mean changes on their simulated environment, *NOT* on the branch. The problems are not fixed and you need to fix them as well as other reported errors locally.
   - You need to [address merge conflicts](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/addressing-merge-conflicts) if they arise. Resolve the conflicts locally.
   - After passing all CI checks and resolving the conflicts, you should [request a review](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/requesting-a-pull-request-review). If you know who is appropriate or like the [suggested reviewers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/requesting-a-pull-request-review#:~:text=Suggested%20reviewers%20are%20based%20on,review%20from%20the%20same%20reviewer.), request/assign that person. Otherwise, we will assign one shortly.
   - A reviewer will follow the [review and merge guidelines](#review-and-merge-pull-requests). The reviewer may discuss with you and request explanations/changes before merging.
-  - Merging to the master branch **requires** *ALL checks to pass* AND *at least one approving review*.
+  - Merging to the main branch **requires** *ALL checks to pass* AND *at least one approving review*.
 
 #### Before pull requests: pre-commit hooks
 
@@ -63,7 +63,7 @@ We set up several  [`pre-commit`](https://pre-commit.com/) hooks to ensure code 
 
 - Linting tools: [flake8](https://gitlab.com/pycqa/flake8), [black](https://github.com/psf/black), and [isort](https://github.com/timothycrosley/isort).
 - Static type analysis: [mypy](https://github.com/python/mypy) (to do, not yet active)
-- Other hooks as specified in [`.pre-commit-config.yaml`](https://github.com/pykale/pykale/blob/master/.pre-commit-config.yaml), such as restricting the largest file size to 300KB.
+- Other hooks as specified in [`.pre-commit-config.yaml`](https://github.com/pykale/pykale/blob/main/.pre-commit-config.yaml), such as restricting the largest file size to 300KB.
 
 You need to install pre-commit and the hooks from the root directory via
 
@@ -74,7 +74,7 @@ pre-commit install
 
 This will install the `pre-commit` hooks at `pykale\.git\hooks`, to be **triggered by each new commit** to automatically run them *over the files you commit*. In this way, problems can be detected and fixed early. Several **important** points to note:
 
-- Pre-commit hooks are configured in [`.pre-commit-config.yaml`](https://github.com/pykale/pykale/blob/master/.pre-commit-config.yaml). Only administrator should modify it.
+- Pre-commit hooks are configured in [`.pre-commit-config.yaml`](https://github.com/pykale/pykale/blob/main/.pre-commit-config.yaml). Only administrator should modify it.
 - These hooks, e.g.,  [black](https://black.readthedocs.io/en/stable/index.html) and [isort](https://pycqa.github.io/isort/), will **automatically fix** some problems for you by **changing the files**, so please check the changes after you trigger `commit`.
 - If your commits can not pass the above checks, read the error message to see what has been automatically fixed and what needs your manual fix, e.g. flake8 errors. Some flake8 errors may be fixed by some hooks so you can rerun the pre-commit (e.g. re-commit to trigger it) or just run flake8 to see the updated flake8 errors.
 
@@ -93,13 +93,13 @@ flake8 ./kale/embed/new_module.py # "flake8 ." do it for all files
 
 Run [black](https://black.readthedocs.io/en/stable/index.html) and [isort](https://pycqa.github.io/isort/) will fix the found problems automatically by modifying the files but they will be automatically run and you do *not* need to do it manually. Remaining [flake8](https://flake8.pycqa.org/en/latest/) or other errors need to be manually fixed.
 
-**Important**: Run these commands from the root directory so that the PyKale configuration files ([`setup.cfg`](https://github.com/pykale/pykale/blob/master/setup.cfg), [`pyproject.toml`](https://github.com/pykale/pykale/blob/master/pyproject.toml), and [`.pre-commit-config.yaml`](https://github.com/pykale/pykale/blob/master/.pre-commit-config.yaml)) are used for these tools. Otherwise, the default configurations will be used, which **differ** from the PyKale configurations and are consistent.
+**Important**: Run these commands from the root directory so that the PyKale configuration files ([`setup.cfg`](https://github.com/pykale/pykale/blob/main/setup.cfg), [`pyproject.toml`](https://github.com/pykale/pykale/blob/main/pyproject.toml), and [`.pre-commit-config.yaml`](https://github.com/pykale/pykale/blob/main/.pre-commit-config.yaml)) are used for these tools. Otherwise, the default configurations will be used, which **differ** from the PyKale configurations and are consistent.
 
-**IDE integration**: flake8 linting can be set up for both [VSCode](https://code.visualstudio.com/docs/python/linting) and [PyCharm](https://tirinox.ru/flake8-pycharm/) but you must use [`setup.cfg`](https://github.com/pykale/pykale/blob/master/setup.cfg) to configure it. In this way, you could fix linting errors on the go.
+**IDE integration**: flake8 linting can be set up for both [VSCode](https://code.visualstudio.com/docs/python/linting) and [PyCharm](https://tirinox.ru/flake8-pycharm/) but you must use [`setup.cfg`](https://github.com/pykale/pykale/blob/main/setup.cfg) to configure it. In this way, you could fix linting errors on the go.
 
 #### Automated GitHub workflows (continuous integration)
 
-For continuous integration (CI) and continuous deployment (CD), we use several [GitHub workflows (actions)](https://github.com/pykale/pykale/actions) that will be triggered upon a push or pull request as specified at [`pykale/.github/workflows/`](https://github.com/pykale/pykale/tree/master/.github/workflows)
+For continuous integration (CI) and continuous deployment (CD), we use several [GitHub workflows (actions)](https://github.com/pykale/pykale/actions) that will be triggered upon a push or pull request as specified at [`pykale/.github/workflows/`](https://github.com/pykale/pykale/tree/main/.github/workflows)
 
 - Build: install Python dependencies (set up)
 - Linting: run flake8 and pre-commit
@@ -124,7 +124,7 @@ We aim to design the core `kale` modules to be highly **reusable**, generic, and
 - Use [`logging`](https://docs.python.org/3/howto/logging.html#logging-basic-tutorial) instead of `print` to log messages. Users can choose the level via, e.g., `logging.getLogger().setLevel(logging.INFO)`. See the [benefits](https://stackoverflow.com/questions/6918493/in-python-why-use-logging-instead-of-print).
 - Include detailed docstrings in code for generating documentations, following the [Google Style Python Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
 - Highly reusable modules should go into `kale`. Highly data/example-specific code goes into `Examples`.
-- Configure learning systems using [YAML](https://en.wikipedia.org/wiki/YAML) following [YACS](https://github.com/rbgirshick/yacs). See our [examples](https://github.com/pykale/pykale/tree/master/examples).
+- Configure learning systems using [YAML](https://en.wikipedia.org/wiki/YAML) following [YACS](https://github.com/rbgirshick/yacs). See our [examples](https://github.com/pykale/pykale/tree/main/examples).
 - Use [PyTorch](https://pytorch.org/tutorials/) and [PyTorch Lightning](https://towardsdatascience.com/from-pytorch-to-pytorch-lightning-a-gentle-introduction-b371b7caaf09) ([Video](https://www.youtube.com/watch?v=QHww1JH7IDU)) as much as possible.
 - If high-quality existing code from other sources are used, add credit and license information at the top of the file.
 - Use pre-commit hooks to enforce consistent styles via [flake8](https://gitlab.com/pycqa/flake8), [black](https://github.com/psf/black), and [isort](https://github.com/timothycrosley/isort)), with common PyKale configuration files.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,4 +17,4 @@ On the right (delete these after selection):
 - [ ] Breaking change (fix or new feature that would cause existing functionality to change).
 - [ ] New tests added to cover the changes.
 - [ ] In-line docstrings updated.
-- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/master/docs/source) manually updated for new API.
+- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,9 +5,9 @@ name: docs
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   docs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,9 +5,9 @@ name: lint
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,9 @@ name: test
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://github.com/pykale/pykale/raw/master/docs/images/pykale_logo.png" width="5%" alt='project-monai'> PyKale
+  <img src="https://github.com/pykale/pykale/raw/main/docs/images/pykale_logo.png" width="5%" alt='project-pykale'> PyKale
 </p>
 
 -----------------------------------------
@@ -9,11 +9,11 @@
 [![PyPI version](https://img.shields.io/pypi/v/pykale?color=blue)](https://pypi.org/project/pykale/)
 [![PyPI downloads](https://pepy.tech/badge/pykale)](https://pepy.tech/project/pykale)
 
-[Getting Started](https://github.com/pykale/pykale/tree/master/examples) |
+[Getting Started](https://github.com/pykale/pykale/tree/main/examples) |
 [Documentation](https://pykale.readthedocs.io/) |
-[Contributing](https://github.com/pykale/pykale/blob/master/.github/CONTRIBUTING.md) |
+[Contributing](https://github.com/pykale/pykale/blob/main/.github/CONTRIBUTING.md) |
 [Discussions](https://github.com/pykale/pykale/discussions) |
-[Changelog](https://github.com/pykale/pykale/tree/master/.github/CHANGELOG.md)
+[Changelog](https://github.com/pykale/pykale/tree/main/.github/CHANGELOG.md)
 
  PyKale is a [PyTorch](https://pytorch.org/) library for [multimodal learning](https://en.wikipedia.org/wiki/Multimodal_learning) and [transfer learning](https://en.wikipedia.org/wiki/Transfer_learning) as well as [deep learning](https://en.wikipedia.org/wiki/Deep_learning) and [dimensionality reduction](https://en.wikipedia.org/wiki/Dimensionality_reduction) on graphs, images, texts, and videos. By adopting a unified *pipeline-based* API design, PyKale enforces *standardization* and *minimalism*, via *reusing* existing resources, *reducing* repetitions and redundancy, and *recycling* learning models across areas. PyKale aims to facilitate *interdisciplinary*, *knowledge-aware* machine learning research for graphs, images, texts, and videos in applications including bioinformatics, graph analysis, image/video recognition, and medical imaging. It focuses on leveraging knowledge from multiple sources for accurate and *interpretable* prediction. See a [12-minute introduction video on YouTube](https://youtu.be/i5BYdMfbpMQ).
 
@@ -43,7 +43,7 @@ For more details and other options, please refer to [the installation guide](htt
 
 ## Examples, Tutorials, and Discussions
 
-See our numerous [**examples (and tutorials)**](https://github.com/pykale/pykale/tree/master/examples) on how to perform various prediction tasks in a wide range of applications using PyKale.
+See our numerous [**examples (and tutorials)**](https://github.com/pykale/pykale/tree/main/examples) on how to perform various prediction tasks in a wide range of applications using PyKale.
 
 Ask and answer questions on [PyKale's GitHub Discussions tab](https://github.com/pykale/pykale/discussions).
 
@@ -53,9 +53,9 @@ We appreciate all contributions. You can contribute in three ways:
 
 - [Star](https://docs.github.com/en/github/getting-started-with-github/saving-repositories-with-stars) and [fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) PyKale to follow its latest developments, share it with your networks, and [ask questions](https://github.com/pykale/pykale/discussions)  about it.
 - Use PyKale in your project and let us know any bugs (& fixes) and feature requests/suggestions via creating an [issue](https://github.com/pykale/pykale/issues).
-- Contribute via [branch, fork, and pull](https://github.com/pykale/pykale/blob/master/CONTRIBUTING.md#branch-fork-and-pull) for minor fixes and new features, functions, or examples to become one of the [contributors](https://github.com/pykale/pykale/graphs/contributors).
+- Contribute via [branch, fork, and pull](https://github.com/pykale/pykale/blob/main/CONTRIBUTING.md#branch-fork-and-pull) for minor fixes and new features, functions, or examples to become one of the [contributors](https://github.com/pykale/pykale/graphs/contributors).
 
-See [contributing guidelines](https://github.com/pykale/pykale/blob/master/.github/CONTRIBUTING.md) for more details. You can also reach us via <a href="mailto:pykale-group&#64;sheffield.ac.uk">email</a> if needed. The participation in this open source project is subject to [Code of Conduct](https://github.com/pykale/pykale/blob/master/.github/CODE_OF_CONDUCT.md).
+See [contributing guidelines](https://github.com/pykale/pykale/blob/main/.github/CONTRIBUTING.md) for more details. You can also reach us via <a href="mailto:pykale-group&#64;sheffield.ac.uk">email</a> if needed. The participation in this open source project is subject to [Code of Conduct](https://github.com/pykale/pykale/blob/main/.github/CODE_OF_CONDUCT.md).
 
 ## The Team
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,10 +31,10 @@ The core APIs above are ordered following the machine learning pipeline rather t
     :maxdepth: 1
     :caption: Example Projects
 
-	CIFAR - CNN Transformer <https://github.com/pykale/pykale/tree/master/examples/cifar_cnntransformer>
-	VIDEOS - Data Loading <https://github.com/pykale/pykale/tree/master/examples/video_loading>
-	CIFAR - ISONet <https://github.com/pykale/pykale/tree/master/examples/cifar_isonet>
-	Digits - Domain Adaptation <https://github.com/pykale/pykale/tree/master/examples/digits_dann_lightn>
+	CIFAR - CNN Transformer <https://github.com/pykale/pykale/tree/main/examples/cifar_cnntransformer>
+	VIDEOS - Data Loading <https://github.com/pykale/pykale/tree/main/examples/video_loading>
+	CIFAR - ISONet <https://github.com/pykale/pykale/tree/main/examples/cifar_isonet>
+	Digits - Domain Adaptation <https://github.com/pykale/pykale/tree/main/examples/digits_dann_lightn>
 
 .. To study later the best way to document examples
 .. examples/examples.cifar_cnntransformer

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -8,11 +8,11 @@ These guidelines will help you to write tests to address sufficiently compact pi
 
 - [Compact pytest tutorial](https://www.tutorialspoint.com/pytest/pytest_tutorial.pdf), [pytest fixtures](https://docs.pytest.org/en/stable/fixture.html), [pytest exceptions](https://docs.pytest.org/en/stable/assert.html#assertions-about-expected-exceptions)
 - Example [unit tests for deep learning code of Variational Autoencoder (VAE) in PyTorch](https://github.com/tilman151/unittest_dl) and the associated post [How to Trust Your Deep Learning Code](https://krokotsch.eu/cleancode/2020/08/11/Unit-Tests-for-Deep-Learning.html). *Note: it uses `unittest` but we use `pytest`*.
-- Learn from [existing pykale tests](https://github.com/pykale/pykale/tree/master/tests) (particularly recent ones) and pytest+pytorch examples [fastai1 tests](https://github.com/fastai/fastai1/tree/master/tests) and [Kornia tests](https://github.com/kornia/kornia/tree/master/test)
+- Learn from [existing pykale tests](https://github.com/pykale/pykale/tree/main/tests) (particularly recent ones) and pytest+pytorch examples [fastai1 tests](https://github.com/fastai/fastai1/tree/master/tests) and [Kornia tests](https://github.com/kornia/kornia/tree/master/test)
 - Use GitHub code links to find out definitions and references
 - Consider to use [pytest in vscode](https://code.visualstudio.com/docs/python/testing) or [pytest in pycharm](https://www.jetbrains.com/help/pycharm/pytest.html)
 - [fastai testing](https://fastai1.fast.ai/dev/test.html) is a good high-level reference. We adapt its recommendations on [writing tests](https://fastai1.fast.ai/dev/test.html#writing-tests) below:
-  - Think about how to create a test of the real functionality that runs quickly, e.g. based on our [`examples`](https://github.com/pykale/pykale/tree/master/examples).
+  - Think about how to create a test of the real functionality that runs quickly, e.g. based on our [`examples`](https://github.com/pykale/pykale/tree/main/examples).
   - Use module scope fixtures to run initial code that can be shared amongst tests. When using fixtures, make sure the test doesn’t modify the global object it received. If there's a risk of modifying a broadly scoped fixture, you could clone it with a more tightly scoped fixture or create a fresh fixture/object instead.
   - Avoid pretrained models, since they have to be downloaded from the internet to run the test.
   - Create some minimal data for your test, or use data already in repo’s data/ directory.
@@ -21,7 +21,7 @@ See more details below, particularly [test data](#test-data), [common parameters
 
 ## Test data
 
-Data needed for testing should be placed in [`tests/test_data`](https://github.com/pykale/pykale/tree/master/tests/test_data). Only small files (current limit: 300KB) should be uploaded directly. Larger data should be **automatically downloaded** during tests from external sources to `tests/test_data/download` as defined in [`tests/conftest.py`](https://github.com/pykale/pykale/blob/master/tests/conftest.py). Such data will be kept local, as set in [`.gitignore`](https://github.com/pykale/pykale/blob/master/.gitignore). Discuss more complex test data requirements for your **pull request** in the motivating **issue** or [pykale discussions on testing](https://github.com/pykale/pykale/discussions/categories/testing).
+Data needed for testing should be placed in [`tests/test_data`](https://github.com/pykale/pykale/tree/main/tests/test_data). Only small files (current limit: 300KB) should be uploaded directly. Larger data should be **automatically downloaded** during tests from external sources to `tests/test_data/download` as defined in [`tests/conftest.py`](https://github.com/pykale/pykale/blob/main/tests/conftest.py). Such data will be kept local, as set in [`.gitignore`](https://github.com/pykale/pykale/blob/main/.gitignore). Discuss more complex test data requirements for your **pull request** in the motivating **issue** or [pykale discussions on testing](https://github.com/pykale/pykale/discussions/categories/testing).
 
 ## Common parameters
 


### PR DESCRIPTION
### Description
Update reference to pykale master to pykale main after we renamed our default branch to main.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).