### PR TITLE
Add concord_index calculation into DeepDTA

### DIFF
--- a/kale/evaluate/metrics.py
+++ b/kale/evaluate/metrics.py
@@ -1,4 +1,4 @@
-def c_index(y, y_pred):
+def concord_index(y, y_pred):
     """
     Calculate the Concordance Index (CI), which is a metric to measure the proportion of `concordant pairs
     <https://en.wikipedia.org/wiki/Concordant_pair>`_ between real and

--- a/tests/pipeline/test_deep_dti.py
+++ b/tests/pipeline/test_deep_dti.py
@@ -21,7 +21,7 @@ def test_deep_data(download_path):
     decoder = MLPDecoder(in_dim=192, hidden_dim=16, out_dim=16)
     # test deep_dta trainer
     save_parameters = {"seed": 2020, "batch_size": 256}
-    model = DeepDTATrainer(drug_encoder, target_encoder, decoder, lr=0.001, **save_parameters).eval()
+    model = DeepDTATrainer(drug_encoder, target_encoder, decoder, lr=0.001, ci_metric=True, **save_parameters).eval()
     assert isinstance(model.drug_encoder, CNNEncoder)
     assert isinstance(model.target_encoder, CNNEncoder)
     assert isinstance(model.decoder, MLPDecoder)
@@ -33,7 +33,7 @@ def test_deep_data(download_path):
         assert "log_metrics" in str(excinfo.value)
 
     # test base_dta trainer
-    model = BaseDTATrainer(drug_encoder, target_encoder, decoder, lr=0.001, **save_parameters).eval()
+    model = BaseDTATrainer(drug_encoder, target_encoder, decoder, lr=0.001, ci_metric=True, **save_parameters).eval()
     with pytest.raises(NotImplementedError) as excinfo:
         model.training_step(test_batch, 0)
         assert "Forward pass needs to be defined" in str(excinfo.value)


### PR DESCRIPTION
### Description
- Add CI calculation into deep_dti pipeline
- Add CI metric test case (test_deep_dti)
- Rename c_index to concord_index
- Add default lr value

### Status
**Ready*

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] In-line docstrings updated.
