### PR TITLE
Multi domain loader and office data access

### DIFF
--- a/docs/source/kale.loaddata.rst
+++ b/docs/source/kale.loaddata.rst
@@ -102,6 +102,14 @@ kale.loaddata.video\_multi\_domain module
    :undoc-members:
    :show-inheritance:
 
+kale.loaddata.office\_access
+------------------------------------------
+
+.. automodule:: kale.loaddata.office_access
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Module contents
 ---------------
 

--- a/kale/loaddata/dataset_access.py
+++ b/kale/loaddata/dataset_access.py
@@ -39,10 +39,8 @@ class DatasetAccess:
             Dataset: a torch.utils.data.Dataset
         """
         train_dataset = self.get_train()
-        ntotal = len(train_dataset)
-        ntrain = int((1 - val_ratio) * ntotal)
 
-        return torch.utils.data.random_split(train_dataset, [ntrain, ntotal - ntrain])
+        return split_by_ratios(train_dataset, [val_ratio])
 
     def get_test(self):
         raise NotImplementedError()
@@ -58,3 +56,18 @@ def get_class_subset(dataset, class_ids):
     """
     sub_indices = [i for i in range(0, len(dataset)) if dataset[i][1] in class_ids]
     return torch.utils.data.Subset(dataset, sub_indices)
+
+
+def split_by_ratios(dataset, split_ratios):
+    n_total = len(dataset)
+    ratio_sum = sum(split_ratios)
+    if ratio_sum > 1 or ratio_sum <= 0:
+        raise ValueError("The sum of ratios should be in range(0, 1]")
+    elif ratio_sum == 1:
+        split_ratios_ = split_ratios[:-1]
+    else:
+        split_ratios_ = split_ratios.copy()
+    split_sizes = [int(n_total * ratio_) for ratio_ in split_ratios_]
+    split_sizes.append(n_total - sum(split_sizes))
+
+    return torch.utils.data.random_split(dataset, split_sizes)

