### PR TITLE
Add Google Drive Download API

### DIFF
--- a/examples/video_loading/main.py
+++ b/examples/video_loading/main.py
@@ -4,39 +4,13 @@ import matplotlib.pyplot as plt
 import torch
 from mpl_toolkits.axes_grid1 import ImageGrid
 from torchvision import transforms
-from torchvision.datasets.utils import download_file_from_google_drive, extract_archive
 
 from kale.loaddata.videos import VideoFrameDataset
 from kale.prepdata.video_transform import ImglistToTensor
+from kale.utils.download import download_file_gdrive
 
 """
 Ignore this function and look at "main" below.
-"""
-
-
-def download_dummy_dataset():
-    # Full File URL: https://drive.google.com/file/d/1U4D23R8u8MJX9KVKb92bZZX-tbpKWtga/view?usp=sharing
-    gdrive_file_id = "1U4D23R8u8MJX9KVKb92bZZX-tbpKWtga"
-    output_directory = os.path.join(os.getcwd())
-    output_file_name = "demo_datasets.zip"
-
-    print("Downloading Dummy Datasets")
-    download_file_from_google_drive(gdrive_file_id, output_directory, output_file_name)
-
-    if os.path.exists(os.path.join(os.getcwd(), "demo_dataset")):
-        print("Skipping Download and Extraction")
-        return
-
-    print("Extracting Dummy Dataset")
-    zip_file = os.path.join(os.getcwd(), output_file_name)
-    extract_archive(zip_file)
-
-    print("Datasets downloaded and extracted. Run this program again to run the demo.")
-    exit()
-
-
-"""
-Ignore this function too
 """
 
 
@@ -69,7 +43,12 @@ if __name__ == "__main__":
     5. Demo of using a dataset where samples have multiple separate class labels
 
     """
-    download_dummy_dataset()
+    download_file_gdrive(
+        id="1U4D23R8u8MJX9KVKb92bZZX-tbpKWtga",
+        output_directory=os.path.join(os.getcwd()),
+        output_file_name="demo_datasets.zip",
+        file_format=".zip",
+    )
 
     videos_root = os.path.join(os.getcwd(), "demo_dataset")
     annotation_file = os.path.join(videos_root, "annotations.txt")

--- a/kale/utils/download.py
+++ b/kale/utils/download.py
@@ -69,6 +69,9 @@ def download_file_gdrive(id, output_directory, output_file_name, file_format=Non
     Example:
         >>> gdrive_id = "1U4D23R8u8MJX9KVKb92bZZX-tbpKWtga"
         >>> download_file_gdrive(gdrive_id, "data", "demo_datasets.zip", "zip")
+
+        >>> gdrive_id = "1SV7fmAnWj-6AU9X5BGOrvGMoh2Gu9Nih"
+        >>> download_file_gdrive(gdrive_id, "data", "dummy_data.csv", "csv")
     """
 
     output_directory = Path(output_directory).absolute()

--- a/kale/utils/download.py
+++ b/kale/utils/download.py
@@ -17,7 +17,7 @@ from torch.hub import download_url_to_file
 from torchvision.datasets.utils import download_and_extract_archive, download_file_from_google_drive, extract_archive
 
 
-def download_file_by_url(url, output_directory, output_file_name, file_format):
+def download_file_by_url(url, output_directory, output_file_name, file_format=None):
     """Download file/compressed file by url.
 
     Args:
@@ -66,7 +66,11 @@ def download_file_gdrive(id, output_directory, output_file_name, file_format=Non
         file_format (string, optional): File format
                                 For compressed file, support ["tar.xz", "tar", "tar.gz", "tgz", "gz", "zip"]
 
+    Example:
+        >>> gdrive_id = "1U4D23R8u8MJX9KVKb92bZZX-tbpKWtga"
+        >>> download_file_gdrive(gdrive_id, "data", "demo_datasets.zip", "zip")
     """
