### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
### Description
Enable dependabot for pykale. Once enabled, we will continue to investigate how best to use dependabot to ensure that pykale tests run with newer versions of dependencies as they are released. See https://github.com/pykale/pykale/network/dependencies for insights on current dependencies.

### Status
**Ready**

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).