--- a/kale/loaddata/multi_domain.py
+++ b/kale/loaddata/multi_domain.py
@@ -3,12 +3,15 @@ Construct a dataset with (multiple) source and target domains, from https://gith
 """
 
 import logging
+import os
 from enum import Enum
-from typing import Dict
+from typing import Any, Callable, cast, Dict, List, Optional, Tuple
 
 import numpy as np
 import torch.utils.data
 from sklearn.utils import check_random_state
+from torchvision.datasets import VisionDataset
+from torchvision.datasets.folder import default_loader, has_file_allowed_extension, IMG_EXTENSIONS
 
 from kale.loaddata.dataset_access import DatasetAccess, get_class_subset
 from kale.loaddata.sampler import get_labels, MultiDataLoader, SamplingConfig
@@ -229,3 +232,174 @@ def _split_dataset_few_shot(dataset, n_fewshot, random_state=None):
     labeled_dataset = torch.utils.data.Subset(dataset, tindices)
     unlabeled_dataset = torch.utils.data.Subset(dataset, uindices)
     return labeled_dataset, unlabeled_dataset
+
+
+class MultiDomainImageFolder(VisionDataset):
+    """A generic data loader where the samples are arranged in this way: ::
+            root/domain_a/class_x/xxx.ext
+            root/domain_a/class_x/xxy.ext
+            ...
+            root/domain_a/class_y/xxz.ext
+            ...
+            root/domain_k/class_x/123.ext
+            root/domain_k/class_x/abc3.ext
+            ...
+            root/domain_k/class_y/asd932_.ext
+        Args:
+            root (string): Root directory path.
+            loader (callable): A function to load a sample given its path.
+            extensions (tuple[string]): A list of allowed extensions.
+                both extensions and is_valid_file should not be passed.
+            transform (callable, optional): A function/transform that takes in
+                a sample and returns a transformed version.
+                E.g, ``transforms.RandomCrop`` for images.
+            target_transform (callable, optional): A function/transform that takes
+                in the target and transforms it.
+            is_valid_file (callable, optional): A function that takes path of a file
+                and check if the file is a valid file (used to check of corrupt files)
+                both extensions and is_valid_file should not be passed.
+         Attributes:
+            classes (list): List of the class names sorted alphabetically.
+            class_to_idx (dict): Dict with items (class_name, class_index).
+            samples (list): List of (sample path, class_index) tuples
+            targets (list): The class_index value for each image in the dataset
+            domains (list): List of the domain names sorted alphabetically.
+            domain_to_idx (dict): Dict with items (domain_name, domain_index).
+            domain_labels (list): The domain_index value for each image in the dataset
+        """
+
+    def __init__(
+        self,
+        root: str,
+        loader: Callable[[str], Any] = default_loader,
+        extensions: Optional[Tuple[str, ...]] = IMG_EXTENSIONS,
+        transform: Optional[Callable] = None,
+        target_transform: Optional[Callable] = None,
+        domains: Optional[List] = None,
+        is_valid_file: Optional[Callable[[str], bool]] = None,
+        return_domain_label: Optional[bool] = False,
+    ) -> None:
+        super(MultiDomainImageFolder, self).__init__(root, transform=transform, target_transform=target_transform)
+        domains_, domain_to_idx = self._find_classes(self.root)
+        if type(domains) == list:
+            for domain_name in domains:
+                if domain_name not in domains_:
+                    raise ValueError("Domain %s not in the image directory" % domain_name)
+            domain_to_idx = {domain_name: i for i, domain_name in enumerate(domains)}
+        elif domains is None:
+            domains = domains_
+        else:
+            raise ValueError("Unsupported type for variable domains")
+        classes, class_to_idx = self._find_classes(os.path.join(self.root, domains[0]))
+        for domain in domains:
+            domain_path = os.path.join(self.root, domain)
+            classes_, class_to_idx_ = self._find_classes(domain_path)
+            if not classes == classes_:
+                raise ValueError("Classes for different domains are expected to be the same.")
+        samples = make_multi_domain_set(self.root, class_to_idx, domain_to_idx, extensions, is_valid_file)
+        if len(samples) == 0:
+            msg = "Found 0 files in sub-folders of: {}\n".format(self.root)
+            if extensions is not None:
+                msg += "Supported extensions are: {}".format(",".join(extensions))
+            raise RuntimeError(msg)
+
+        self.loader = loader
+        self.extensions = extensions
+
+        self.classes = classes
+        self.class_to_idx = class_to_idx
+        self.samples = samples
+        self.targets = [s[1] for s in samples]
+        self.domains = domains
+        self.domain_to_idx = domain_to_idx
+        self.domain_labels = [s[2] for s in samples]
+        self.return_domain_label = return_domain_label
+
+    @staticmethod
+    def _find_classes(directory: str) -> Tuple[List[str], Dict[str, int]]:
+        """
+            Finds the class folders in a dataset.
+            Args:
+                directory (string): Directory path.
+            Returns:
+                tuple: (classes, class_to_idx) where classes are relative to (dir), and class_to_idx is a dictionary.
+            Ensures:
+                No class is a subdirectory of another.
+            """
+        classes = [d.name for d in os.scandir(directory) if d.is_dir()]
+        classes.sort()
+        class_to_idx = {cls_name: i for i, cls_name in enumerate(classes)}
+        return classes, class_to_idx
+
+    def __getitem__(self, index: int) -> Tuple:
+        """
+            Args:
+                index (int): Index
+            Returns:
+                tuple: (sample, target, domain) where target is class_index of the target class.
+            """
+        path, target, domain = self.samples[index]
+        sample = self.loader(path)
+        if self.transform is not None:
+            sample = self.transform(sample)
+        if self.target_transform is not None:
+            target = self.target_transform(target)
+        if self.return_domain_label:
+            return sample, target, domain
+        else:
+            return sample, target
+
+    def __len__(self) -> int:
+        return len(self.samples)
+
+
+def make_multi_domain_set(
+    directory: str,
+    class_to_idx: Dict[str, int],
+    domain_to_idx: Dict[str, int],
+    extensions: Optional[Tuple[str, ...]] = None,
+    is_valid_file: Optional[Callable[[str], bool]] = None,
+) -> List[Tuple[str, int, int]]:
+    """Generates a list of samples of a form (path_to_sample, class, domain).
+    Args:
+        directory (str): root dataset directory
+        class_to_idx (Dict[str, int]): dictionary mapping class name to class index
+        domain_to_idx (Dict[str, int]): dictionary mapping d name to class index
+        extensions (optional): A list of allowed extensions.
+            Either extensions or is_valid_file should be passed. Defaults to None.
+        is_valid_file (optional): A function that takes path of a file
+            and checks if the file is a valid file
+            (used to check of corrupt files) both extensions and
+            is_valid_file should not be passed. Defaults to None.
+    Raises:
+        ValueError: In case ``extensions`` and ``is_valid_file`` are None or both are not None.
+    Returns:
+        List[Tuple[str, int, int]]: samples of a form (path_to_sample, class, domain)
+    """
+    instances = []
+    directory = os.path.expanduser(directory)
+    both_none = extensions is None and is_valid_file is None
+    both_something = extensions is not None and is_valid_file is not None
+    if both_none or both_something:
+        raise ValueError("Both extensions and is_valid_file cannot be None or not None at the same time")
+    if extensions is not None:
+
+        def is_valid_file(x: str) -> bool:
+            return has_file_allowed_extension(x, cast(Tuple[str, ...], extensions))
+
+    is_valid_file = cast(Callable[[str], bool], is_valid_file)
+    for target_domain in sorted(domain_to_idx.keys()):
+        domain_index = domain_to_idx[target_domain]
+        domain_dir = os.path.join(directory, target_domain)
+        for target_class in sorted(class_to_idx.keys()):
+            class_index = class_to_idx[target_class]
+            target_dir = os.path.join(domain_dir, target_class)
+            if not os.path.isdir(target_dir):
+                continue
+            for root, _, fnames in sorted(os.walk(target_dir, followlinks=True)):
+                for fname in sorted(fnames):
+                    path = os.path.join(root, fname)
+                    if is_valid_file(path):
+                        item = path, class_index, domain_index
+                        instances.append(item)
+    return instances

--- a/kale/loaddata/office_access.py
+++ b/kale/loaddata/office_access.py
@@ -1,10 +1,10 @@
-import os
 import logging
-from kale.loaddata.multi_domain import MultiDomainImageFolder
-from kale.utils.download import download_file_by_url
-from kale.prepdata.image_transform import get_transform
-from kale.loaddata.dataset_access import DatasetAccess
+import os
 
+from kale.loaddata.dataset_access import DatasetAccess
+from kale.loaddata.multi_domain import MultiDomainImageFolder
+from kale.prepdata.image_transform import get_transform
+from kale.utils.download import download_file_by_url
 
 url = "https://github.com/sz144/data/raw/main/image_data/office/"
 DOMAINS = ["amazon", "caltech", "dslr", "webcam"]
@@ -43,14 +43,26 @@ class OfficeAccess(MultiDomainImageFolder, DatasetAccess):
 
 class Office31(OfficeAccess):
     def __init__(self, root, transform=office_transform, download=False, **kwargs):
-        sub_domain_set = ['amazon', 'dslr', 'webcam']
-        super(Office31, self).__init__(root, transform=transform, download=download, sub_domain_set=sub_domain_set,
-                                       **kwargs)
+        sub_domain_set = ["amazon", "dslr", "webcam"]
+        super(Office31, self).__init__(
+            root, transform=transform, download=download, sub_domain_set=sub_domain_set, **kwargs
+        )
 
 
 class OfficeCaltech(OfficeAccess):
     def __init__(self, root, transform=office_transform, download=False, **kwargs):
-        sub_class_set = ["mouse", "calculator", "back_pack", "keyboard", "monitor", "projector", "headphones", "bike",
-                         "laptop_computer", "mug"]
-        super(OfficeCaltech, self).__init__(root, transform=transform, download=download, sub_class_set=sub_class_set,
-                                            **kwargs)
+        sub_class_set = [
+            "mouse",
+            "calculator",
+            "back_pack",
+            "keyboard",
+            "monitor",
+            "projector",
+            "headphones",
+            "bike",
+            "laptop_computer",
+            "mug",
+        ]
+        super(OfficeCaltech, self).__init__(
+            root, transform=transform, download=download, sub_class_set=sub_class_set, **kwargs
+        )

--- a/kale/loaddata/office_access.py
+++ b/kale/loaddata/office_access.py
@@ -1,0 +1,56 @@
+import os
+import logging
+from kale.loaddata.multi_domain import MultiDomainImageFolder
+from kale.utils.download import download_file_by_url
+from kale.prepdata.image_transform import get_transform
+from kale.loaddata.dataset_access import DatasetAccess
+
+
+url = "https://github.com/sz144/data/raw/main/image_data/office/"
+DOMAINS = ["amazon", "caltech", "dslr", "webcam"]
+office_transform = get_transform("office")
+
+
+class OfficeAccess(MultiDomainImageFolder, DatasetAccess):
+    def __init__(self, root, transform=office_transform, download=False, **kwargs):
+        """Init office dataset."""
+        # init params
+        if download:
+            self.download(root)
+        super(OfficeAccess, self).__init__(root, transform=transform, **kwargs)
+
+    @staticmethod
+    def download(path):
+        """Download dataset."""
+        if not os.path.exists(path):
+            os.makedirs(path)
+        for domian_ in DOMAINS:
+            filename = "%s.zip" % domian_
+            data_path = os.path.join(path, filename)
+            if os.path.exists(data_path):
+                logging.info(f"Data file {filename} already exists.")
+                continue
+            else:
+                data_url = "%s/%s" % (url, filename)
+                download_file_by_url(data_url, path, filename, "zip")
+                # zip_file = zipfile.ZipFile(data_path, "r")
+                # zip_file.extractall(path)
+                logging.info(f"Download {data_url} to {data_path}")
+
+        logging.info("[DONE]")
+        return
+
+
+class Office31(OfficeAccess):
+    def __init__(self, root, transform=office_transform, download=False, **kwargs):
+        sub_domain_set = ['amazon', 'dslr', 'webcam']
+        super(Office31, self).__init__(root, transform=transform, download=download, sub_domain_set=sub_domain_set,
+                                       **kwargs)
+
+
+class OfficeCaltech(OfficeAccess):
+    def __init__(self, root, transform=office_transform, download=False, **kwargs):
+        sub_class_set = ["mouse", "calculator", "back_pack", "keyboard", "monitor", "projector", "headphones", "bike",
+                         "laptop_computer", "mug"]
+        super(OfficeCaltech, self).__init__(root, transform=transform, download=download, sub_class_set=sub_class_set,
+                                            **kwargs)

--- a/kale/prepdata/image_transform.py
+++ b/kale/prepdata/image_transform.py
@@ -79,7 +79,7 @@ def get_transform(kind, augment=False):
                 [transforms.Resize(256), transforms.RandomResizedCrop(224), transforms.RandomHorizontalFlip()]
             )
         else:
-            transform_aug = transforms.Compose([transforms.Resize(256)])
+            transform_aug = transforms.Compose([transforms.Resize(256), transforms.CenterCrop(256)])
         transform = transforms.Compose(
             [
                 transform_aug,

--- a/tests/loaddata/test_office_access.py
+++ b/tests/loaddata/test_office_access.py
@@ -1,0 +1,36 @@
+import torch
+from numpy import testing
+from kale.loaddata.office_access import OfficeAccess, Office31, OfficeCaltech
+from kale.loaddata.multi_domain import MultiDomainDatasets, MultiDomainAdapDataset
+
+
+def test_office31(download_path):
+    office_access = Office31(root=download_path, download=True, return_domain_label=True)
+    testing.assert_equal(len(office_access.class_to_idx), 31)
+    testing.assert_equal(len(office_access.domain_to_idx), 3)
+    dataset = MultiDomainAdapDataset(office_access)
+    dataset.prepare_data_loaders()
+    domain_labels = list(dataset.domain_to_idx.values())
+    for split in ["train", "valid", "test"]:
+        dataloader = dataset.get_domain_loaders(split=split)
+        x, y, z = next(iter(dataloader))
+        for domain_label_ in domain_labels:
+            testing.assert_equal(torch.where(z == domain_label_)[0].shape[0], 10)
+
+
+def test_office_caltech(download_path):
+    office_access = OfficeCaltech(root=download_path, download=True)
+    testing.assert_equal(len(office_access.class_to_idx), 10)
+    testing.assert_equal(len(office_access.domain_to_idx), 4)
+
+
+def test_custom_office(download_path):
+    source = OfficeAccess(root=download_path, download=True, sub_domain_set=['dslr', ], split_train_test=True)
+    target = OfficeAccess(root=download_path, download=True, sub_domain_set=['webcam'], split_train_test=True)
+    dataset = MultiDomainDatasets(source_access=source, target_access=target)
+    dataset.prepare_data_loaders()
+    dataloader = dataset.get_domain_loaders()
+    testing.assert_equal(len(next(iter(dataloader))), 2)
+
+
+

--- a/tests/loaddata/test_office_access.py
+++ b/tests/loaddata/test_office_access.py
@@ -1,7 +1,8 @@
 import torch
 from numpy import testing
-from kale.loaddata.office_access import OfficeAccess, Office31, OfficeCaltech
-from kale.loaddata.multi_domain import MultiDomainDatasets, MultiDomainAdapDataset
+
+from kale.loaddata.multi_domain import MultiDomainAdapDataset, MultiDomainDatasets
+from kale.loaddata.office_access import Office31, OfficeAccess, OfficeCaltech
 
 
 def test_office31(download_path):
@@ -25,12 +26,9 @@ def test_office_caltech(download_path):
 
 
 def test_custom_office(download_path):
-    source = OfficeAccess(root=download_path, download=True, sub_domain_set=['dslr', ], split_train_test=True)
-    target = OfficeAccess(root=download_path, download=True, sub_domain_set=['webcam'], split_train_test=True)
+    source = OfficeAccess(root=download_path, download=True, sub_domain_set=["dslr"], split_train_test=True)
+    target = OfficeAccess(root=download_path, download=True, sub_domain_set=["webcam"], split_train_test=True)
     dataset = MultiDomainDatasets(source_access=source, target_access=target)
     dataset.prepare_data_loaders()
     dataloader = dataset.get_domain_loaders()
     testing.assert_equal(len(next(iter(dataloader))), 2)
-
-
-


### PR DESCRIPTION
### Description

- A new class `kale.loaddata.multi_domain.MultiDomainImageFolder` for reading images from multiple domain folders. It can create datasets, which are compatible with `kale.loaddata.multi_domain.MultiDomainDatasets`.
- A new class `kale.loaddata.multi_domain.MultiDomainAdapDataset` for creating dataloaders for `MultiDomainImageFolder` objects.
- A new function `split_by_ratios` in `kale.loaddata.dataset_access.py` for splitting a dataset into several partitions according to a list of proportions.
- A new sampler `kale.loaddata.sampler.BalancedDomainBatchSampler` for sampling equal number of sample for each domain in each batch.
- A new data access "kale.loaddata.office_access.py" for downloading and loading office dataset, including office-31 and office-caltech 10.
- Tests for above new features.

### Status
**Ready**



### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [x] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
