### PR TITLE
Fix doc build, improve docstrings and MPCA pipeline fit efficiency

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ We call `kale` and `examples` the **root**-level modules, `kale.xxx` and `exampl
 4. Other standardization
 
 * Put a docstring at the top of each `.py` to summarize the module
+* Docstring for a class should be at the top of the class definition, above `__init__`
 * See `examples/digits_dann_lightn` and related modules for reference.
 
 If you are aware of a better way to auto-generate documentations, create an issue or push your suggested changes.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,6 +8,8 @@ https://download.pytorch.org/whl/cpu/torch-1.7.0%2Bcpu-cp37-cp37m-linux_x86_64.w
 https://pytorch-geometric.com/whl/torch-1.7.0+cpu/torch_scatter-2.0.6-cp37-cp37m-linux_x86_64.whl
 https://pytorch-geometric.com/whl/torch-1.7.0+cpu/torch_sparse-0.6.8-cp37-cp37m-linux_x86_64.whl
 
+ipython<8.0
+
 nbsphinx
 nbsphinx-link
 numpy

--- a/docs/source/kale.utils.rst
+++ b/docs/source/kale.utils.rst
@@ -6,14 +6,6 @@ Utilities
 Submodules
 ----------
 
-kale.utils.csv\_logger module
------------------------------
-
-.. automodule:: kale.utils.csv_logger
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 kale.utils.download module
 --------------------------
 

--- a/kale/loaddata/multi_domain.py
+++ b/kale/loaddata/multi_domain.py
@@ -507,16 +507,16 @@ class ConcatMultiDomainAccess(torch.utils.data.Dataset):
 
 
 class MultiDomainAccess(DatasetAccess):
-    def __init__(self, data_access: dict, n_classes: int, return_domain_label: Optional[bool] = False):
-        """Convert multiple digits-like data accesses to a single data access.
+    """Convert multiple digits-like data accesses to a single data access.
+    Args:
+        data_access (dict): Dictionary of data accesses, e.g. {"Domain1_name": domain1_access,
+            "Domain2_name": domain2_access}
+        n_classes (int): number of classes.
+        return_domain_label (Optional[bool], optional): Whether return domain labels in each batch.
+            Defaults to False.
+    """
 
-        Args:
-            data_access (dict): Dictionary of data accesses, e.g. {"Domain1_name": domain1_access,
-                "Domain2_name": domain2_access}
-            n_classes (int): number of classes.
-            return_domain_label (Optional[bool], optional): Whether return domain labels in each batch.
-                Defaults to False.
-        """
+    def __init__(self, data_access: dict, n_classes: int, return_domain_label: Optional[bool] = False):
         super().__init__(n_classes)
         self.data_access = data_access
         self.domain_to_idx = {list(data_access.keys())[i]: i for i in range(len(data_access))}

--- a/kale/pipeline/domain_adapter.py
+++ b/kale/pipeline/domain_adapter.py
@@ -215,7 +215,7 @@ class BaseAdaptTrainer(pl.LightningModule):
 
     where :math:`\lambda` will follow the schedule defined by the DANN paper:
 
-    :math:`\lambda_p = \frac{2}{1 + \exp{(-\gamma \cdot p)}} - 1` where $p$ the learning progress
+    :math:`\lambda_p = \frac{2}{1 + \exp{(-\gamma \cdot p)}} - 1` where :math:`p` the learning progress
     changes linearly from 0 to 1.
 
     Args:

--- a/kale/pipeline/mpca_trainer.py
+++ b/kale/pipeline/mpca_trainer.py
@@ -74,7 +74,6 @@ class MPCATrainer(BaseEstimator, ClassifierMixin):
         n_features=None,
         search_params=None,
     ):
-
         if classifier not in ["svc", "linear_svc", "lr"]:
             error_msg = "Valid classifier should be 'svc', 'linear_svc', or 'lr', but given %s" % classifier
             logging.error(error_msg)

--- a/kale/pipeline/mpca_trainer.py
+++ b/kale/pipeline/mpca_trainer.py
@@ -41,24 +41,29 @@ default_mpca_params = {"var_ratio": 0.97, "return_vector": True}
 
 
 class MPCATrainer(BaseEstimator, ClassifierMixin):
+    """Trainer of pipeline: MPCA->Feature selection->Classifier
+
+    Args:
+        classifier (str, optional): Available classifier options: {"svc", "linear_svc", "lr"}, where "svc" trains a
+            support vector classifier, supports both linear and non-linear kernels, optimizes with library "libsvm";
+            "linear_svc" trains a support vector classifier with linear kernel only, and optimizes with library
+            "liblinear", which suppose to be faster and better in handling large number of samples; and "lr" trains
+            a classifier with logistic regression. Defaults to "svc".
+        classifier_params (dict, optional): Parameters of classifier. Defaults to 'auto'.
+        mpca_params (dict, optional): Parameters of MPCA, e.g., {"var_ratio": 0.8}. Defaults to None, i.e., using the
+            default parameters (https://pykale.readthedocs.io/en/latest/kale.embed.html#module-kale.embed.mpca).
+        n_features (int, optional): Number of features for feature selection. Defaults to None, i.e., all features
+            after dimension reduction will be used.
+        search_params (dict, optional): Parameters of grid search, for more detail please see
+            https://scikit-learn.org/stable/modules/grid_search.html#grid-search . Defaults to None, i.e., using the
+            default params: {"cv": 5}.
+
+    """
+
     def __init__(
         self, classifier="svc", classifier_params="auto", mpca_params=None, n_features=None, search_params=None
     ):
-        """Trainer of pipeline: MPCA->Feature selection->Classifier
 
-        Args:
-            classifier (str, optional): Available classifier options: {"svc", "linear_svc", "lr"}, where "svc" trains a
-                support vector classifier, supports both linear and non-linear kernels, optimizes with library "libsvm";
-                "linear_svc" trains a support vector classifier with linear kernel only, and optimizes with library
-                "liblinear", which suppose to be faster and better in handling large number of samples; and "lr" trains
-                a classifier with logistic regression. Defaults to "svc".
-            classifier_params (dict, optional): Parameters of classifier. Defaults to 'auto'.
-            mpca_params (dict, optional): Parameters of MPCA. Defaults to None.
-            n_features (int, optional): Number of features for feature selection. Defaults to None, i.e. all features
-                after dimension reduction will be used.
-            search_params (dict, optional): Parameters of grid search. Defaults to None.
-
-        """
         if classifier not in ["svc", "linear_svc", "lr"]:
             error_msg = "Valid classifier should be 'svc', 'linear_svc', or 'lr', but given %s" % classifier
             logging.error(error_msg)

--- a/kale/pipeline/mpca_trainer.py
+++ b/kale/pipeline/mpca_trainer.py
@@ -62,7 +62,6 @@ class MPCATrainer(BaseEstimator, ClassifierMixin):
         search_params (dict, optional): Parameters of grid search, for more detail please see
             https://scikit-learn.org/stable/modules/grid_search.html#grid-search . Defaults to None, i.e., using the
             default params: {"cv": 5}.
-
     """
 
     def __init__(

--- a/kale/pipeline/multi_domain_adapter.py
+++ b/kale/pipeline/multi_domain_adapter.py
@@ -41,18 +41,19 @@ def _average_cls_output(x, classifiers: nn.ModuleDict):
 
 
 class BaseMultiSourceTrainer(BaseAdaptTrainer):
+    """Base class for all domain adaptation architectures
+
+    Args:
+        dataset (kale.loaddata.multi_domain): the multi-domain datasets to be used for train, validation, and tests.
+        feature_extractor (torch.nn.Module): the feature extractor network
+        task_classifier (torch.nn.Module): the task classifier network
+        n_classes (int): number of classes
+        target_domain (str): target domain name
+    """
+
     def __init__(
         self, dataset, feature_extractor, task_classifier, n_classes: int, target_domain: str, **base_params,
     ):
-        """Base class for all domain adaptation architectures
-
-        Args:
-            dataset (kale.loaddata.multi_domain): the multi-domain datasets to be used for train, validation, and tests.
-            feature_extractor (torch.nn.Module): the feature extractor network
-            task_classifier (torch.nn.Module): the task classifier network
-            n_classes (int): number of classes
-            target_domain (str): target domain name
-        """
         super().__init__(dataset, feature_extractor, task_classifier, **base_params)
         self.n_classes = n_classes
         self.feature_dim = feature_extractor.state_dict()[list(feature_extractor.state_dict().keys())[-2]].shape[0]
@@ -186,8 +187,7 @@ class M3SDATrainer(BaseMultiSourceTrainer):
 
 
 class _DINTrainer(BaseMultiSourceTrainer):
-    """Domain independent network (DIN). It is under development and will be updated with references later.
-    """
+    """Domain independent network (DIN). It is under development and will be updated with references later."""
 
     def __init__(
         self,

--- a/kale/pipeline/multi_domain_adapter.py
+++ b/kale/pipeline/multi_domain_adapter.py
@@ -98,6 +98,14 @@ class BaseMultiSourceTrainer(BaseAdaptTrainer):
 
 
 class M3SDATrainer(BaseMultiSourceTrainer):
+    """Moment matching for multi-source domain adaptation (M3SDA).
+
+    Reference:
+        Peng, X., Bai, Q., Xia, X., Huang, Z., Saenko, K., & Wang, B. (2019). Moment matching for multi-source
+        domain adaptation. In Proceedings of the IEEE/CVF International Conference on Computer Vision
+        (pp. 1406-1415).
+    """
+
     def __init__(
         self,
         dataset,
@@ -108,13 +116,6 @@ class M3SDATrainer(BaseMultiSourceTrainer):
         k_moment: int = 3,
         **base_params,
     ):
-        """Moment matching for multi-source domain adaptation (M3SDA).
-
-        Reference:
-            Peng, X., Bai, Q., Xia, X., Huang, Z., Saenko, K., & Wang, B. (2019). Moment matching for multi-source
-            domain adaptation. In Proceedings of the IEEE/CVF International Conference on Computer Vision
-            (pp. 1406-1415).
-        """
         super().__init__(dataset, feature_extractor, task_classifier, n_classes, target_domain, **base_params)
         self.classifiers = dict()
         for domain_ in self.domain_to_idx.keys():
@@ -185,6 +186,9 @@ class M3SDATrainer(BaseMultiSourceTrainer):
 
 
 class _DINTrainer(BaseMultiSourceTrainer):
+    """Domain independent network (DIN). It is under development and will be updated with references later.
+    """
+
     def __init__(
         self,
         dataset,
@@ -197,9 +201,6 @@ class _DINTrainer(BaseMultiSourceTrainer):
         kernel_num: int = 5,
         **base_params,
     ):
-        """Domain independent network (DIN). It is under development and will be updated with references later.
-
-        """
         super().__init__(dataset, feature_extractor, task_classifier, n_classes, target_domain, **base_params)
         self.kernel = kernel
         self.n_domains = len(self.domain_to_idx.values())
@@ -238,6 +239,14 @@ class _DINTrainer(BaseMultiSourceTrainer):
 
 
 class MFSANTrainer(BaseMultiSourceTrainer):
+    """Multiple Feature Spaces Adaptation Network (MFSAN)
+
+    Reference: Zhu, Y., Zhuang, F. and Wang, D., 2019, July. Aligning domain-specific distribution and classifier
+        for cross-domain classification from multiple sources. In AAAI.
+
+    Original implementation: https://github.com/easezyc/deep-transfer-learning/tree/master/MUDA/MFSAN
+    """
+
     def __init__(
         self,
         dataset,
@@ -251,15 +260,7 @@ class MFSANTrainer(BaseMultiSourceTrainer):
         input_dimension: int = 2,
         **base_params,
     ):
-        """Multiple Feature Spaces Adaptation Network (MFSAN)
-
-        Reference: Zhu, Y., Zhuang, F. and Wang, D., 2019, July. Aligning domain-specific distribution and classifier
-            for cross-domain classification from multiple sources. In AAAI.
-
-        Original implementation: https://github.com/easezyc/deep-transfer-learning/tree/master/MUDA/MFSAN
-        """
         super().__init__(dataset, feature_extractor, task_classifier, n_classes, target_domain, **base_params)
-
         self.classifiers = dict()
         self.domain_net = dict()
         self.src_domains = []

--- a/kale/pipeline/video_domain_adapter.py
+++ b/kale/pipeline/video_domain_adapter.py
@@ -103,11 +103,11 @@ def create_dann_like_4video(
 
 
 class BaseMMDLike4Video(BaseMMDLike):
+    """Common API for MME-based domain adaptation on video data: DAN, JAN"""
+
     def __init__(
         self, dataset, image_modality, feature_extractor, task_classifier, kernel_mul=2.0, kernel_num=5, **base_params,
     ):
-        """Common API for MME-based domain adaptation on video data: DAN, JAN"""
-
         super().__init__(dataset, feature_extractor, task_classifier, kernel_mul, kernel_num, **base_params)
         self.image_modality = image_modality
         self.rgb_feat = self.feat["rgb"]


### PR DESCRIPTION
Fixes #270 and #274

### Description

1. Move docstrings to above `__init__` to show up in docs
2. Add default `max_iter` to `SVC` in `MPCATrainer` to improve efficiency
3. Restrict `ipython` to `<8.0` to fix doc build error

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