+
     output_directory = Path(output_directory).absolute()
     file = Path(output_directory).joinpath(output_file_name)
     if os.path.exists(file):
@@ -74,12 +78,12 @@ def download_file_gdrive(id, output_directory, output_file_name, file_format=Non
         return
     os.makedirs(output_directory, exist_ok=True)
 
+    logging.info("Downloading {}.".format(output_file_name))
+    download_file_from_google_drive(id, output_directory, output_file_name)
+
     if file_format is not None and file_format in ["tar.xz", "tar", "tar.gz", "tgz", "gz", "zip"]:
         logging.info("Downloading and extracting {}.".format(output_file_name))
-        download_file_from_google_drive(id, output_directory, output_file_name)
         extract_archive(file.as_posix())
         logging.info("Datasets downloaded and extracted in {}".format(file))
     else:
-        logging.info("Downloading {}.".format(output_file_name))
-        download_file_from_google_drive(id, output_directory, output_file_name)
         logging.info("Datasets downloaded in {}".format(file))

--- a/kale/utils/download.py
+++ b/kale/utils/download.py
@@ -28,7 +28,7 @@ def download_file_by_url(url, output_directory, output_file_name, file_format):
         file_format (string, optional): File format
                                 For compressed file, support ["tar.xz", "tar", "tar.gz", "tgz", "gz", "zip"]
 
-    Example:
+    Example: (Grab the raw link from GitHub. Notice that using "raw" in the URL.)
         >>> url = "https://github.com/pykale/data/raw/main/video_data/video_test_data/ADL/annotations/labels_train_test/adl_P_04_train.pkl"
         >>> download_file_by_url(url, "data", "a.pkl", "pkl")
 

--- a/kale/utils/download.py
+++ b/kale/utils/download.py
@@ -14,7 +14,7 @@ import os
 from pathlib import Path
 
 from torch.hub import download_url_to_file
-from torchvision.datasets.utils import download_and_extract_archive
+from torchvision.datasets.utils import download_and_extract_archive, download_file_from_google_drive, extract_archive
 
 
 def download_file_by_url(url, output_directory, output_file_name, file_format):
@@ -52,4 +52,34 @@ def download_file_by_url(url, output_directory, output_file_name, file_format):
     else:
         logging.info("Downloading {}.".format(output_file_name))
         download_url_to_file(url, file)
+        logging.info("Datasets downloaded in {}".format(file))
+
+
+def download_file_gdrive(id, output_directory, output_file_name, file_format=None):
+    """Download file/compressed file by google drive id.
+
+    Args:
+        id (string): Google Drive file id of the object to download
+        output_directory (string, optional): Full path where object will be saved
+                                             Abosolute path recommended. Relative path also works.
+        output_file_name (string, optional): File name which object will be saved as
+        file_format (string, optional): File format
+                                For compressed file, support ["tar.xz", "tar", "tar.gz", "tgz", "gz", "zip"]
+
+    """
+    output_directory = Path(output_directory).absolute()
+    file = Path(output_directory).joinpath(output_file_name)
+    if os.path.exists(file):
+        logging.info("Skipping Download and Extraction")
+        return
+    os.makedirs(output_directory, exist_ok=True)
+
+    if file_format is not None and file_format in ["tar.xz", "tar", "tar.gz", "tgz", "gz", "zip"]:
+        logging.info("Downloading and extracting {}.".format(output_file_name))
+        download_file_from_google_drive(id, output_directory, output_file_name)
+        extract_archive(file)
+        logging.info("Datasets downloaded and extracted in {}".format(file))
+    else:
+        logging.info("Downloading {}.".format(output_file_name))
+        download_file_from_google_drive(id, output_directory, output_file_name)
         logging.info("Datasets downloaded in {}".format(file))

--- a/kale/utils/download.py
+++ b/kale/utils/download.py
@@ -85,7 +85,7 @@ def download_file_gdrive(id, output_directory, output_file_name, file_format=Non
     download_file_from_google_drive(id, output_directory, output_file_name)
 
     if file_format is not None and file_format in ["tar.xz", "tar", "tar.gz", "tgz", "gz", "zip"]:
-        logging.info("Downloading and extracting {}.".format(output_file_name))
+        logging.info("Extracting {}.".format(output_file_name))
         extract_archive(file.as_posix())
         logging.info("Datasets downloaded and extracted in {}".format(file))
     else:

--- a/kale/utils/download.py
+++ b/kale/utils/download.py
@@ -56,7 +56,7 @@ def download_file_by_url(url, output_directory, output_file_name, file_format=No
 
 
 def download_file_gdrive(id, output_directory, output_file_name, file_format=None):
-    """Download file/compressed file by google drive id.
+    """Download file/compressed file by Google Drive id.
 
     Args:
         id (string): Google Drive file id of the object to download

--- a/kale/utils/download.py
+++ b/kale/utils/download.py
@@ -77,7 +77,7 @@ def download_file_gdrive(id, output_directory, output_file_name, file_format=Non
     if file_format is not None and file_format in ["tar.xz", "tar", "tar.gz", "tgz", "gz", "zip"]:
         logging.info("Downloading and extracting {}.".format(output_file_name))
         download_file_from_google_drive(id, output_directory, output_file_name)
-        extract_archive(file)
+        extract_archive(file.as_posix())
         logging.info("Datasets downloaded and extracted in {}".format(file))
     else:
         logging.info("Downloading {}.".format(output_file_name))

--- a/tests/utils/test_download.py
+++ b/tests/utils/test_download.py
@@ -13,6 +13,7 @@ PARAM = [
 
 GDRIVE_PARAM = [
     "1U4D23R8u8MJX9KVKb92bZZX-tbpKWtga;demo_datasets.zip;zip",
+    "1SV7fmAnWj-6AU9X5BGOrvGMoh2Gu9Nih;dummy_data.csv;csv",
 ]
 
 

--- a/tests/utils/test_download.py
+++ b/tests/utils/test_download.py
@@ -3,12 +3,16 @@ from pathlib import Path
 
 import pytest
 
-from kale.utils.download import download_file_by_url
+from kale.utils.download import download_file_by_url, download_file_gdrive
 
 output_directory = Path().absolute().parent.joinpath("test_data/download")
 PARAM = [
     " https://github.com/pykale/data/raw/main/video_data/video_test_data/ADL/annotations/labels_train_test/adl_P_11_train.pkl;a.pkl;pkl",
     " https://github.com/pykale/data/raw/main/video_data/video_test_data.zip;video_test_data.zip;zip",
+]
+
+GDRIVE_PARAM = [
+    "1U4D23R8u8MJX9KVKb92bZZX-tbpKWtga;demo_datasets.zip;zip",
 ]
 
 
@@ -19,5 +23,16 @@ def test_download_file_by_url(param):
     # run twice to test the code when the file exist
     download_file_by_url(url, output_directory, output_file_name, file_format)
     download_file_by_url(url, output_directory, output_file_name, file_format)
+
+    assert os.path.exists(output_directory.joinpath(output_file_name)) is True
+
+
+@pytest.mark.parametrize("param", GDRIVE_PARAM)
+def test_download_file_gdrive(param):
+    id, output_file_name, file_format = param.split(";")
+
+    # run twice to test the code when the file exist
+    download_file_gdrive(id, output_directory, output_file_name, file_format)
+    download_file_gdrive(id, output_directory, output_file_name, file_format)
 
     assert os.path.exists(output_directory.joinpath(output_file_name)) is True


### PR DESCRIPTION
Fixes https://github.com/pykale/pykale/issues/182.

### Description
Adds drive download function from [video loading example](https://github.com/pykale/pykale/blob/main/examples/video_loading/main.py) to core API for better reusability. API allows easier download of google drive files from their ids.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
