### PR TITLE
update readme to say functional code is on another branch,

### DIFF
--- a/examples/landmark_uncertainty/README.md
+++ b/examples/landmark_uncertainty/README.md
@@ -1,5 +1,7 @@
 # Uncertainty Estimation in Landmark Localization
 
+
+**IMPORTANT:** This is the clean branch of Pykale. Fully functional and reproducable code can be found on branch: https://github.com/pykale/pykale/tree/landmark_uncertainty/examples/landmark_uncertainty. It is not merged yet due to low test coverage. 
 ## 1. Description
 
 In this example we implement the methods from [Uncertainty Estimation for Heatmap-based Landmark Localization](placeholder_link). The method is Quantile Binning, which bins landmark predictions by any continuous uncertainty estimation measure. We assign each bin estimated localization error bounds. We can use these bins to filter out the worst predictions, or identify the likely best predictions.

--- a/examples/landmark_uncertainty/README.md
+++ b/examples/landmark_uncertainty/README.md
@@ -1,6 +1,6 @@
 # Uncertainty Estimation in Landmark Localization
 
-**IMPORTANT:** This is the clean branch of Pykale. Fully functional and reproducable code can be found on branch: https://github.com/pykale/pykale/tree/landmark_uncertainty/examples/landmark_uncertainty. It is not merged yet due to low test coverage.
+**IMPORTANT:** This is the clean branch of Pykale. Fully functional and reproducable code can be found on [this branch](https://github.com/pykale/pykale/tree/landmark_uncertainty/examples/landmark_uncertainty). It is not merged yet due to low test coverage.
 
 ## 1. Description
 

--- a/examples/landmark_uncertainty/README.md
+++ b/examples/landmark_uncertainty/README.md
@@ -1,7 +1,7 @@
 # Uncertainty Estimation in Landmark Localization
 
+**IMPORTANT:** This is the clean branch of Pykale. Fully functional and reproducable code can be found on branch: https://github.com/pykale/pykale/tree/landmark_uncertainty/examples/landmark_uncertainty. It is not merged yet due to low test coverage.
 
-**IMPORTANT:** This is the clean branch of Pykale. Fully functional and reproducable code can be found on branch: https://github.com/pykale/pykale/tree/landmark_uncertainty/examples/landmark_uncertainty. It is not merged yet due to low test coverage. 
 ## 1. Description
 
 In this example we implement the methods from [Uncertainty Estimation for Heatmap-based Landmark Localization](placeholder_link). The method is Quantile Binning, which bins landmark predictions by any continuous uncertainty estimation measure. We assign each bin estimated localization error bounds. We can use these bins to filter out the worst predictions, or identify the likely best predictions.


### PR DESCRIPTION
Fixes No issue.

### Description
Just added a sentence at the top of the README to indicate how to find the landmark uncertainty code on another branch.

### Status
**Ready**


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
