### PR TITLE
Add a new example for video feature vector input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ examples/*/data/
 examples/*/outputs/
 examples/*/lightning_logs/
 examples/*/demo*/
-examples/action_dann_lightn/configs_xianyuan/
+examples/*/configs_xianyuan/
 
 # Logs
 log-*.txt

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ examples/data/
 examples/*/data/
 examples/*/outputs/
 examples/*/lightning_logs/
+examples/*/tb_logs/
 examples/*/demo*/
 examples/*/configs_xianyuan/
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.pth
 *.zip
 *.ckpt
+*.json
 
 # Distribution / packaging
 build/

--- a/examples/action_dann_lightn/config.py
+++ b/examples/action_dann_lightn/config.py
@@ -24,7 +24,7 @@ _C.DATASET.TARGET = "EPIC"  # dataset options=["EPIC", "GTEA", "ADL", "KITCHEN"]
 _C.DATASET.TGT_TRAINLIST = "epic_D2_train.pkl"
 _C.DATASET.TGT_TESTLIST = "epic_D2_test.pkl"
 _C.DATASET.IMAGE_MODALITY = "rgb"  # mode options=["rgb", "flow", "joint"]
-_C.DATASET.INPUT_TYPE = "image"
+_C.DATASET.INPUT_TYPE = "image"  # input type options=["image", "feature"]
 _C.DATASET.CLASS_TYPE = "verb"  # options=["verb", "verb+noun"]
 _C.DATASET.NUM_SEGMENTS = 1  # = 1, if image input; = 8, if feature input.
 _C.DATASET.FRAMES_PER_SEGMENT = 16
@@ -74,7 +74,7 @@ _C.OUTPUT = CN()
 _C.OUTPUT.VERBOSE = False  # To discuss, for HPC jobs
 _C.OUTPUT.FAST_DEV_RUN = False  # True for debug
 _C.OUTPUT.PB_FRESH = 0  # 0 # 50 # 0 to disable  ; MAYBE make it a command line option
-_C.OUTPUT.TB_DIR = os.path.join("lightning_logs", _C.DATASET.SOURCE + "2" + _C.DATASET.TARGET)
+_C.OUTPUT.TB_DIR = os.path.join("tb_logs", _C.DATASET.SOURCE + "2" + _C.DATASET.TARGET)
 
 
 def get_cfg_defaults():

--- a/examples/action_dann_lightn/config.py
+++ b/examples/action_dann_lightn/config.py
@@ -24,7 +24,7 @@ _C.DATASET.TARGET = "EPIC"  # dataset options=["EPIC", "GTEA", "ADL", "KITCHEN"]
 _C.DATASET.TGT_TRAINLIST = "epic_D2_train.pkl"
 _C.DATASET.TGT_TESTLIST = "epic_D2_test.pkl"
 _C.DATASET.IMAGE_MODALITY = "rgb"  # mode options=["rgb", "flow", "joint"]
-# _C.DATASET.NUM_CLASSES = 8
+_C.DATASET.NUM_SEGMENTS = 1  # = 1, if image input; = 8, if feature input.
 _C.DATASET.FRAMES_PER_SEGMENT = 16
 _C.DATASET.NUM_REPEAT = 5  # 10
 _C.DATASET.WEIGHT_TYPE = "natural"

--- a/examples/action_dann_lightn/config.py
+++ b/examples/action_dann_lightn/config.py
@@ -25,6 +25,7 @@ _C.DATASET.TGT_TRAINLIST = "epic_D2_train.pkl"
 _C.DATASET.TGT_TESTLIST = "epic_D2_test.pkl"
 _C.DATASET.IMAGE_MODALITY = "rgb"  # mode options=["rgb", "flow", "joint"]
 _C.DATASET.INPUT_TYPE = "image"
+_C.DATASET.CLASS_TYPE = "verb"  # options=["verb", "verb+noun"]
 _C.DATASET.NUM_SEGMENTS = 1  # = 1, if image input; = 8, if feature input.
 _C.DATASET.FRAMES_PER_SEGMENT = 16
 _C.DATASET.NUM_REPEAT = 5  # 10

--- a/examples/action_dann_lightn/config.py
+++ b/examples/action_dann_lightn/config.py
@@ -36,6 +36,7 @@ _C.DATASET.SIZE_TYPE = "max"  # options=["source", "max"]
 # ---------------------------------------------------------------------------- #
 _C.SOLVER = CN()
 _C.SOLVER.SEED = 2020
+_C.SOLVER.NUM_WORKERS = 0
 _C.SOLVER.BASE_LR = 0.01  # Initial learning rate
 _C.SOLVER.MOMENTUM = 0.9
 _C.SOLVER.WEIGHT_DECAY = 0.0005  # 1e-4

--- a/examples/action_dann_lightn/config.py
+++ b/examples/action_dann_lightn/config.py
@@ -27,7 +27,7 @@ _C.DATASET.IMAGE_MODALITY = "rgb"  # options=["rgb", "flow", "joint"]
 _C.DATASET.INPUT_TYPE = "image"  # options=["image", "feature"]
 _C.DATASET.CLASS_TYPE = "verb"  # options=["verb", "verb+noun"]
 _C.DATASET.NUM_SEGMENTS = 1  # = 1, if image input; = 8, if feature input.
-_C.DATASET.FRAMES_PER_SEGMENT = 16
+_C.DATASET.FRAMES_PER_SEGMENT = 16  # = 16, if image input; = 1, if feature input.
 _C.DATASET.NUM_REPEAT = 5  # 10
 _C.DATASET.WEIGHT_TYPE = "natural"
 _C.DATASET.SIZE_TYPE = "max"  # options=["source", "max"]

--- a/examples/action_dann_lightn/config.py
+++ b/examples/action_dann_lightn/config.py
@@ -17,10 +17,10 @@ _C = CN()
 # -----------------------------------------------------------------------------
 _C.DATASET = CN()
 _C.DATASET.ROOT = "J:/Datasets/EgoAction/"  # "/shared/tale2/Shared"
-_C.DATASET.SOURCE = "EPIC"  # dataset options=["EPIC", "GTEA", "ADL", "KITCHEN"]
+_C.DATASET.SOURCE = "EPIC"  # dataset options=["EPIC", "GTEA", "ADL", "KITCHEN", "EPIC100"]
 _C.DATASET.SRC_TRAINLIST = "epic_D1_train.pkl"
 _C.DATASET.SRC_TESTLIST = "epic_D1_test.pkl"
-_C.DATASET.TARGET = "EPIC"  # dataset options=["EPIC", "GTEA", "ADL", "KITCHEN"]
+_C.DATASET.TARGET = "EPIC"  # dataset options=["EPIC", "GTEA", "ADL", "KITCHEN", "EPIC100"]
 _C.DATASET.TGT_TRAINLIST = "epic_D2_train.pkl"
 _C.DATASET.TGT_TESTLIST = "epic_D2_test.pkl"
 _C.DATASET.IMAGE_MODALITY = "rgb"  # options=["rgb", "flow", "joint"]
@@ -28,9 +28,9 @@ _C.DATASET.INPUT_TYPE = "image"  # options=["image", "feature"]
 _C.DATASET.CLASS_TYPE = "verb"  # options=["verb", "verb+noun"]
 _C.DATASET.NUM_SEGMENTS = 1  # = 1, if image input; = 8, if feature input.
 _C.DATASET.FRAMES_PER_SEGMENT = 16  # = 16, if image input; = 1, if feature input.
-_C.DATASET.NUM_REPEAT = 5  # 10
+_C.DATASET.NUM_REPEAT = 5
 _C.DATASET.WEIGHT_TYPE = "natural"
-_C.DATASET.SIZE_TYPE = "max"  # options=["source", "max"]
+_C.DATASET.SIZE_TYPE = "max"  # options=["source", "max", "adaptive]
 # ---------------------------------------------------------------------------- #
 # Solver
 # ---------------------------------------------------------------------------- #
@@ -65,7 +65,7 @@ _C.MODEL.ATTENTION = "None"  # options=["None", "SELayer"]
 # Domain Adaptation Net (DAN) configs
 # ---------------------------------------------------------------------------- #
 _C.DAN = CN()
-_C.DAN.METHOD = "CDAN"  # options=["CDAN", "CDAN-E", "DANN", "DAN"]
+_C.DAN.METHOD = "CDAN"  # options=["CDAN", "CDAN-E", "DANN", "DAN", "JAN"]
 _C.DAN.USERANDOM = False
 _C.DAN.RANDOM_DIM = 1024
 # ---------------------------------------------------------------------------- #

--- a/examples/action_dann_lightn/config.py
+++ b/examples/action_dann_lightn/config.py
@@ -23,8 +23,8 @@ _C.DATASET.SRC_TESTLIST = "epic_D1_test.pkl"
 _C.DATASET.TARGET = "EPIC"  # dataset options=["EPIC", "GTEA", "ADL", "KITCHEN"]
 _C.DATASET.TGT_TRAINLIST = "epic_D2_train.pkl"
 _C.DATASET.TGT_TESTLIST = "epic_D2_test.pkl"
-_C.DATASET.IMAGE_MODALITY = "rgb"  # mode options=["rgb", "flow", "joint"]
-_C.DATASET.INPUT_TYPE = "image"  # input type options=["image", "feature"]
+_C.DATASET.IMAGE_MODALITY = "rgb"  # options=["rgb", "flow", "joint"]
+_C.DATASET.INPUT_TYPE = "image"  # options=["image", "feature"]
 _C.DATASET.CLASS_TYPE = "verb"  # options=["verb", "verb+noun"]
 _C.DATASET.NUM_SEGMENTS = 1  # = 1, if image input; = 8, if feature input.
 _C.DATASET.FRAMES_PER_SEGMENT = 16

--- a/examples/action_dann_lightn/config.py
+++ b/examples/action_dann_lightn/config.py
@@ -16,7 +16,7 @@ _C = CN()
 # Dataset
 # -----------------------------------------------------------------------------
 _C.DATASET = CN()
-_C.DATASET.ROOT = "I:/Datasets/EgoAction/"  # "/shared/tale2/Shared"
+_C.DATASET.ROOT = "J:/Datasets/EgoAction/"  # "/shared/tale2/Shared"
 _C.DATASET.SOURCE = "EPIC"  # dataset options=["EPIC", "GTEA", "ADL", "KITCHEN"]
 _C.DATASET.SRC_TRAINLIST = "epic_D1_train.pkl"
 _C.DATASET.SRC_TESTLIST = "epic_D1_test.pkl"

--- a/examples/action_dann_lightn/config.py
+++ b/examples/action_dann_lightn/config.py
@@ -24,6 +24,7 @@ _C.DATASET.TARGET = "EPIC"  # dataset options=["EPIC", "GTEA", "ADL", "KITCHEN"]
 _C.DATASET.TGT_TRAINLIST = "epic_D2_train.pkl"
 _C.DATASET.TGT_TESTLIST = "epic_D2_test.pkl"
 _C.DATASET.IMAGE_MODALITY = "rgb"  # mode options=["rgb", "flow", "joint"]
+_C.DATASET.INPUT_TYPE = "image"
 _C.DATASET.NUM_SEGMENTS = 1  # = 1, if image input; = 8, if feature input.
 _C.DATASET.FRAMES_PER_SEGMENT = 16
 _C.DATASET.NUM_REPEAT = 5  # 10

--- a/examples/action_dann_lightn/main.py
+++ b/examples/action_dann_lightn/main.py
@@ -57,9 +57,10 @@ def main():
         source,
         target,
         image_modality=cfg.DATASET.IMAGE_MODALITY,
-        seed=seed,
+        random_state=seed,
         config_weight_type=cfg.DATASET.WEIGHT_TYPE,
         config_size_type=cfg.DATASET.SIZE_TYPE,
+        num_workers=cfg.SOLVER.NUM_WORKERS,
     )
 
     # ---- training/test process ----

--- a/examples/action_dann_lightn/main.py
+++ b/examples/action_dann_lightn/main.py
@@ -47,9 +47,10 @@ def main():
     # ---- setup output ----
     format_str = "@%(asctime)s %(name)s [%(levelname)s] - (%(message)s)"
     logging.basicConfig(format=format_str)
+
     # ---- setup dataset ----
     seed = cfg.SOLVER.SEED
-    source, target, num_classes = VideoDataset.get_source_target(
+    source, target, dict_num_classes = VideoDataset.get_source_target(
         VideoDataset(cfg.DATASET.SOURCE.upper()), VideoDataset(cfg.DATASET.TARGET.upper()), seed, cfg
     )
     dataset = VideoMultiDomainDatasets(
@@ -68,7 +69,7 @@ def main():
         set_seed(seed)  # seed_everything in pytorch_lightning did not set torch.backends.cudnn
         print(f"==> Building model for seed {seed} ......")
         # ---- setup model and logger ----
-        model, train_params = get_model(cfg, dataset, num_classes)
+        model, train_params = get_model(cfg, dataset, dict_num_classes)
         tb_logger = pl_loggers.TensorBoardLogger(cfg.OUTPUT.TB_DIR, name="seed{}".format(seed))
         checkpoint_callback = ModelCheckpoint(
             # dirpath=full_checkpoint_dir,

--- a/examples/action_dann_lightn/model.py
+++ b/examples/action_dann_lightn/model.py
@@ -10,7 +10,7 @@ References from https://github.com/criteo-research/pytorch-ada/blob/master/adali
 
 from copy import deepcopy
 
-from kale.embed.video_feature_extractor import get_extractor_video, get_extractor_feat
+from kale.embed.video_feature_extractor import get_extractor_feat, get_extractor_video
 from kale.pipeline import domain_adapter, video_domain_adapter
 from kale.predict.class_domain_nets import ClassNetVideo, DomainNetVideo
 
@@ -32,7 +32,7 @@ def get_config(cfg):
             "nb_init_epochs": cfg.SOLVER.MIN_EPOCHS,
             "init_lr": cfg.SOLVER.BASE_LR,
             "batch_size": cfg.SOLVER.TRAIN_BATCH_SIZE,
-            "optimizer": {"type": cfg.SOLVER.TYPE, "optim_params": {"weight_decay": cfg.SOLVER.WEIGHT_DECAY, }, },
+            "optimizer": {"type": cfg.SOLVER.TYPE, "optim_params": {"weight_decay": cfg.SOLVER.WEIGHT_DECAY,},},
         }
     }
     data_params = {
@@ -85,7 +85,9 @@ def get_model(cfg, dataset, dict_num_classes):
         )
 
     # setup task classifier
-    classifier_network = ClassNetVideo(input_size=class_feature_dim, dict_n_class=dict_num_classes, class_type=class_type.lower())
+    classifier_network = ClassNetVideo(
+        input_size=class_feature_dim, dict_n_class=dict_num_classes, class_type=class_type.lower()
+    )
 
     # setup domain classifier
     method_params = {}

--- a/examples/action_dann_lightn/model.py
+++ b/examples/action_dann_lightn/model.py
@@ -32,15 +32,10 @@ def get_config(cfg):
             "nb_init_epochs": cfg.SOLVER.MIN_EPOCHS,
             "init_lr": cfg.SOLVER.BASE_LR,
             "batch_size": cfg.SOLVER.TRAIN_BATCH_SIZE,
-            "optimizer": {
-                "type": cfg.SOLVER.TYPE,
-                "optim_params": {
-                    "momentum": cfg.SOLVER.MOMENTUM,
-                    "weight_decay": cfg.SOLVER.WEIGHT_DECAY,
-                    "nesterov": cfg.SOLVER.NESTEROV,
-                },
-            },
-        },
+            "optimizer": {"type": cfg.SOLVER.TYPE, "optim_params": {"weight_decay": cfg.SOLVER.WEIGHT_DECAY, }, },
+        }
+    }
+    data_params = {
         "data_params": {
             # "dataset_group": cfg.DATASET.NAME,
             "dataset_name": cfg.DATASET.SOURCE + "2" + cfg.DATASET.TARGET,
@@ -50,8 +45,13 @@ def get_config(cfg):
             "weight_type": cfg.DATASET.WEIGHT_TYPE,
             "input_type": cfg.DATASET.INPUT_TYPE,
             "class_type": cfg.DATASET.CLASS_TYPE,
-        },
+        }
     }
+    config_params.update(data_params)
+    if config_params["train_params"]["optimizer"]["type"] == "SGD":
+        config_params["train_params"]["optimizer"]["optim_params"]["momentum"] = cfg.SOLVER.MOMENTUM
+        config_params["train_params"]["optimizer"]["optim_params"]["nesterov"] = cfg.SOLVER.NESTEROV
+
     return config_params
 
 

--- a/examples/action_dann_lightn/model.py
+++ b/examples/action_dann_lightn/model.py
@@ -10,7 +10,7 @@ References from https://github.com/criteo-research/pytorch-ada/blob/master/adali
 
 from copy import deepcopy
 
-from kale.embed.video_feature_extractor import get_video_feat_extractor
+from kale.embed.video_feature_extractor import get_extractor_video, get_extractor_feat
 from kale.pipeline import domain_adapter, video_domain_adapter
 from kale.predict.class_domain_nets import ClassNetVideo, DomainNetVideo
 
@@ -76,12 +76,12 @@ def get_model(cfg, dataset, dict_num_classes):
 
     # setup feature extractor
     if input_type == "image":
-        feature_network, class_feature_dim, domain_feature_dim = get_video_feat_extractor(
+        feature_network, class_feature_dim, domain_feature_dim = get_extractor_video(
             cfg.MODEL.METHOD.upper(), cfg.DATASET.IMAGE_MODALITY, cfg.MODEL.ATTENTION, dict_num_classes
         )
     else:
         feature_network, class_feature_dim, domain_feature_dim = get_extractor_feat(
-            cfg.DAN.METHOD.upper(), cfg.DATASET.IMAGE_MODALITY, dict_num_classes, input_size=1024, output_size=256,
+            cfg.DAN.METHOD.upper(), cfg.DATASET.IMAGE_MODALITY, input_size=1024, output_size=256,
         )
 
     # setup task classifier
@@ -98,7 +98,6 @@ def get_model(cfg, dataset, dict_num_classes):
             image_modality=cfg.DATASET.IMAGE_MODALITY,
             feature_extractor=feature_network,
             task_classifier=classifier_network,
-            input_type=input_type,
             class_type=class_type,
             **method_params,
             **train_params_local,
@@ -124,7 +123,6 @@ def get_model(cfg, dataset, dict_num_classes):
             feature_extractor=feature_network,
             task_classifier=classifier_network,
             critic=critic_network,
-            input_type=input_type,
             class_type=class_type,
             **method_params,
             **train_params_local,

--- a/examples/action_dann_lightn/model.py
+++ b/examples/action_dann_lightn/model.py
@@ -54,22 +54,22 @@ def get_config(cfg):
 
 
 # Based on https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/utils/experimentation.py
-def get_model(cfg, dataset, num_classes):
+def get_model(cfg, dataset, dict_num_classes):
     """
     Builds and returns a model and associated hyper parameters according to the config object passed.
 
     Args:
         cfg: A YACS config object.
         dataset: A multi domain dataset consisting of source and target datasets.
-        num_classes: The class number of specific dataset.
+        dict_num_classes (dict): The dictionary of class number for specific dataset.
     """
 
     # setup feature extractor
     feature_network, class_feature_dim, domain_feature_dim = get_video_feat_extractor(
-        cfg.MODEL.METHOD.upper(), cfg.DATASET.IMAGE_MODALITY, cfg.MODEL.ATTENTION, num_classes
+        cfg.MODEL.METHOD.upper(), cfg.DATASET.IMAGE_MODALITY, cfg.MODEL.ATTENTION, dict_num_classes
     )
     # setup classifier
-    classifier_network = ClassNetVideo(input_size=class_feature_dim, n_class=num_classes)
+    classifier_network = ClassNetVideo(input_size=class_feature_dim, dict_n_class=dict_num_classes)
 
     config_params = get_config(cfg)
     train_params = config_params["train_params"]
@@ -95,7 +95,7 @@ def get_model(cfg, dataset, num_classes):
             if cfg.DAN.USERANDOM:
                 critic_input_size = cfg.DAN.RANDOM_DIM
             else:
-                critic_input_size = domain_feature_dim * num_classes
+                critic_input_size = domain_feature_dim * dict_num_classes["verb"]
         critic_network = DomainNetVideo(input_size=critic_input_size)
 
         if cfg.DAN.METHOD == "CDAN":

--- a/examples/action_dann_lightn/model.py
+++ b/examples/action_dann_lightn/model.py
@@ -81,7 +81,7 @@ def get_model(cfg, dataset, dict_num_classes):
         )
     else:
         feature_network, class_feature_dim, domain_feature_dim = get_extractor_feat(
-            cfg.DAN.METHOD.upper(), cfg.DATASET.IMAGE_MODALITY, input_size=1024, output_size=256,
+            cfg.DAN.METHOD.upper(), cfg.DATASET.IMAGE_MODALITY, input_size=1024, output_size=256, num_segments=cfg.DATASET.NUM_SEGMENTS
         )
 
     # setup task classifier

--- a/examples/action_dann_lightn/model.py
+++ b/examples/action_dann_lightn/model.py
@@ -77,7 +77,7 @@ def get_model(cfg, dataset, dict_num_classes):
     # setup feature extractor
     if input_type == "image":
         feature_network, class_feature_dim, domain_feature_dim = get_extractor_video(
-            cfg.MODEL.METHOD.upper(), cfg.DATASET.IMAGE_MODALITY, cfg.MODEL.ATTENTION, dict_num_classes
+            cfg.MODEL.METHOD.upper(), cfg.DATASET.IMAGE_MODALITY, cfg.MODEL.ATTENTION, dict_num_classes["verb"]
         )
     else:
         feature_network, class_feature_dim, domain_feature_dim = get_extractor_feat(

--- a/examples/action_dann_lightn/model.py
+++ b/examples/action_dann_lightn/model.py
@@ -48,6 +48,7 @@ def get_config(cfg):
             "target": cfg.DATASET.TARGET,
             "size_type": cfg.DATASET.SIZE_TYPE,
             "weight_type": cfg.DATASET.WEIGHT_TYPE,
+            "class_type": cfg.DATASET.CLASS_TYPE,
         },
     }
     return config_params
@@ -74,6 +75,9 @@ def get_model(cfg, dataset, dict_num_classes):
     config_params = get_config(cfg)
     train_params = config_params["train_params"]
     train_params_local = deepcopy(train_params)
+    data_params = config_params["data_params"]
+    data_params_local = deepcopy(data_params)
+    class_type = data_params_local["class_type"]
     method_params = {}
 
     method = domain_adapter.Method(cfg.DAN.METHOD)
@@ -85,6 +89,7 @@ def get_model(cfg, dataset, dict_num_classes):
             image_modality=cfg.DATASET.IMAGE_MODALITY,
             feature_extractor=feature_network,
             task_classifier=classifier_network,
+            class_type=class_type,
             **method_params,
             **train_params_local,
         )
@@ -109,6 +114,7 @@ def get_model(cfg, dataset, dict_num_classes):
             feature_extractor=feature_network,
             task_classifier=classifier_network,
             critic=critic_network,
+            class_type=class_type,
             **method_params,
             **train_params_local,
         )

--- a/examples/action_dann_lightn/model.py
+++ b/examples/action_dann_lightn/model.py
@@ -81,7 +81,11 @@ def get_model(cfg, dataset, dict_num_classes):
         )
     else:
         feature_network, class_feature_dim, domain_feature_dim = get_extractor_feat(
-            cfg.DAN.METHOD.upper(), cfg.DATASET.IMAGE_MODALITY, input_size=1024, output_size=256, num_segments=cfg.DATASET.NUM_SEGMENTS
+            cfg.DAN.METHOD.upper(),
+            cfg.DATASET.IMAGE_MODALITY,
+            input_size=1024,
+            output_size=256,
+            num_segments=cfg.DATASET.NUM_SEGMENTS,
         )
 
     # setup task classifier

--- a/kale/embed/attention_cnn.py
+++ b/kale/embed/attention_cnn.py
@@ -151,9 +151,7 @@ class CNNTransformer(ContextCNNGeneric):
 
 
 class SelfAttention(nn.Module):
-    """
-    A vanilla multi-head attention layer with a projection at the end. Can be set to causal or not causal.
-    """
+    """A vanilla multi-head attention layer with a projection at the end. Can be set to causal or not causal."""
 
     def __init__(
         self, emb_dim, num_heads, att_dropout, final_dropout, causal=False, max_seq_len=10000, use_performer_att=False

--- a/kale/embed/attention_cnn.py
+++ b/kale/embed/attention_cnn.py
@@ -1,7 +1,9 @@
+import math
 from typing import Tuple
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 
 from kale.embed.positional_encoding import PositionalEncoding
 from kale.embed.video_selayer import SELayerFeat
@@ -146,6 +148,7 @@ class CNNTransformer(ContextCNNGeneric):
         for p in encoder.parameters():
             if p.dim() > 1:
                 nn.init.xavier_uniform_(p)
+
 
 class SelfAttention(nn.Module):
     """

--- a/kale/embed/attention_cnn.py
+++ b/kale/embed/attention_cnn.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn as nn
 
 from kale.embed.positional_encoding import PositionalEncoding
+from kale.embed.video_selayer import SELayerFeat
 from kale.prepdata.tensor_reshape import seq_to_spatial, spatial_to_seq
 
 
@@ -145,3 +146,127 @@ class CNNTransformer(ContextCNNGeneric):
         for p in encoder.parameters():
             if p.dim() > 1:
                 nn.init.xavier_uniform_(p)
+
+class SelfAttention(nn.Module):
+    """
+    A vanilla multi-head attention layer with a projection at the end. Can be set to causal or not causal.
+    """
+
+    def __init__(
+        self, emb_dim, num_heads, att_dropout, final_dropout, causal=False, max_seq_len=10000, use_performer_att=False
+    ):
+        super().__init__()
+        assert emb_dim % num_heads == 0
+        # key, query, value projections for all heads
+        self.key = nn.Linear(emb_dim, emb_dim)
+        self.query = nn.Linear(emb_dim, emb_dim)
+        self.value = nn.Linear(emb_dim, emb_dim)
+        # regularization
+        self.att_dropout = nn.Dropout(att_dropout)
+        self.final_dropout = nn.Dropout(final_dropout)
+        # output projection
+        self.proj = nn.Linear(emb_dim, emb_dim)
+        self.causal = causal
+        if causal:
+            # causal mask to ensure that attention is only applied to the left in the input sequence
+            self.register_buffer(
+                "mask", torch.tril(torch.ones(max_seq_len, max_seq_len)).view(1, 1, max_seq_len, max_seq_len)
+            )
+
+        self.num_heads = num_heads
+
+        self.use_performer_att = use_performer_att
+        # if self.use_performer_att:
+        #     self.performer_att = FastAttention(dim_heads=emb_dim//num_heads, nb_features=emb_dim, causal=False)
+
+    def forward(self, x):
+        B, T, C = x.size()
+
+        # calculate query, key, values for all heads in batch and move head forward to be the batch dim
+        k = self.key(x).view(B, T, self.num_heads, C // self.num_heads).transpose(1, 2)  # (B, nh, T, hs)
+        q = self.query(x).view(B, T, self.num_heads, C // self.num_heads).transpose(1, 2)  # (B, nh, T, hs)
+        v = self.value(x).view(B, T, self.num_heads, C // self.num_heads).transpose(1, 2)  # (B, nh, T, hs)
+
+        if not self.use_performer_att:
+            # causal self-attention; Self-attend: (B, nh, T, hs) x (B, nh, hs, T) -> (B, nh, T, T)
+            att = (q @ k.transpose(-2, -1)) * (1.0 / math.sqrt(k.size(-1)))
+            if self.causal:
+                att = att.masked_fill(self.mask[:, :, :T, :T] == 0, float("-inf"))
+            att = F.softmax(att, dim=-1)
+            att = self.att_dropout(att)
+            y = att @ v  # (B, nh, T, T) x (B, nh, T, hs) -> (B, nh, T, hs)
+        else:
+            y = self.performer_att(q, k, v)
+
+        y = y.transpose(1, 2).contiguous().view(B, T, C)  # re-assemble all head outputs side by side
+
+        # output projection
+        y = self.final_dropout(self.proj(y))
+        return y
+
+
+class TransformerBlock(nn.Module):
+    """
+    Standard transformer block consisting of multi-head attention and two-layer MLP.
+    """
+
+    def __init__(
+        self, emb_dim, num_heads, att_dropout, att_resid_dropout, final_dropout, max_seq_len, ff_dim, causal=False,
+    ):
+        super().__init__()
+        self.ln1 = nn.LayerNorm(emb_dim)
+        self.ln2 = nn.LayerNorm(emb_dim)
+        self.attn = SelfAttention(emb_dim, num_heads, att_dropout, att_resid_dropout, causal, max_seq_len)
+        self.mlp = nn.Sequential(
+            nn.Linear(emb_dim, ff_dim), nn.GELU(), nn.Linear(ff_dim, emb_dim), nn.Dropout(final_dropout),
+        )
+
+    def forward(self, x):
+        # BATCH, TIME, CHANNELS = x.size()
+        x = x + self.attn(self.ln1(x))
+        x = x + self.mlp(self.ln2(x))
+        return x
+
+
+class TransformerSENet(nn.Module):
+    """Regular simple network for video input.
+    Args:
+        input_size (int, optional): the dimension of the final feature vector. Defaults to 512.
+        n_channel (int, optional): the number of channel for Linear and BN layers.
+        output_size (int, optional): the dimension of output.
+        dropout_keep_prob (int, optional): the dropout probability for keeping the parameters.
+    """
+
+    def __init__(self, input_size=512, n_channel=512, output_size=256, dropout_keep_prob=0.5):
+        super(TransformerSENet, self).__init__()
+        self.hidden_sizes = 512
+        self.num_layers = 4
+
+        self.transformer = nn.ModuleList(
+            [
+                TransformerBlock(
+                    emb_dim=input_size,
+                    num_heads=8,
+                    att_dropout=0.1,
+                    att_resid_dropout=0.1,
+                    final_dropout=0.1,
+                    max_seq_len=9,
+                    ff_dim=self.hidden_sizes,
+                    causal=False,
+                )
+                for _ in range(self.num_layers)
+            ]
+        )
+
+        self.fc1 = nn.Linear(input_size, n_channel)
+        self.relu1 = nn.ReLU()
+        self.dp1 = nn.Dropout(dropout_keep_prob)
+        self.fc2 = nn.Linear(n_channel, output_size)
+        self.selayer = SELayerFeat(channel=8, reduction=2)
+
+    def forward(self, x):
+        for layer in self.transformer:
+            x = layer(x)
+        x = self.fc2(self.dp1(self.relu1(self.fc1(x))))
+        x = self.selayer(x)
+        return x

--- a/kale/embed/video_feature_extractor.py
+++ b/kale/embed/video_feature_extractor.py
@@ -36,7 +36,7 @@ def get_extractor_video(model_name, image_modality, attention, dict_num_classes)
         domain_feature_dim (int): The dimension of the feature network output for DomainNet.
     """
 
-    rgb, flow = get_image_modality(image_modality)
+    rgb, flow, audio = get_image_modality(image_modality)
     # only use verb class when input is image.
     num_classes = dict_num_classes["verb"]
 

--- a/kale/embed/video_feature_extractor.py
+++ b/kale/embed/video_feature_extractor.py
@@ -16,7 +16,7 @@ from kale.embed.video_se_res3d import se_mc3, se_r2plus1d, se_r3d
 from kale.loaddata.video_access import get_image_modality
 
 
-def get_extractor_video(model_name, image_modality, attention, dict_num_classes):
+def get_extractor_video(model_name, image_modality, attention, num_classes):
     """
     Get the feature extractor w/o the pre-trained model and SELayers. The pre-trained models are saved in the path
     ``$XDG_CACHE_HOME/torch/hub/checkpoints/``. For Linux, default path is ``~/.cache/torch/hub/checkpoints/``.
@@ -27,7 +27,7 @@ def get_extractor_video(model_name, image_modality, attention, dict_num_classes)
         model_name (string): The name of the feature extractor. (Choices=["I3D", "R3D_18", "R2PLUS1D_18", "MC3_18"])
         image_modality (string): Image type. (Choices=["rgb", "flow", "joint"])
         attention (string): The attention type. (Choices=["SELayerC", "SELayerT", "SELayerCoC", "SELayerMC", "SELayerCT", "SELayerTC", "SELayerMAC"])
-        dict_num_classes (dict): The class number of specific dataset. (Default: No use)
+        num_classes (int): The class number of specific dataset. (Default: No use)
 
     Returns:
         feature_network (dictionary): The network to extract features.
@@ -37,8 +37,6 @@ def get_extractor_video(model_name, image_modality, attention, dict_num_classes)
     """
 
     rgb, flow, audio = get_image_modality(image_modality)
-    # only use verb class when input is image.
-    num_classes = dict_num_classes["verb"]
 
     attention_list = ["SELayerC", "SELayerT", "SELayerCoC", "SELayerMC", "SELayerCT", "SELayerTC", "SELayerMAC"]
     model_list = ["I3D", "R3D_18", "MC3_18", "R2PLUS1D_18"]

--- a/kale/embed/video_feature_extractor.py
+++ b/kale/embed/video_feature_extractor.py
@@ -26,7 +26,7 @@ def get_video_feat_extractor(model_name, image_modality, attention, dict_num_cla
         model_name (string): The name of the feature extractor. (Choices=["I3D", "R3D_18", "R2PLUS1D_18", "MC3_18"])
         image_modality (string): Image type. (Choices=["rgb", "flow", "joint"])
         attention (string): The attention type. (Choices=["SELayerC", "SELayerT", "SELayerCoC", "SELayerMC", "SELayerCT", "SELayerTC", "SELayerMAC"])
-        dict_num_classes (int): The class number of specific dataset. (Default: No use)
+        dict_num_classes (dict): The class number of specific dataset. (Default: No use)
 
     Returns:
         feature_network (dictionary): The network to extract features.

--- a/kale/embed/video_feature_extractor.py
+++ b/kale/embed/video_feature_extractor.py
@@ -115,7 +115,7 @@ def get_extractor_video(model_name, image_modality, attention, dict_num_classes)
             else:
                 logging.info("{} with {}.".format(model_name, attention))
                 feature_network = se_mc3(rgb=rgb, flow=flow, pretrained=True, attention=attention)
-
+    feature_network.update({"audio": None})
     return feature_network, int(class_feature_dim), int(domain_feature_dim)
 
 

--- a/kale/embed/video_feature_extractor.py
+++ b/kale/embed/video_feature_extractor.py
@@ -27,7 +27,7 @@ def get_extractor_video(model_name, image_modality, attention, num_classes):
         model_name (string): The name of the feature extractor. (Choices=["I3D", "R3D_18", "R2PLUS1D_18", "MC3_18"])
         image_modality (string): Image type. (Choices=["rgb", "flow", "joint"])
         attention (string): The attention type. (Choices=["SELayerC", "SELayerT", "SELayerCoC", "SELayerMC", "SELayerCT", "SELayerTC", "SELayerMAC"])
-        num_classes (int): The class number of specific dataset. (Default: No use)
+        num_classes (int): The class number of specific dataset.
 
     Returns:
         feature_network (dictionary): The network to extract features.

--- a/kale/embed/video_feature_extractor.py
+++ b/kale/embed/video_feature_extractor.py
@@ -15,7 +15,7 @@ from kale.embed.video_se_res3d import se_mc3, se_r2plus1d, se_r3d
 from kale.loaddata.video_access import get_image_modality
 
 
-def get_video_feat_extractor(model_name, image_modality, attention, num_classes):
+def get_video_feat_extractor(model_name, image_modality, attention, dict_num_classes):
     """
     Get the feature extractor w/o the pre-trained model and SELayers. The pre-trained models are saved in the path
     ``$XDG_CACHE_HOME/torch/hub/checkpoints/``. For Linux, default path is ``~/.cache/torch/hub/checkpoints/``.
@@ -26,7 +26,7 @@ def get_video_feat_extractor(model_name, image_modality, attention, num_classes)
         model_name (string): The name of the feature extractor. (Choices=["I3D", "R3D_18", "R2PLUS1D_18", "MC3_18"])
         image_modality (string): Image type. (Choices=["rgb", "flow", "joint"])
         attention (string): The attention type. (Choices=["SELayerC", "SELayerT", "SELayerCoC", "SELayerMC", "SELayerCT", "SELayerTC", "SELayerMAC"])
-        num_classes (int): The class number of specific dataset. (Default: No use)
+        dict_num_classes (int): The class number of specific dataset. (Default: No use)
 
     Returns:
         feature_network (dictionary): The network to extract features.
@@ -34,7 +34,10 @@ def get_video_feat_extractor(model_name, image_modality, attention, num_classes)
                             It is a convention when the input dimension and the network is fixed.
         domain_feature_dim (int): The dimension of the feature network output for DomainNet.
     """
+
     rgb, flow = get_image_modality(image_modality)
+    # only use verb class when input is image.
+    num_classes = dict_num_classes["verb"]
 
     attention_list = ["SELayerC", "SELayerT", "SELayerCoC", "SELayerMC", "SELayerCT", "SELayerTC", "SELayerMAC"]
     model_list = ["I3D", "R3D_18", "MC3_18", "R2PLUS1D_18"]

--- a/kale/embed/video_feature_extractor.py
+++ b/kale/embed/video_feature_extractor.py
@@ -119,7 +119,7 @@ def get_extractor_video(model_name, image_modality, attention, dict_num_classes)
     return feature_network, int(class_feature_dim), int(domain_feature_dim)
 
 
-def get_extractor_feat(model_name, image_modality, input_size=1024, output_size=256):
+def get_extractor_feat(model_name, image_modality, input_size=1024, output_size=256, num_segments=8):
     """Get the extractor for feature input.
     """
     logging.info("{}".format(model_name))
@@ -132,7 +132,7 @@ def get_extractor_feat(model_name, image_modality, input_size=1024, output_size=
     if audio:
         feature_network_audio = TransformerSENet(input_size=input_size, output_size=output_size)
 
-    domain_feature_dim = int(output_size * 8)
+    domain_feature_dim = int(output_size * num_segments)
     if rgb:
         if flow:
             if audio:  # For all inputs

--- a/kale/embed/video_feature_extractor.py
+++ b/kale/embed/video_feature_extractor.py
@@ -8,6 +8,7 @@ Define the feature extractor for video including I3D, R3D_18, MC3_18 and R2PLUS1
 
 import logging
 
+from kale.embed.attention_cnn import TransformerSENet
 from kale.embed.video_i3d import i3d_joint
 from kale.embed.video_res3d import mc3, r2plus1d, r3d
 from kale.embed.video_se_i3d import se_i3d_joint
@@ -15,7 +16,7 @@ from kale.embed.video_se_res3d import se_mc3, se_r2plus1d, se_r3d
 from kale.loaddata.video_access import get_image_modality
 
 
-def get_video_feat_extractor(model_name, image_modality, attention, dict_num_classes):
+def get_extractor_video(model_name, image_modality, attention, dict_num_classes):
     """
     Get the feature extractor w/o the pre-trained model and SELayers. The pre-trained models are saved in the path
     ``$XDG_CACHE_HOME/torch/hub/checkpoints/``. For Linux, default path is ``~/.cache/torch/hub/checkpoints/``.
@@ -116,3 +117,44 @@ def get_video_feat_extractor(model_name, image_modality, attention, dict_num_cla
                 feature_network = se_mc3(rgb=rgb, flow=flow, pretrained=True, attention=attention)
 
     return feature_network, int(class_feature_dim), int(domain_feature_dim)
+
+
+def get_extractor_feat(model_name, image_modality, input_size=1024, output_size=256):
+    """Get the extractor for feature input.
+    """
+    logging.info("{}".format(model_name))
+    rgb, flow, audio = get_image_modality(image_modality)
+    feature_network_rgb = feature_network_flow = feature_network_audio = None
+    if rgb:
+        feature_network_rgb = TransformerSENet(input_size=input_size, output_size=output_size)
+    if flow:
+        feature_network_flow = TransformerSENet(input_size=input_size, output_size=output_size)
+    if audio:
+        feature_network_audio = TransformerSENet(input_size=input_size, output_size=output_size)
+
+    domain_feature_dim = int(output_size * 8)
+    if rgb:
+        if flow:
+            if audio:  # For all inputs
+                class_feature_dim = int(domain_feature_dim * 3)
+            else:  # For joint(rgb+flow) input
+                class_feature_dim = int(domain_feature_dim * 2)
+        else:
+            if audio:  # For rgb+audio input
+                class_feature_dim = int(domain_feature_dim * 2)
+            else:  # For rgb input
+                class_feature_dim = domain_feature_dim
+    else:
+        if flow:
+            if audio:  # For flow+audio input
+                class_feature_dim = int(domain_feature_dim * 2)
+            else:  # For flow input
+                class_feature_dim = domain_feature_dim
+        else:  # For audio input
+            class_feature_dim = domain_feature_dim
+
+    return (
+        {"rgb": feature_network_rgb, "flow": feature_network_flow, "audio": feature_network_audio},
+        int(class_feature_dim),
+        int(domain_feature_dim),
+    )

--- a/kale/embed/video_selayer.py
+++ b/kale/embed/video_selayer.py
@@ -105,6 +105,23 @@ class SELayerT(SELayer):
         return out
 
 
+class SELayerFeat(SELayer):
+    """Construct channel-wise SELayer for feature vector input."""
+
+    def __init__(self, channel, reduction=2):
+        super(SELayerFeat, self).__init__(channel, reduction)
+        self.avg_pool = nn.AdaptiveAvgPool1d(1)
+
+    def forward(self, x):
+        b, t, _ = x.size()
+        y = self.avg_pool(x).view(b, t)
+        y = self.fc(y).view(b, t, 1)
+        # out = x * y.expand_as(x)
+        y = y - 0.5
+        out = x + x * y.expand_as(x)
+        return out
+
+
 class SELayerCoC(SELayer):
     """Construct convolution-based channel-wise SELayer."""
 
@@ -184,3 +201,6 @@ class SELayerMAC(SELayer):
         y = y - 0.5
         out = x + x * y.expand_as(x)
         return out
+
+
+

--- a/kale/embed/video_selayer.py
+++ b/kale/embed/video_selayer.py
@@ -111,6 +111,12 @@ class SELayerFeat(SELayer):
     def __init__(self, channel, reduction=2):
         super(SELayerFeat, self).__init__(channel, reduction)
         self.avg_pool = nn.AdaptiveAvgPool1d(1)
+        self.fc = nn.Sequential(
+            nn.Linear(self.channel, self.channel // self.reduction, bias=False),
+            nn.ReLU(inplace=True),
+            nn.Linear(self.channel // self.reduction, self.channel, bias=False),
+            nn.Sigmoid(),
+        )
 
     def forward(self, x):
         b, t, _ = x.size()

--- a/kale/embed/video_selayer.py
+++ b/kale/embed/video_selayer.py
@@ -201,6 +201,3 @@ class SELayerMAC(SELayer):
         y = y - 0.5
         out = x + x * y.expand_as(x)
         return out
-
-
-

--- a/kale/loaddata/dataset_access.py
+++ b/kale/loaddata/dataset_access.py
@@ -52,12 +52,12 @@ class DatasetAccess:
 def get_class_subset(dataset, class_ids):
     """
     Args:
-        dataset: a torch.utils.data.Dataset
+        dataset: a torch.utils.data.Dataset (every batch is a tensor of (x, list[y1, y2, ...], id))
         class_ids (list, optional): List of chosen subset of class ids.
     Returns: a torch.utils.data.Dataset
         Dataset: a torch.utils.data.Dataset with only classes in class_ids
     """
-    sub_indices = [i for i in range(0, len(dataset)) if dataset[i][1] in class_ids]
+    sub_indices = [i for i in range(0, len(dataset)) if dataset[i][1][0] in class_ids]
     return torch.utils.data.Subset(dataset, sub_indices)
 
 

--- a/kale/loaddata/multi_domain.py
+++ b/kale/loaddata/multi_domain.py
@@ -198,7 +198,7 @@ class MultiDomainDatasets(DomainsDatasetBase):
                 target_labeled_ds, batch_size=min(len(target_labeled_ds), batch_size)
             )
             target_unlabeled_loader = self._target_sampling_config.create_loader(target_unlabeled_ds, batch_size)
-            n_dataset = DatasetSizeType.get_size(self._size_type, source_ds, target_labeled_ds, target_unlabeled_ds)
+            n_dataset, _ = DatasetSizeType.get_size(self._size_type, source_ds, target_labeled_ds, target_unlabeled_ds)
             return MultiDataLoader(
                 dataloaders=[source_loader, target_labeled_loader, target_unlabeled_loader],
                 n_batches=max(n_dataset // batch_size, 1),
@@ -208,10 +208,10 @@ class MultiDomainDatasets(DomainsDatasetBase):
         source_ds = self._source_by_split["train"]
         target_ds = self._target_by_split["train"]
         if self._labeled_target_by_split is None:
-            return DatasetSizeType.get_size(self._size_type, source_ds, target_ds)
+            return DatasetSizeType.get_size(self._size_type, source_ds, target_ds)[0]
         else:
             labeled_target_ds = self._labeled_target_by_split["train"]
-            return DatasetSizeType.get_size(self._size_type, source_ds, labeled_target_ds, target_ds)
+            return DatasetSizeType.get_size(self._size_type, source_ds, labeled_target_ds, target_ds)[0]
 
 
 def _split_dataset_few_shot(dataset, n_fewshot, random_state=None):

--- a/kale/loaddata/multi_domain.py
+++ b/kale/loaddata/multi_domain.py
@@ -185,7 +185,7 @@ class MultiDomainDatasets(DomainsDatasetBase):
         if self._labeled_target_by_split is None:
             # unsupervised target domain
             target_loader = self._target_sampling_config.create_loader(target_ds, batch_size)
-            n_dataset = DatasetSizeType.get_size(self._size_type, source_ds, target_ds)
+            n_dataset, _ = DatasetSizeType.get_size(self._size_type, source_ds, target_ds)
             return MultiDataLoader(
                 dataloaders=[source_loader, target_loader], n_batches=max(n_dataset // batch_size, 1),
             )

--- a/kale/loaddata/multi_domain.py
+++ b/kale/loaddata/multi_domain.py
@@ -27,13 +27,19 @@ class WeightingType(Enum):
 class DatasetSizeType(Enum):
     Max = "max"  # size of the biggest dataset
     Source = "source"  # size of the source dataset
+    Adaptive = "adaptive"  # adaptive batch size between source and target dataset, based on the ratio of the sizes
 
     @staticmethod
-    def get_size(size_type, source_dataset, *other_datasets):
+    def get_size(size_type, batch_size, source_dataset, *other_datasets):
         if size_type is DatasetSizeType.Max:
-            return max(list(map(len, other_datasets)) + [len(source_dataset)])
+            return max(list(map(len, other_datasets)) + [len(source_dataset)]), batch_size
         elif size_type is DatasetSizeType.Source:
-            return len(source_dataset)
+            return len(source_dataset), batch_size
+        elif size_type is DatasetSizeType.Adaptive:
+            if len(other_datasets) > 1:
+                raise ValueError("Invalid SIZE_TYPE. Not support {} for semi-supervised".format(size_type))
+            target_batch_size = int(batch_size * len(other_datasets[0]) / len(source_dataset))
+            return len(source_dataset), target_batch_size
         else:
             raise ValueError(f"Size type size must be 'max' or 'source', had '{size_type}'")
 

--- a/kale/loaddata/sampler.py
+++ b/kale/loaddata/sampler.py
@@ -54,10 +54,11 @@ class SamplingConfig:
 
 
 class FixedSeedSamplingConfig(SamplingConfig):
-    def __init__(self, seed=1, balance=False, class_weights=None, balance_domain=False):
+    def __init__(self, seed=1, num_workers=1, balance=False, class_weights=None, balance_domain=False):
         """Sampling with fixed seed."""
         super(FixedSeedSamplingConfig, self).__init__(balance, class_weights, balance_domain)
         self._seed = seed
+        self._num_workers = num_workers
 
     def create_loader(self, dataset, batch_size):
         """Create the data loader with fixed seed."""
@@ -78,7 +79,7 @@ class FixedSeedSamplingConfig(SamplingConfig):
             else:
                 sub_sampler = RandomSampler(dataset, generator=torch.Generator().manual_seed(self._seed))
             sampler = BatchSampler(sub_sampler, batch_size=batch_size, drop_last=True)
-        return torch.utils.data.DataLoader(dataset=dataset, batch_sampler=sampler)
+        return torch.utils.data.DataLoader(dataset=dataset, batch_sampler=sampler, num_workers=self._num_workers)
 
 
 # TODO: deterministic shuffle?

--- a/kale/loaddata/sampler.py
+++ b/kale/loaddata/sampler.py
@@ -54,7 +54,7 @@ class SamplingConfig:
 
 
 class FixedSeedSamplingConfig(SamplingConfig):
-    def __init__(self, seed=1, num_workers=1, balance=False, class_weights=None, balance_domain=False):
+    def __init__(self, seed=1, num_workers=0, balance=False, class_weights=None, balance_domain=False):
         """Sampling with fixed seed."""
         super(FixedSeedSamplingConfig, self).__init__(balance, class_weights, balance_domain)
         self._seed = seed

--- a/kale/loaddata/video_access.py
+++ b/kale/loaddata/video_access.py
@@ -48,6 +48,7 @@ def get_videodata_config(cfg):
             "dataset_tgt_trainlist": cfg.DATASET.TGT_TRAINLIST,
             "dataset_tgt_testlist": cfg.DATASET.TGT_TESTLIST,
             "dataset_image_modality": cfg.DATASET.IMAGE_MODALITY,
+            "dataset_num_segments": cfg.DATASET.NUM_SEGMENTS,
             "frames_per_segment": cfg.DATASET.FRAMES_PER_SEGMENT,
         }
     }
@@ -117,6 +118,7 @@ class VideoDataset(Enum):
         data_tgt_name = data_params_local["dataset_tgt_name"].upper()
         tgt_data_path, tgt_tr_listpath, tgt_te_listpath = generate_list(data_tgt_name, data_params_local, domain="tgt")
         image_modality = data_params_local["dataset_image_modality"]
+        num_segments = data_params_local["dataset_num_segments"]
         frames_per_segment = data_params_local["frames_per_segment"]
 
         rgb, flow = get_image_modality(image_modality)
@@ -155,6 +157,7 @@ class VideoDataset(Enum):
                 src_tr_listpath,
                 src_te_listpath,
                 "rgb",
+                num_segments,
                 frames_per_segment,
                 num_classes,
                 source_tf,
@@ -165,6 +168,7 @@ class VideoDataset(Enum):
                 tgt_tr_listpath,
                 tgt_te_listpath,
                 "rgb",
+                num_segments,
                 frames_per_segment,
                 num_classes,
                 target_tf,
@@ -177,6 +181,7 @@ class VideoDataset(Enum):
                 src_tr_listpath,
                 src_te_listpath,
                 "flow",
+                num_segments,
                 frames_per_segment,
                 num_classes,
                 source_tf,
@@ -187,6 +192,7 @@ class VideoDataset(Enum):
                 tgt_tr_listpath,
                 tgt_te_listpath,
                 "flow",
+                num_segments,
                 frames_per_segment,
                 num_classes,
                 target_tf,
@@ -216,7 +222,16 @@ class VideoDatasetAccess(DatasetAccess):
     """
 
     def __init__(
-            self, data_path, train_list, test_list, image_modality, num_segments, frames_per_segment, n_classes, transform, seed
+        self,
+        data_path,
+        train_list,
+        test_list,
+        image_modality,
+        num_segments,
+        frames_per_segment,
+        n_classes,
+        transform,
+        seed,
     ):
         super().__init__(n_classes)
         self._data_path = data_path
@@ -380,18 +395,18 @@ class EPIC100DatasetAccess(VideoDatasetAccess):
     """EPIC-100 video feature data loader"""
 
     def __init__(
-            self,
-            domain,
-            data_path,
-            train_list,
-            test_list,
-            image_modality,
-            num_segments,
-            frames_per_segment,
-            n_classes,
-            transform,
-            seed,
-            input_type,
+        self,
+        domain,
+        data_path,
+        train_list,
+        test_list,
+        image_modality,
+        num_segments,
+        frames_per_segment,
+        n_classes,
+        transform,
+        seed,
+        input_type,
     ):
         super(EPIC100DatasetAccess, self).__init__(
             data_path,

--- a/kale/loaddata/video_access.py
+++ b/kale/loaddata/video_access.py
@@ -391,7 +391,7 @@ class EPICDatasetAccess(VideoDatasetAccess):
         return EPIC(
             root_path=self._data_path,
             annotationfile_path=self._train_list,
-            num_segments=1,
+            num_segments=self._num_segments,  # 1
             frames_per_segment=self._frames_per_segment,
             imagefile_template="frame_{:010d}.jpg",
             transform=self._transform["train"],
@@ -406,7 +406,7 @@ class EPICDatasetAccess(VideoDatasetAccess):
         return EPIC(
             root_path=self._data_path,
             annotationfile_path=self._test_list,
-            num_segments=1,
+            num_segments=self._num_segments,  # 1
             frames_per_segment=self._frames_per_segment,
             imagefile_template="frame_{:010d}.jpg",
             transform=self._transform["test"],
@@ -425,7 +425,7 @@ class GTEADatasetAccess(VideoDatasetAccess):
         return BasicVideoDataset(
             root_path=self._data_path,
             annotationfile_path=self._train_list,
-            num_segments=1,
+            num_segments=self._num_segments,  # 1
             frames_per_segment=self._frames_per_segment,
             imagefile_template="frame_{:010d}.jpg" if self._image_modality in ["rgb"] else "flow_{}_{:010d}.jpg",
             transform=self._transform["train"],
@@ -440,7 +440,7 @@ class GTEADatasetAccess(VideoDatasetAccess):
         return BasicVideoDataset(
             root_path=self._data_path,
             annotationfile_path=self._test_list,
-            num_segments=1,
+            num_segments=self._num_segments,  # 1
             frames_per_segment=self._frames_per_segment,
             imagefile_template="frame_{:010d}.jpg" if self._image_modality in ["rgb"] else "flow_{}_{:010d}.jpg",
             transform=self._transform["test"],
@@ -459,7 +459,7 @@ class ADLDatasetAccess(VideoDatasetAccess):
         return BasicVideoDataset(
             root_path=self._data_path,
             annotationfile_path=self._train_list,
-            num_segments=1,
+            num_segments=self._num_segments,  # 1
             frames_per_segment=self._frames_per_segment,
             imagefile_template="frame_{:010d}.jpg" if self._image_modality in ["rgb"] else "flow_{}_{:010d}.jpg",
             transform=self._transform["train"],
@@ -474,7 +474,7 @@ class ADLDatasetAccess(VideoDatasetAccess):
         return BasicVideoDataset(
             root_path=self._data_path,
             annotationfile_path=self._test_list,
-            num_segments=1,
+            num_segments=self._num_segments,  # 1
             frames_per_segment=self._frames_per_segment,
             imagefile_template="frame_{:010d}.jpg" if self._image_modality in ["rgb"] else "flow_{}_{:010d}.jpg",
             transform=self._transform["test"],
@@ -493,7 +493,7 @@ class KITCHENDatasetAccess(VideoDatasetAccess):
         return BasicVideoDataset(
             root_path=self._data_path,
             annotationfile_path=self._train_list,
-            num_segments=1,
+            num_segments=self._num_segments,  # 1
             frames_per_segment=self._frames_per_segment,
             imagefile_template="frame_{:010d}.jpg" if self._image_modality in ["rgb"] else "flow_{}_{:010d}.jpg",
             transform=self._transform["train"],
@@ -508,7 +508,7 @@ class KITCHENDatasetAccess(VideoDatasetAccess):
         return BasicVideoDataset(
             root_path=self._data_path,
             annotationfile_path=self._test_list,
-            num_segments=1,
+            num_segments=self._num_segments,  # 1
             frames_per_segment=self._frames_per_segment,
             imagefile_template="frame_{:010d}.jpg" if self._image_modality in ["rgb"] else "flow_{}_{:010d}.jpg",
             transform=self._transform["test"],
@@ -559,8 +559,7 @@ class EPIC100DatasetAccess(VideoDatasetAccess):
             # Uncomment to run on train subset for EPIC 2021 challenge
             # data_path=Path(self._data_path, self._input_type, "{}_train.pkl".format(self._domain)),
             annotationfile_path=self._train_list,
-            total_segments=25,
-            num_segments=self._num_segments,  # 1
+            num_segments=self._num_segments,  # 5
             frames_per_segment=self._frames_per_segment,  # 1
             image_modality=self._image_modality,
             imagefile_template="img_{:05d}.t7"
@@ -578,9 +577,8 @@ class EPIC100DatasetAccess(VideoDatasetAccess):
             # Uncomment to run on test subset for EPIC 2021 challenge
             # data_path=Path(self._data_path, self._input_type, "{}_test.pkl".format(self._domain)),
             annotationfile_path=self._test_list,
-            total_segments=25,
-            num_segments=self._num_segments,
-            frames_per_segment=self._frames_per_segment,
+            num_segments=self._num_segments,  # 5
+            frames_per_segment=self._frames_per_segment,  # 1
             image_modality=self._image_modality,
             imagefile_template="img_{:05d}.t7"
             if self._image_modality in ["RGB", "RGBDiff", "RGBDiff2", "RGBDiffplus"]

--- a/kale/loaddata/video_access.py
+++ b/kale/loaddata/video_access.py
@@ -8,7 +8,6 @@ Action video dataset loading for EPIC-Kitchen, ADL, GTEA, KITCHEN. The code is b
 https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/datasets/digits_dataset_access.py
 """
 
-import os
 from copy import deepcopy
 from enum import Enum
 from pathlib import Path
@@ -86,18 +85,18 @@ def generate_list(data_name, data_params_local, domain):
     """
 
     if data_name == "EPIC":
-        dataset_path = os.path.join(data_params_local["dataset_root"], data_name, "EPIC_KITCHENS_2018")
-        data_path = os.path.join(dataset_path, "frames_rgb_flow")
-    elif data_name in ["ADL", "GTEA", "KITCHEN"]:
-        dataset_path = os.path.join(data_params_local["dataset_root"], data_name)
-        data_path = os.path.join(dataset_path, "frames_rgb_flow")
+        dataset_path = Path(data_params_local["dataset_root"]).joinpath(data_name, "EPIC_KITCHENS_2018")
+    elif data_name in ["ADL", "GTEA", "KITCHEN", "EPIC100"]:
+        dataset_path = Path(data_params_local["dataset_root"]).joinpath(data_name)
     else:
-        raise ValueError("Wrong dataset name. Select from [EPIC, ADL, GTEA, KITCHEN]")
+        raise ValueError("Wrong dataset name. Select from [EPIC, ADL, GTEA, KITCHEN, EPIC100]")
 
-    train_listpath = os.path.join(
+    data_path = Path.joinpath(dataset_path, "frames_rgb_flow")
+
+    train_listpath = Path.joinpath(
         dataset_path, "annotations", "labels_train_test", data_params_local["dataset_{}_trainlist".format(domain)]
     )
-    test_listpath = os.path.join(
+    test_listpath = Path.joinpath(
         dataset_path, "annotations", "labels_train_test", data_params_local["dataset_{}_testlist".format(domain)]
     )
 
@@ -273,6 +272,20 @@ class VideoDataset(Enum):
                     frames_per_segment=frames_per_segment,
                     n_classes=num_verb_classes,
                     transform=source_tf,
+                    seed=seed,
+                    input_type=input_type,
+                )
+
+                flow_target = factories[source](
+                    domain="target",
+                    data_path=tgt_data_path,
+                    train_list=tgt_tr_listpath,
+                    test_list=tgt_te_listpath,
+                    image_modality="flow",
+                    num_segments=num_segments,
+                    frames_per_segment=frames_per_segment,
+                    n_classes=num_verb_classes,
+                    transform=target_tf,
                     seed=seed,
                     input_type=input_type,
                 )

--- a/kale/loaddata/video_access.py
+++ b/kale/loaddata/video_access.py
@@ -211,12 +211,12 @@ class VideoDatasetAccess(DatasetAccess):
         image_modality (string): image type (RGB or Optical Flow)
         frames_per_segment (int): length of each action sample (the unit is number of frame)
         n_classes (int): number of class
-        transform_kind (string): types of video transforms
+        transform (string): types of video transforms
         seed: (int): seed value set manually.
     """
 
     def __init__(
-            self, data_path, train_list, test_list, image_modality, num_segments, frames_per_segment, n_classes, transform_kind, seed
+            self, data_path, train_list, test_list, image_modality, num_segments, frames_per_segment, n_classes, transform, seed
     ):
         super().__init__(n_classes)
         self._data_path = data_path
@@ -225,7 +225,7 @@ class VideoDatasetAccess(DatasetAccess):
         self._image_modality = image_modality
         self._num_segments = num_segments
         self._frames_per_segment = frames_per_segment
-        self._transform = video_transform.get_transform(transform_kind, self._image_modality)
+        self._transform = video_transform.get_transform(transform, self._image_modality)
         self._seed = seed
 
     def get_train_valid(self, valid_ratio):

--- a/kale/loaddata/video_access.py
+++ b/kale/loaddata/video_access.py
@@ -35,6 +35,20 @@ def get_image_modality(image_modality):
     return rgb, flow
 
 
+def get_class_type(class_type):
+    """Change class_type (string) to verb (bool) and noun (bool) for efficiency. Only noun is NA because we
+    work on action recognition."""
+
+    verb = True
+    if class_type.lower() == "verb":
+        noun = False
+    elif class_type.lower() == "verb+noun":
+        noun = True
+    else:
+        raise ValueError("Invalid class type option: {}".format(class_type))
+    return verb, noun
+
+
 def get_videodata_config(cfg):
     """Get the configure parameters for video data from the cfg files"""
 
@@ -271,6 +285,7 @@ class VideoDatasetAccess(DatasetAccess):
         train_list (string): training list file directory of dataset
         test_list (string): test list file directory of dataset
         image_modality (string): image type (RGB or Optical Flow)
+        num_segments (int): number of segments the video should be divided into to sample frames from.
         frames_per_segment (int): length of each action sample (the unit is number of frame)
         n_classes (int): number of class
         transform (string): types of video transforms
@@ -278,16 +293,16 @@ class VideoDatasetAccess(DatasetAccess):
     """
 
     def __init__(
-        self,
-        data_path,
-        train_list,
-        test_list,
-        image_modality,
-        num_segments,
-        frames_per_segment,
-        n_classes,
-        transform,
-        seed,
+            self,
+            data_path,
+            train_list,
+            test_list,
+            image_modality,
+            num_segments,
+            frames_per_segment,
+            n_classes,
+            transform,
+            seed,
     ):
         super().__init__(n_classes)
         self._data_path = data_path
@@ -451,18 +466,18 @@ class EPIC100DatasetAccess(VideoDatasetAccess):
     """EPIC-100 video feature data loader"""
 
     def __init__(
-        self,
-        domain,
-        data_path,
-        train_list,
-        test_list,
-        image_modality,
-        num_segments,
-        frames_per_segment,
-        n_classes,
-        transform,
-        seed,
-        input_type,
+            self,
+            domain,
+            data_path,
+            train_list,
+            test_list,
+            image_modality,
+            num_segments,
+            frames_per_segment,
+            n_classes,
+            transform,
+            seed,
+            input_type,
     ):
         super(EPIC100DatasetAccess, self).__init__(
             data_path,

--- a/kale/loaddata/video_access.py
+++ b/kale/loaddata/video_access.py
@@ -566,7 +566,7 @@ class EPIC100DatasetAccess(VideoDatasetAccess):
             if self._image_modality in ["RGB", "RGBDiff", "RGBDiff2", "RGBDiffplus"]
             else self._input_type + "{}_{:05d}.t7",
             random_shift=False,
-            test_mode=True,
+            test_mode=False,
             input_type="feature",
             num_data_load=self._num_train_dataload,
         )
@@ -583,7 +583,7 @@ class EPIC100DatasetAccess(VideoDatasetAccess):
             imagefile_template="img_{:05d}.t7"
             if self._image_modality in ["RGB", "RGBDiff", "RGBDiff2", "RGBDiffplus"]
             else self._input_type + "{}_{:05d}.t7",
-            random_shift=True,
+            random_shift=False,
             test_mode=True,
             input_type="feature",
             num_data_load=self._num_test_dataload,

--- a/kale/loaddata/video_multi_domain.py
+++ b/kale/loaddata/video_multi_domain.py
@@ -337,7 +337,7 @@ class VideoMultiDomainDatasets(MultiDomainDatasets):
             target_ds = self._audio_target_by_split["train"]
 
         if self._labeled_target_by_split is None:
-            return DatasetSizeType.get_size(self._size_type, source_ds, target_ds)
+            return DatasetSizeType.get_size(self._size_type, source_ds, target_ds)[0]
         else:
             labeled_target_ds = self._labeled_target_by_split["train"]
-            return DatasetSizeType.get_size(self._size_type, source_ds, labeled_target_ds, target_ds)
+            return DatasetSizeType.get_size(self._size_type, source_ds, labeled_target_ds, target_ds)[0]

--- a/kale/loaddata/video_multi_domain.py
+++ b/kale/loaddata/video_multi_domain.py
@@ -175,7 +175,7 @@ class VideoMultiDomainDatasets(MultiDomainDatasets):
             logging.debug("Load audio train and val")
             (self._audio_source_by_split["train"], self._audio_source_by_split["valid"]) = self._source_access_dict[
                 "audio"
-            ].get_train_val(self._valid_split_ratio)
+            ].get_train_valid(self._valid_split_ratio)
             if self.class_ids is not None:
                 self._audio_source_by_split["train"] = get_class_subset(
                     self._audio_source_by_split["train"], self.class_ids
@@ -186,7 +186,7 @@ class VideoMultiDomainDatasets(MultiDomainDatasets):
 
             (self._audio_target_by_split["train"], self._audio_target_by_split["valid"]) = self._target_access_dict[
                 "audio"
-            ].get_train_val(self._valid_split_ratio)
+            ].get_train_valid(self._valid_split_ratio)
             if self.class_ids is not None:
                 self._audio_target_by_split["train"] = get_class_subset(
                     self._audio_target_by_split["train"], self.class_ids

--- a/kale/loaddata/video_multi_domain.py
+++ b/kale/loaddata/video_multi_domain.py
@@ -26,7 +26,7 @@ class VideoMultiDomainDatasets(MultiDomainDatasets):
         config_weight_type="natural",
         config_size_type=DatasetSizeType.Max,
         valid_split_ratio=0.1,
-        num_workers=1,
+        num_workers=0,
         source_sampling_config=None,
         target_sampling_config=None,
         n_fewshot=None,

--- a/kale/loaddata/video_multi_domain.py
+++ b/kale/loaddata/video_multi_domain.py
@@ -6,6 +6,7 @@
 """Construct a dataset for videos with (multiple) source and target domains"""
 
 import logging
+import math
 
 import numpy as np
 from sklearn.utils import check_random_state
@@ -22,10 +23,10 @@ class VideoMultiDomainDatasets(MultiDomainDatasets):
         source_access_dict,
         target_access_dict,
         image_modality,
-        seed,
         config_weight_type="natural",
         config_size_type=DatasetSizeType.Max,
         valid_split_ratio=0.1,
+        num_workers=1,
         source_sampling_config=None,
         target_sampling_config=None,
         n_fewshot=None,
@@ -38,13 +39,24 @@ class VideoMultiDomainDatasets(MultiDomainDatasets):
             source_access_dict (dictionary): dictionary of source RGB and flow dataset accessors
             target_access_dict (dictionary): dictionary of target RGB and flow dataset accessors
             image_modality (string): image type (RGB or Optical Flow)
-            seed (int): seed value set manually.
+            config_weight_type (WeightingType, optional): The weight type for sampling. Defaults to 'natural'.
+            config_size_type (DatasetSizeType, optional): Which dataset size to use to define the number of epochs vs
+                batch_size. Defaults to DatasetSizeType.Max.
+            valid_split_ratio (float, optional): ratio for the validation part of the train dataset. Defaults to 0.1.
+            num_workers (int, optional): number of workers for data loading. Defaults to 1.
+            source_sampling_config (SamplingConfig, optional): How to sample from the source. Defaults to None
+                (=> RandomSampler).
+            target_sampling_config (SamplingConfig, optional): How to sample from the target. Defaults to None
+                (=> RandomSampler).
+            n_fewshot (int, optional): Number of target samples for which the label may be used,
+                to define the few-shot, semi-supervised setting. Defaults to None.
+            random_state ([int|np.random.RandomState], optional): Used for deterministic sampling/few-shot label
+                selection. Defaults to None.
             class_ids (list, optional): List of chosen subset of class ids. Defaults to None (=> All Classes).
         """
 
         self._image_modality = image_modality
-        self.rgb, self.flow = get_image_modality(self._image_modality)
-        self._seed = seed
+        self.rgb, self.flow, self.audio = get_image_modality(self._image_modality)
 
         if self.rgb:
             source_access = source_access_dict["rgb"]
@@ -52,6 +64,9 @@ class VideoMultiDomainDatasets(MultiDomainDatasets):
         if self.flow:
             source_access = source_access_dict["flow"]
             target_access = target_access_dict["flow"]
+        if self.audio:
+            source_access = source_access_dict["audio"]
+            target_access = target_access_dict["audio"]
 
         weight_type = WeightingType(config_weight_type)
         size_type = DatasetSizeType(config_size_type)
@@ -69,16 +84,18 @@ class VideoMultiDomainDatasets(MultiDomainDatasets):
         elif weight_type not in WeightingType:
             raise ValueError(f"Unknown weighting method {weight_type}.")
         else:
-            self._source_sampling_config = FixedSeedSamplingConfig(seed=self._seed)
-            self._target_sampling_config = FixedSeedSamplingConfig(seed=self._seed)
+            self._source_sampling_config = FixedSeedSamplingConfig(seed=random_state, num_workers=num_workers)
+            self._target_sampling_config = FixedSeedSamplingConfig(seed=random_state, num_workers=num_workers)
 
         self._source_access_dict = source_access_dict
         self._target_access_dict = target_access_dict
         self._valid_split_ratio = valid_split_ratio
         self._rgb_source_by_split = {}
         self._flow_source_by_split = {}
+        self._audio_source_by_split = {}
         self._rgb_target_by_split = {}
         self._flow_target_by_split = {}
+        self._audio_target_by_split = {}
         self._size_type = size_type
         self._n_fewshot = n_fewshot
         self._random_state = check_random_state(random_state)
@@ -154,11 +171,47 @@ class VideoMultiDomainDatasets(MultiDomainDatasets):
                     self._flow_target_by_split["test"], self.class_ids
                 )
 
+        if self.audio:
+            logging.debug("Load audio train and val")
+            (self._audio_source_by_split["train"], self._audio_source_by_split["valid"]) = self._source_access_dict[
+                "audio"
+            ].get_train_val(self._valid_split_ratio)
+            if self.class_ids is not None:
+                self._audio_source_by_split["train"] = get_class_subset(
+                    self._audio_source_by_split["train"], self.class_ids
+                )
+                self._audio_source_by_split["valid"] = get_class_subset(
+                    self._audio_source_by_split["valid"], self.class_ids
+                )
+
+            (self._audio_target_by_split["train"], self._audio_target_by_split["valid"]) = self._target_access_dict[
+                "audio"
+            ].get_train_val(self._valid_split_ratio)
+            if self.class_ids is not None:
+                self._audio_target_by_split["train"] = get_class_subset(
+                    self._audio_target_by_split["train"], self.class_ids
+                )
+                self._audio_target_by_split["valid"] = get_class_subset(
+                    self._audio_target_by_split["valid"], self.class_ids
+                )
+
+            logging.debug("Load RGB Test")
+            self._audio_source_by_split["test"] = self._source_access_dict["audio"].get_test()
+            self._audio_target_by_split["test"] = self._target_access_dict["audio"].get_test()
+            if self.class_ids is not None:
+                self._audio_source_by_split["test"] = get_class_subset(
+                    self._audio_source_by_split["test"], self.class_ids
+                )
+                self._audio_target_by_split["test"] = get_class_subset(
+                    self._audio_target_by_split["test"], self.class_ids
+                )
+
     def get_domain_loaders(self, split="train", batch_size=32):
-        rgb_source_ds = rgb_target_ds = flow_source_ds = flow_target_ds = None
+        rgb_source_ds = rgb_target_ds = flow_source_ds = flow_target_ds = audio_source_ds = audio_target_ds = None
         rgb_source_loader = rgb_target_loader = flow_source_loader = flow_target_loader = None
-        rgb_target_labeled_loader = flow_target_labeled_loader = None
-        rgb_target_unlabeled_loader = flow_target_unlabeled_loader = n_dataset = None
+        audio_source_loader = audio_target_loader = None
+        rgb_target_labeled_loader = flow_target_labeled_loader = audio_target_labeled_loader = None
+        rgb_target_unlabeled_loader = flow_target_unlabeled_loader = audio_target_unlabeled_loader = n_dataset = None
 
         if self.rgb:
             rgb_source_ds = self._rgb_source_by_split[split]
@@ -170,25 +223,53 @@ class VideoMultiDomainDatasets(MultiDomainDatasets):
             flow_source_loader = self._source_sampling_config.create_loader(flow_source_ds, batch_size)
             flow_target_ds = self._flow_target_by_split[split]
 
+        if self.audio:
+            audio_source_ds = self._audio_source_by_split[split]
+            audio_source_loader = self._source_sampling_config.create_loader(audio_source_ds, batch_size)
+            audio_target_ds = self._audio_target_by_split[split]
+
         if self._labeled_target_by_split is None:
             # unsupervised target domain
             if self.rgb:
-                rgb_target_loader = self._target_sampling_config.create_loader(rgb_target_ds, batch_size)
-                n_dataset = DatasetSizeType.get_size(self._size_type, rgb_source_ds, rgb_target_ds)
+                n_dataset, target_batch_size = DatasetSizeType.get_size(
+                    self._size_type, batch_size, rgb_source_ds, rgb_target_ds
+                )
+                rgb_target_loader = self._target_sampling_config.create_loader(rgb_target_ds, target_batch_size)
             if self.flow:
-                flow_target_loader = self._target_sampling_config.create_loader(flow_target_ds, batch_size)
-                n_dataset = DatasetSizeType.get_size(self._size_type, flow_source_ds, flow_target_ds)
+                n_dataset, target_batch_size = DatasetSizeType.get_size(
+                    self._size_type, batch_size, flow_source_ds, flow_target_ds
+                )
+                flow_target_loader = self._target_sampling_config.create_loader(flow_target_ds, target_batch_size)
+            if self.audio:
+                n_dataset, target_batch_size = DatasetSizeType.get_size(
+                    self._size_type, batch_size, audio_source_ds, audio_target_ds
+                )
+                audio_target_loader = self._target_sampling_config.create_loader(audio_target_ds, target_batch_size)
 
-            dataloaders = [rgb_source_loader, flow_source_loader, rgb_target_loader, flow_target_loader]
+            dataloaders = [
+                rgb_source_loader,
+                flow_source_loader,
+                audio_source_loader,
+                rgb_target_loader,
+                flow_target_loader,
+                audio_target_loader,
+            ]
             dataloaders = [x for x in dataloaders if x is not None]
 
-            return MultiDataLoader(dataloaders=dataloaders, n_batches=max(n_dataset // batch_size, 1),)
+            return (
+                MultiDataLoader(dataloaders=dataloaders, n_batches=max(int(math.ceil(n_dataset / batch_size)), 1)),
+                target_batch_size,
+            )
+
         else:
             # semi-supervised target domain
             if self.rgb:
                 rgb_target_labeled_ds = self._labeled_target_by_split[split]
                 rgb_target_unlabeled_ds = rgb_target_ds
                 # label domain: always balanced
+                n_dataset, target_batch_size = DatasetSizeType.get_size(
+                    self._size_type, batch_size, rgb_source_ds, rgb_target_labeled_ds, rgb_target_unlabeled_ds
+                )
                 rgb_target_labeled_loader = FixedSeedSamplingConfig(balance=True, class_weights=None).create_loader(
                     rgb_target_labeled_ds, batch_size=min(len(rgb_target_labeled_ds), batch_size)
                 )
@@ -196,34 +277,53 @@ class VideoMultiDomainDatasets(MultiDomainDatasets):
                 rgb_target_unlabeled_loader = self._target_sampling_config.create_loader(
                     rgb_target_unlabeled_ds, batch_size
                 )
-                n_dataset = DatasetSizeType.get_size(
-                    self._size_type, rgb_source_ds, rgb_target_labeled_ds, rgb_target_unlabeled_ds
-                )
+
             if self.flow:
                 flow_target_labeled_ds = self._labeled_target_by_split[split]
                 flow_target_unlabeled_ds = flow_target_ds
+                n_dataset, target_batch_size = DatasetSizeType.get_size(
+                    self._size_type, batch_size, flow_source_ds, flow_target_labeled_ds, flow_target_unlabeled_ds
+                )
                 flow_target_labeled_loader = FixedSeedSamplingConfig(balance=True, class_weights=None).create_loader(
                     flow_target_labeled_ds, batch_size=min(len(flow_target_labeled_ds), batch_size)
                 )
                 flow_target_unlabeled_loader = self._target_sampling_config.create_loader(
                     flow_target_unlabeled_ds, batch_size
                 )
-                n_dataset = DatasetSizeType.get_size(
-                    self._size_type, rgb_source_ds, flow_target_labeled_ds, flow_target_unlabeled_ds
+
+            if self.audio:
+                audio_target_labeled_ds = self._labeled_target_by_split[split]
+                audio_target_unlabeled_ds = audio_target_ds
+                # label domain: always balanced
+                n_dataset, target_batch_size = DatasetSizeType.get_size(
+                    self._size_type, batch_size, audio_source_ds, audio_target_labeled_ds, audio_target_unlabeled_ds
+                )
+                audio_target_labeled_loader = FixedSeedSamplingConfig(balance=True, class_weights=None).create_loader(
+                    audio_target_labeled_ds, batch_size=min(len(audio_target_labeled_ds), batch_size)
+                )
+
+                audio_target_unlabeled_loader = self._target_sampling_config.create_loader(
+                    audio_target_unlabeled_ds, batch_size
                 )
 
             # combine loaders into a list and remove the loader which is NONE.
             dataloaders = [
                 rgb_source_loader,
                 flow_source_loader,
+                audio_source_loader,
                 rgb_target_labeled_loader,
                 flow_target_labeled_loader,
+                audio_target_labeled_loader,
                 rgb_target_unlabeled_loader,
                 flow_target_unlabeled_loader,
+                audio_target_unlabeled_loader,
             ]
             dataloaders = [x for x in dataloaders if x is not None]
 
-            return MultiDataLoader(dataloaders=dataloaders, n_batches=max(n_dataset // batch_size, 1))
+            return (
+                MultiDataLoader(dataloaders=dataloaders, n_batches=max(n_dataset // batch_size, 1)),
+                target_batch_size,
+            )
 
     def __len__(self):
         if self.rgb:
@@ -232,6 +332,9 @@ class VideoMultiDomainDatasets(MultiDomainDatasets):
         if self.flow:
             source_ds = self._flow_source_by_split["train"]
             target_ds = self._flow_target_by_split["train"]
+        if self.audio:
+            source_ds = self._audio_source_by_split["train"]
+            target_ds = self._audio_target_by_split["train"]
 
         if self._labeled_target_by_split is None:
             return DatasetSizeType.get_size(self._size_type, source_ds, target_ds)

--- a/kale/loaddata/videos.py
+++ b/kale/loaddata/videos.py
@@ -132,12 +132,12 @@ class VideoFrameDataset(torch.utils.data.Dataset):
                              one row per video sample as described above.
         image_modality (str): image modality (RGB or Optical Flow).
         num_segments (int): number of segments the video should be divided into to sample frames from.
-                            Default is 1 in image mode and 5 in feature vector mode.
+                            (Default is 1 in image mode and 5 in feature mode)
         frames_per_segment (int): number of frames that should
                             be loaded per segment. For each segment's
                             frame-range, a random start index or the
                             center is chosen, from which frames_per_segment
-                            consecutive frames are loaded.
+                            consecutive frames are loaded. (set as 1 in feature vector mode)
         imagefile_template (str): image filename template that video frame files
                             have inside of their video folders as described above.
         transform (Compose, optional): transform pipeline that receives a list of PIL images/frames.
@@ -149,7 +149,7 @@ class VideoFrameDataset(torch.utils.data.Dataset):
                    frames from segments with random_shift=False.
         input_type (str): type of input. (options: 'image' or 'feature')
         num_data_load (int): number of the data to load. (only used in feature vector mode)
-        total_segments (int): total number of segments a video is divided into. (only used in feature vector mode)
+        total_segments (int): total number of segments a video is divided into. (only used in feature mode)
 
     """
 
@@ -158,7 +158,7 @@ class VideoFrameDataset(torch.utils.data.Dataset):
         root_path,
         annotationfile_path,
         image_modality="rgb",
-        num_segments=1,
+        num_segments=5,
         frames_per_segment=1,
         imagefile_template="img_{:05d}.jpg",
         transform=None,
@@ -184,6 +184,9 @@ class VideoFrameDataset(torch.utils.data.Dataset):
         self.input_type = input_type
         self.num_data_load = num_data_load
         self.total_segments = total_segments
+        if self.input_type == "feature":
+            if self.total_segments != 25 or self.frames_per_segment != 1:
+                raise ValueError("total_segments and frames_per_segment must be 25 and 1 in feature vector mode")
 
         self._parse_list()
 

--- a/kale/loaddata/videos.py
+++ b/kale/loaddata/videos.py
@@ -72,6 +72,10 @@ class VideoFeatureRecord(object):
         self._n_seg = num_segments
 
     @property
+    def segment_id(self):
+        return self._data.narration_id
+
+    @property
     def num_frames(self):
         return int(self._n_seg)
 
@@ -184,6 +188,7 @@ class VideoFrameDataset(torch.utils.data.Dataset):
         self.input_type = input_type
         self.num_data_load = num_data_load
         self.total_segments = total_segments
+        self._data = None
         if self.input_type == "feature":
             if self.total_segments != 25 or self.frames_per_segment != 1:
                 raise ValueError("total_segments and frames_per_segment must be 25 and 1 in feature vector mode")

--- a/kale/loaddata/videos.py
+++ b/kale/loaddata/videos.py
@@ -31,6 +31,10 @@ class VideoRecord(object):
         self._path = os.path.join(root_datapath, row[0])
 
     @property
+    def segment_id(self):
+        return "{}-{}-{}".format(self._data[0], self._data[1], self._data[2])
+
+    @property
     def path(self):
         return self._path
 
@@ -50,7 +54,7 @@ class VideoRecord(object):
     def label(self):
         # just one label_id
         if len(self._data) == 4:
-            return int(self._data[3])
+            return [int(self._data[3])]
         # sample associated with multiple labels
         else:
             return [int(label_id) for label_id in self._data[3:]]
@@ -372,7 +376,7 @@ class VideoFrameDataset(torch.utils.data.Dataset):
         if self.input_type == "image" and self.transform is not None:
             images = self.transform(images)
 
-        return images, record.label
+        return images, record.label, record.segment_id
 
     def __len__(self):
         return len(self.video_list)

--- a/kale/loaddata/videos.py
+++ b/kale/loaddata/videos.py
@@ -375,6 +375,8 @@ class VideoFrameDataset(torch.utils.data.Dataset):
 
         if self.input_type == "image" and self.transform is not None:
             images = self.transform(images)
+        if self.input_type == "feature":
+            images = torch.stack(images)
 
         return images, record.label, record.segment_id
 

--- a/kale/pipeline/domain_adapter.py
+++ b/kale/pipeline/domain_adapter.py
@@ -219,7 +219,8 @@ class BaseAdaptTrainer(pl.LightningModule):
     changes linearly from 0 to 1.
 
     Args:
-        dataset (kale.loaddata.multi_domain): the multi-domain datasets to be used for train, validation, and tests.
+        dataset (kale.loaddata.multi_domain, kale.loaddata.video_multi_domain): the multi-domain datasets to be used
+            for train, validation, and tests.
         feature_extractor (torch.nn.Module): the feature extractor network (mapping inputs :math:`x\in\mathcal{X}`
             to a latent space :math:`\mathcal{Z}`,)
         task_classifier (torch.nn.Module): the task classifier network that learns to predict labels

--- a/kale/pipeline/video_domain_adapter.py
+++ b/kale/pipeline/video_domain_adapter.py
@@ -142,7 +142,7 @@ class BaseAdaptTrainerVideo(BaseAdaptTrainer):
         return {"loss": loss}
 
     def validation_epoch_end(self, outputs):
-        metrics_to_log = self.create_metrics_log("val")
+        metrics_to_log = self.create_metrics_log("valid")
         return self._validation_epoch_end(outputs, metrics_to_log)
 
     def test_epoch_end(self, outputs):
@@ -182,10 +182,10 @@ class BaseAdaptTrainerVideo(BaseAdaptTrainer):
     def get_loss_log_metrics(self, split_name, y_hat, y_t_hat, y_s, y_tu, dok):
         """Get the loss, top-k accuracy and metrics for a given split."""
 
-        loss_cls, ok_src = losses.cross_entropy_logits(y_hat, y_s)
-        _, ok_tgt = losses.cross_entropy_logits(y_t_hat, y_tu)
-        prec1_src, prec3_src = losses.topk_accuracy(y_hat, y_s, topk=(1, 3))
-        prec1_tgt, prec3_tgt = losses.topk_accuracy(y_t_hat, y_tu, topk=(1, 3))
+        loss_cls, ok_src = losses.cross_entropy_logits(y_hat[0], y_s)
+        _, ok_tgt = losses.cross_entropy_logits(y_t_hat[0], y_tu)
+        prec1_src, prec3_src = losses.topk_accuracy(y_hat[0], y_s, topk=(1, 3))
+        prec1_tgt, prec3_tgt = losses.topk_accuracy(y_t_hat[0], y_tu, topk=(1, 3))
         task_loss = loss_cls
 
         log_metrics = {

--- a/kale/pipeline/video_domain_adapter.py
+++ b/kale/pipeline/video_domain_adapter.py
@@ -25,6 +25,8 @@ from kale.pipeline.domain_adapter import (
     WDGRLTrainer,
 )
 
+# from kale.utils.logger import save_results_to_json
+
 
 def create_mmd_based_video(
     method: Method, dataset, image_modality, feature_extractor, task_classifier, class_type, **train_params
@@ -165,6 +167,76 @@ class BaseAdaptTrainerVideo(BaseAdaptTrainer):
         for key in log_dict:
             self.log(key, log_dict[key], prog_bar=True)
 
+    def concatenate(self, x_rgb, x_flow, x_audio):
+        if self.rgb:
+            if self.flow:
+                if self.audio:  # For all inputs
+                    x = torch.cat((x_rgb, x_flow, x_audio), dim=-1)
+                else:  # For joint(rgb+flow) input
+                    x = torch.cat((x_rgb, x_flow), dim=-1)
+            else:
+                if self.audio:  # For rgb+audio input
+                    x = torch.cat((x_rgb, x_audio), dim=-1)
+                else:  # For rgb input
+                    x = x_rgb
+        else:
+            if self.flow:
+                if self.audio:  # For flow+audio input
+                    x = torch.cat((x_flow, x_audio), dim=-1)
+                else:  # For flow input
+                    x = x_flow
+            else:  # For audio input
+                x = x_audio
+        return x
+
+    def get_inputs_from_batch(self, batch):
+        # _s refers to source, _tu refers to unlabeled target
+        x_s_rgb = x_tu_rgb = x_s_flow = x_tu_flow = x_s_audio = x_tu_audio = None
+
+        if self.rgb:
+            if self.flow:
+                if self.audio:  # For all inputs
+                    (
+                        (x_s_rgb, y_s, s_id),
+                        (x_s_flow, y_s_flow, _),
+                        (x_s_audio, y_s_audio, _),
+                        (x_tu_rgb, y_tu, tu_id),
+                        (x_tu_flow, y_tu_flow, _),
+                        (x_tu_audio, y_tu_audio, _),
+                    ) = batch
+                else:  # For joint(rgb+flow) input
+                    (
+                        (x_s_rgb, y_s, s_id),
+                        (x_s_flow, y_s_flow, _),
+                        (x_tu_rgb, y_tu, tu_id),
+                        (x_tu_flow, y_tu_flow, _),
+                    ) = batch
+            else:
+                if self.audio:  # For rgb+audio input
+                    (
+                        (x_s_rgb, y_s, s_id),
+                        (x_s_audio, y_s_audio, _),
+                        (x_tu_rgb, y_tu, tu_id),
+                        (x_tu_audio, y_tu_audio, _),
+                    ) = batch
+                else:  # For rgb input
+                    (x_s_rgb, y_s, s_id), (x_tu_rgb, y_tu, tu_id) = batch
+        else:
+            if self.flow:
+                if self.audio:  # For flow+audio input
+                    (
+                        (x_s_flow, y_s, s_id),
+                        (x_s_audio, y_s_audio, _),
+                        (x_tu_flow, y_tu, tu_id),
+                        (x_tu_audio, y_tu_audio, _),
+                    ) = batch
+                else:  # For flow input
+                    (x_s_flow, y_s, s_id), (x_tu_flow, y_tu, tu_id) = batch
+            else:  # For audio input
+                (x_s_audio, y_s, s_id), (x_tu_audio, y_tu, tu_id) = batch
+
+        return x_s_rgb, x_tu_rgb, x_s_flow, x_tu_flow, x_s_audio, x_tu_audio, y_s, y_tu, s_id, tu_id
+
     def create_metrics_log(self, split_name):
         if self.verb and not self.noun:
             metrics_to_log = (
@@ -291,53 +363,102 @@ class BaseMMDLikeVideo(BaseAdaptTrainerVideo, BaseMMDLike):
     ):
         super().__init__(dataset, feature_extractor, task_classifier, kernel_mul, kernel_num, **base_params)
         self.image_modality = image_modality
-        self.verb, self.noun = get_class_type(class_type)
+        self.rgb, self.flow, self.audio = get_image_modality(self.image_modality)
+        self.class_type = class_type
+        self.verb, self.noun = get_class_type(self.class_type)
         self.rgb_feat = self.feat["rgb"]
         self.flow_feat = self.feat["flow"]
+        self.audio_feat = self.feat["audio"]
 
     def forward(self, x):
         if self.feat is not None:
-            if self.image_modality in ["rgb", "flow"]:
-                if self.rgb_feat is not None:
-                    x = self.rgb_feat(x)
-                else:
-                    x = self.flow_feat(x)
-                x = x.view(x.size(0), -1)
-                class_output = self.classifier(x)
-                return x, class_output
+            x_rgb = x_flow = x_audio = None
 
-            elif self.image_modality == "joint":
+            if self.rgb:
                 x_rgb = self.rgb_feat(x["rgb"])
-                x_flow = self.flow_feat(x["flow"])
                 x_rgb = x_rgb.view(x_rgb.size(0), -1)
+            if self.flow:
+                x_flow = self.flow_feat(x["flow"])
                 x_flow = x_flow.view(x_flow.size(0), -1)
-                x = torch.cat((x_rgb, x_flow), dim=1)
-                class_output = self.classifier(x)
-                return [x_rgb, x_flow], class_output
+            if self.audio:
+                x_audio = self.audio_feat(x["audio"])
+                x_audio = x_audio.view(x_audio.size(0), -1)
+
+            x = self.concatenate(x_rgb, x_flow, x_audio)
+            class_output = self.classifier(x)
+            return [x_rgb, x_flow, x_audio], class_output
 
     def compute_loss(self, batch, split_name="valid"):
         # _s refers to source, _tu refers to unlabeled target
-        if self.image_modality == "joint" and len(batch) == 4:
-            (x_s_rgb, y_s), (x_s_flow, y_s_flow), (x_tu_rgb, y_tu), (x_tu_flow, y_tu_flow) = batch
-            [phi_s_rgb, phi_s_flow], y_hat = self.forward({"rgb": x_s_rgb, "flow": x_s_flow})
-            [phi_t_rgb, phi_t_flow], y_t_hat = self.forward({"rgb": x_tu_rgb, "flow": x_tu_flow})
-            mmd_rgb = self._compute_mmd(phi_s_rgb, phi_t_rgb, y_hat, y_t_hat)
-            mmd_flow = self._compute_mmd(phi_s_flow, phi_t_flow, y_hat, y_t_hat)
-            mmd = mmd_rgb + mmd_flow
-        elif self.image_modality in ["rgb", "flow"] and len(batch) == 2:
-            (x_s, y_s), (x_tu, y_tu) = batch
-            phi_s, y_hat = self.forward(x_s)
-            phi_t, y_t_hat = self.forward(x_tu)
-            mmd = self._compute_mmd(phi_s, phi_t, y_hat, y_t_hat)
+        (
+            x_s_rgb,
+            x_tu_rgb,
+            x_s_flow,
+            x_tu_flow,
+            x_s_audio,
+            x_tu_audio,
+            y_s,
+            y_tu,
+            s_id,
+            tu_id,
+        ) = self.get_inputs_from_batch(batch)
+
+        # _s refers to source, _tu refers to unlabeled target
+        [phi_s_rgb, phi_s_flow, phi_s_audio], y_hat = self.forward(
+            {"rgb": x_s_rgb, "flow": x_s_flow, "audio": x_s_audio}
+        )
+        [phi_t_rgb, phi_t_flow, phi_t_audio], y_t_hat = self.forward(
+            {"rgb": x_tu_rgb, "flow": x_tu_flow, "audio": x_tu_audio}
+        )
+
+        if self.rgb:
+            if self.verb and not self.noun:
+                mmd_rgb = self._compute_mmd(phi_s_rgb, phi_t_rgb, y_hat[0], y_t_hat[0])
+            elif self.verb and self.noun:
+                mmd_rgb_verb = self._compute_mmd(phi_s_rgb, phi_t_rgb, y_hat[0], y_t_hat[0])
+                mmd_rgb_noun = self._compute_mmd(phi_s_rgb, phi_t_rgb, y_hat[1], y_t_hat[1])
+                mmd_rgb = mmd_rgb_verb + mmd_rgb_noun
+        if self.flow:
+            if self.verb and not self.noun:
+                mmd_flow = self._compute_mmd(phi_s_flow, phi_t_flow, y_hat[0], y_t_hat[0])
+            elif self.verb and self.noun:
+                mmd_flow_verb = self._compute_mmd(phi_s_flow, phi_t_flow, y_hat[0], y_t_hat[0])
+                mmd_flow_noun = self._compute_mmd(phi_s_flow, phi_t_flow, y_hat[1], y_t_hat[1])
+                mmd_flow = mmd_flow_verb + mmd_flow_noun
+        if self.audio:
+            if self.verb and not self.noun:
+                mmd_audio = self._compute_mmd(phi_s_audio, phi_t_audio, y_hat[0], y_t_hat[0])
+            elif self.verb and self.noun:
+                mmd_audio_verb = self._compute_mmd(phi_s_audio, phi_t_audio, y_hat[0], y_t_hat[0])
+                mmd_audio_noun = self._compute_mmd(phi_s_audio, phi_t_audio, y_hat[1], y_t_hat[1])
+                mmd_audio = mmd_audio_verb + mmd_audio_noun
+
+        if self.rgb:
+            if self.flow:
+                if self.audio:  # For all inputs
+                    mmd = mmd_rgb + mmd_flow + mmd_audio
+                else:  # For joint(rgb+flow) input
+                    mmd = mmd_rgb + mmd_flow
+            else:
+                if self.audio:  # For rgb+audio input
+                    mmd = mmd_audio
+                else:  # For rgb input
+                    mmd = mmd_rgb
         else:
-            raise NotImplementedError("Batch len is {}. Check the Dataloader.".format(len(batch)))
+            if self.flow:
+                if self.audio:  # For flow+audio input
+                    mmd = mmd_audio
+                else:  # For flow input
+                    mmd = mmd_flow
+            else:  # For audio input
+                mmd = mmd_audio
 
         # Uncomment when checking whether rgb & flow labels are equal.
         # print('rgb_s:{}, flow_s:{}, rgb_f:{}, flow_f:{}'.format(y_s, y_s_flow, y_tu, y_tu_flow))
         # print('equal: {}/{}'.format(torch.all(torch.eq(y_s, y_s_flow)), torch.all(torch.eq(y_tu, y_tu_flow))))
 
         task_loss, log_metrics = self.get_loss_log_metrics(split_name, y_hat, y_t_hat, y_s, y_tu, mmd)
-
+        # log_metrics.update({f"{split_name}_source_domain_acc": mmd, f"{split_name}_target_domain_acc": mmd})
         return task_loss, mmd, log_metrics
 
 
@@ -349,7 +470,7 @@ class DANTrainerVideo(BaseMMDLikeVideo):
 
     def _compute_mmd(self, phi_s, phi_t, y_hat, y_t_hat):
         batch_size = int(phi_s.size()[0])
-        kernels = losses.gaussian_kernel(phi_s, phi_t, kernel_mul=self._kernel_mul, kernel_num=self._kernel_num,)
+        kernels = losses.gaussian_kernel(phi_s, phi_t, kernel_mul=self._kernel_mul, kernel_num=self._kernel_num)
         return losses.compute_mmd_loss(kernels, batch_size)
 
 
@@ -406,13 +527,24 @@ class DANNTrainerVideo(BaseAdaptTrainerVideo, DANNTrainer):
         )
         self.image_modality = image_modality
         self.rgb, self.flow, self.audio = get_image_modality(self.image_modality)
-        self.verb, self.noun = get_class_type(class_type)
+        self.class_type = class_type
+        self.verb, self.noun = get_class_type(self.class_type)
         self.rgb_feat = self.feat["rgb"]
         self.flow_feat = self.feat["flow"]
+        self.audio_feat = self.feat["audio"]
+
+        # Uncomment to store output for EPIC UDA 2021 challenge.(1/3)
+        # self.y_hat = []
+        # self.y_hat_noun = []
+        # self.y_t_hat = []
+        # self.y_t_hat_noun = []
+        # self.s_id = []
+        # self.tu_id = []
 
     def forward(self, x):
         if self.feat is not None:
-            x_rgb = x_flow = adversarial_output_rgb = adversarial_output_flow = None
+            x_rgb = x_flow = x_audio = None
+            adversarial_output_rgb = adversarial_output_flow = adversarial_output_audio = None
 
             # For joint input, both two ifs are used
             if self.rgb:
@@ -425,75 +557,121 @@ class DANNTrainerVideo(BaseAdaptTrainerVideo, DANNTrainer):
                 x_flow = x_flow.view(x_flow.size(0), -1)
                 reverse_feature_flow = GradReverse.apply(x_flow, self.alpha)
                 adversarial_output_flow = self.domain_classifier(reverse_feature_flow)
+            if self.audio:
+                x_audio = self.audio_feat(x["audio"])
+                x_audio = x_audio.view(x_audio.size(0), -1)
+                reverse_feature_audio = GradReverse.apply(x_audio, self.alpha)
+                adversarial_output_audio = self.domain_classifier(reverse_feature_audio)
 
-            if self.rgb:
-                if self.flow:  # For joint input
-                    x = torch.cat((x_rgb, x_flow), dim=1)
-                else:  # For rgb input
-                    x = x_rgb
-            else:  # For flow input
-                x = x_flow
+            x = self.concatenate(x_rgb, x_flow, x_audio)
+
             class_output = self.classifier(x)
 
-            return [x_rgb, x_flow], class_output, [adversarial_output_rgb, adversarial_output_flow]
+            return (
+                [x_rgb, x_flow, x_audio],
+                class_output,
+                [adversarial_output_rgb, adversarial_output_flow, adversarial_output_audio],
+            )
 
-    def compute_loss(self, batch, split_name="valid"):
+    def compute_loss(self, batch, split_name="V"):
         # _s refers to source, _tu refers to unlabeled target
-        x_s_rgb = x_tu_rgb = x_s_flow = x_tu_flow = None
-        if self.rgb:
-            if self.flow:  # For joint input
-                (x_s_rgb, y_s), (x_s_flow, y_s_flow), (x_tu_rgb, y_tu), (x_tu_flow, y_tu_flow) = batch
-            else:  # For rgb input
-                (x_s_rgb, y_s), (x_tu_rgb, y_tu) = batch
-        else:  # For flow input
-            (x_s_flow, y_s), (x_tu_flow, y_tu) = batch
+        (
+            x_s_rgb,
+            x_tu_rgb,
+            x_s_flow,
+            x_tu_flow,
+            x_s_audio,
+            x_tu_audio,
+            y_s,
+            y_tu,
+            s_id,
+            tu_id,
+        ) = self.get_inputs_from_batch(batch)
 
-        _, y_hat, [d_hat_rgb, d_hat_flow] = self.forward({"rgb": x_s_rgb, "flow": x_s_flow})
-        _, y_t_hat, [d_t_hat_rgb, d_t_hat_flow] = self.forward({"rgb": x_tu_rgb, "flow": x_tu_flow})
-        batch_size = len(y_s)
+        _, y_hat, [d_hat_rgb, d_hat_flow, d_hat_audio] = self.forward(
+            {"rgb": x_s_rgb, "flow": x_s_flow, "audio": x_s_audio}
+        )
+        _, y_t_hat, [d_t_hat_rgb, d_t_hat_flow, d_t_hat_audio] = self.forward(
+            {"rgb": x_tu_rgb, "flow": x_tu_flow, "audio": x_tu_audio}
+        )
+        source_batch_size = len(y_s[0])
+        target_batch_size = len(y_tu[0])
 
         if self.rgb:
-            loss_dmn_src_rgb, dok_src_rgb = losses.cross_entropy_logits(d_hat_rgb, torch.zeros(batch_size))
-            loss_dmn_tgt_rgb, dok_tgt_rgb = losses.cross_entropy_logits(d_t_hat_rgb, torch.ones(batch_size))
+            loss_dmn_src_rgb, dok_src_rgb = losses.cross_entropy_logits(d_hat_rgb, torch.zeros(source_batch_size))
+            loss_dmn_tgt_rgb, dok_tgt_rgb = losses.cross_entropy_logits(d_t_hat_rgb, torch.ones(target_batch_size))
         if self.flow:
-            loss_dmn_src_flow, dok_src_flow = losses.cross_entropy_logits(d_hat_flow, torch.zeros(batch_size))
-            loss_dmn_tgt_flow, dok_tgt_flow = losses.cross_entropy_logits(d_t_hat_flow, torch.ones(batch_size))
+            loss_dmn_src_flow, dok_src_flow = losses.cross_entropy_logits(d_hat_flow, torch.zeros(source_batch_size))
+            loss_dmn_tgt_flow, dok_tgt_flow = losses.cross_entropy_logits(d_t_hat_flow, torch.ones(target_batch_size))
+        if self.audio:
+            loss_dmn_src_audio, dok_src_audio = losses.cross_entropy_logits(d_hat_audio, torch.zeros(source_batch_size))
+            loss_dmn_tgt_audio, dok_tgt_audio = losses.cross_entropy_logits(
+                d_t_hat_audio, torch.ones(target_batch_size)
+            )
 
-        if self.rgb and self.flow:  # For joint input
-            loss_dmn_src = loss_dmn_src_rgb + loss_dmn_src_flow
-            loss_dmn_tgt = loss_dmn_tgt_rgb + loss_dmn_tgt_flow
-            dok = torch.cat((dok_src_rgb, dok_src_flow, dok_tgt_rgb, dok_tgt_flow))
-            dok_src = torch.cat((dok_src_rgb, dok_src_flow))
-            dok_tgt = torch.cat((dok_tgt_rgb, dok_tgt_flow))
+        # ok is abbreviation for (all) correct, dok refers to domain correct
+        if self.rgb:
+            if self.flow:
+                if self.audio:  # For all inputs
+                    loss_dmn_src = loss_dmn_src_rgb + loss_dmn_src_flow + loss_dmn_src_audio
+                    loss_dmn_tgt = loss_dmn_tgt_rgb + loss_dmn_tgt_flow + loss_dmn_tgt_audio
+                    dok = torch.cat(
+                        (dok_src_rgb, dok_src_flow, dok_src_audio, dok_tgt_rgb, dok_tgt_flow, dok_tgt_audio)
+                    )
+                    dok_src = torch.cat((dok_src_rgb, dok_src_flow, dok_src_audio))
+                    dok_tgt = torch.cat((dok_tgt_rgb, dok_tgt_flow, dok_tgt_audio))
+                else:  # For joint(rgb+flow) input
+                    loss_dmn_src = loss_dmn_src_rgb + loss_dmn_src_flow
+                    loss_dmn_tgt = loss_dmn_tgt_rgb + loss_dmn_tgt_flow
+                    dok = torch.cat((dok_src_rgb, dok_src_flow, dok_tgt_rgb, dok_tgt_flow))
+                    dok_src = torch.cat((dok_src_rgb, dok_src_flow))
+                    dok_tgt = torch.cat((dok_tgt_rgb, dok_tgt_flow))
+            else:
+                if self.audio:  # For rgb+audio input
+                    loss_dmn_src = loss_dmn_src_rgb + loss_dmn_src_audio
+                    loss_dmn_tgt = loss_dmn_tgt_rgb + loss_dmn_tgt_audio
+                    dok = torch.cat((dok_src_rgb, dok_src_audio, dok_tgt_rgb, dok_tgt_audio))
+                    dok_src = torch.cat((dok_src_rgb, dok_src_audio))
+                    dok_tgt = torch.cat((dok_tgt_rgb, dok_tgt_audio))
+                else:  # For rgb input
+                    loss_dmn_src = loss_dmn_src_rgb
+                    loss_dmn_tgt = loss_dmn_tgt_rgb
+                    dok = torch.cat((dok_src_rgb, dok_tgt_rgb))
+                    dok_src = dok_src_rgb
+                    dok_tgt = dok_tgt_rgb
         else:
-            if self.rgb:  # For rgb input
-                d_hat = d_hat_rgb
-                d_t_hat = d_t_hat_rgb
-            else:  # For flow input
-                d_hat = d_hat_flow
-                d_t_hat = d_t_hat_flow
-
-            # ok is abbreviation for (all) correct, dok refers to domain correct
-            loss_dmn_src, dok_src = losses.cross_entropy_logits(d_hat, torch.zeros(batch_size))
-            loss_dmn_tgt, dok_tgt = losses.cross_entropy_logits(d_t_hat, torch.ones(batch_size))
-            dok = torch.cat((dok_src, dok_tgt))
-
-        # loss_cls, ok_src = losses.cross_entropy_logits(y_hat[0], y_s)
-        # _, ok_tgt = losses.cross_entropy_logits(y_t_hat[0], y_tu)
-        # adv_loss = loss_dmn_src + loss_dmn_tgt  # adv_loss = src + tgt
-        # task_loss = loss_cls
-        #
-        # log_metrics = {
-        #     f"{split_name}_source_acc": ok_src,
-        #     f"{split_name}_target_acc": ok_tgt,
-        #     f"{split_name}_domain_acc": dok,
-        #     f"{split_name}_source_domain_acc": dok_src,
-        #     f"{split_name}_target_domain_acc": dok_tgt,
-        # }
+            if self.flow:
+                if self.audio:  # For flow+audio input
+                    loss_dmn_src = loss_dmn_src_flow + loss_dmn_src_audio
+                    loss_dmn_tgt = loss_dmn_tgt_flow + loss_dmn_tgt_audio
+                    dok = torch.cat((dok_src_flow, dok_src_audio, dok_tgt_flow, dok_tgt_audio))
+                    dok_src = torch.cat((dok_src_flow, dok_src_audio))
+                    dok_tgt = torch.cat((dok_tgt_flow, dok_tgt_audio))
+                else:  # For flow input
+                    loss_dmn_src = loss_dmn_src_flow
+                    loss_dmn_tgt = loss_dmn_tgt_flow
+                    dok = torch.cat((dok_src_flow, dok_tgt_flow))
+                    dok_src = dok_src_flow
+                    dok_tgt = dok_tgt_flow
+            else:  # For audio input
+                loss_dmn_src = loss_dmn_src_audio
+                loss_dmn_tgt = loss_dmn_tgt_audio
+                dok = torch.cat((dok_src_audio, dok_tgt_audio))
+                dok_src = dok_src_audio
+                dok_tgt = dok_tgt_audio
 
         task_loss, log_metrics = self.get_loss_log_metrics(split_name, y_hat, y_t_hat, y_s, y_tu, dok)
         adv_loss = loss_dmn_src + loss_dmn_tgt  # adv_loss = src + tgt
         log_metrics.update({f"{split_name}_source_domain_acc": dok_src, f"{split_name}_target_domain_acc": dok_tgt})
+
+        # # Uncomment to store output for EPIC UDA 2021 challenge.(2/3)
+        # if split_name == "test":
+        #     self.y_hat.extend(y_hat[0].tolist())
+        #     self.y_hat_noun.extend(y_hat[1].tolist())
+        #     self.y_t_hat.extend(y_t_hat[0].tolist())
+        #     self.y_t_hat_noun.extend(y_t_hat[1].tolist())
+        #     self.s_id.extend(s_id)
+        #     self.tu_id.extend(tu_id)
 
         return task_loss, adv_loss, log_metrics
 
@@ -518,14 +696,17 @@ class CDANTrainerVideo(BaseAdaptTrainerVideo, CDANTrainer):
             dataset, feature_extractor, task_classifier, critic, use_entropy, use_random, random_dim, **base_params
         )
         self.image_modality = image_modality
-        self.rgb, self.flow, self.audio = get_image_modality(image_modality)
-        self.verb, self.noun = get_class_type(class_type)
+        self.rgb, self.flow, self.audio = get_image_modality(self.image_modality)
+        self.class_type = class_type
+        self.verb, self.noun = get_class_type(self.class_type)
         self.rgb_feat = self.feat["rgb"]
         self.flow_feat = self.feat["flow"]
+        self.audio_feat = self.feat["audio"]
 
     def forward(self, x):
         if self.feat is not None:
-            x_rgb = x_flow = adversarial_output_rgb = adversarial_output_flow = None
+            x_rgb = x_flow = x_audio = None
+            adversarial_output_rgb = adversarial_output_flow = adversarial_output_audio = None
 
             # For joint input, both two ifs are used
             if self.rgb:
@@ -536,16 +717,15 @@ class CDANTrainerVideo(BaseAdaptTrainerVideo, CDANTrainer):
                 x_flow = self.flow_feat(x["flow"])
                 x_flow = x_flow.view(x_flow.size(0), -1)
                 reverse_feature_flow = GradReverse.apply(x_flow, self.alpha)
+            if self.audio:
+                x_audio = self.audio_feat(x["audio"])
+                x_audio = x_audio.view(x_audio.size(0), -1)
+                reverse_feature_audio = GradReverse.apply(x_audio, self.alpha)
 
-            if self.rgb:
-                if self.flow:  # For joint input
-                    x = torch.cat((x_rgb, x_flow), dim=1)
-                else:  # For rgb input
-                    x = x_rgb
-            else:  # For flow input
-                x = x_flow
+            x = self.concatenate(x_rgb, x_flow, x_audio)
+
             class_output = self.classifier(x)
-            # Only use verb class to get softmax_output
+            # # Only use verb class to get softmax_output
             softmax_output = torch.nn.Softmax(dim=1)(class_output[0])
             reverse_out = GradReverse.apply(softmax_output, self.alpha)
 
@@ -566,23 +746,49 @@ class CDANTrainerVideo(BaseAdaptTrainerVideo, CDANTrainer):
                     adversarial_output_flow = self.domain_classifier(random_out_flow.view(-1, random_out_flow.size(1)))
                 else:
                     adversarial_output_flow = self.domain_classifier(feature_flow)
-            return [x_rgb, x_flow], class_output, [adversarial_output_rgb, adversarial_output_flow]
 
-    def compute_loss(self, batch, split_name="valid"):
+            if self.audio:
+                feature_audio = torch.bmm(reverse_out.unsqueeze(2), reverse_feature_audio.unsqueeze(1))
+                feature_audio = feature_audio.view(-1, reverse_out.size(1) * reverse_feature_audio.size(1))
+                if self.random_layer:
+                    random_out_audio = self.random_layer.forward(feature_audio)
+                    adversarial_output_audio = self.domain_classifier(
+                        random_out_audio.view(-1, random_out_audio.size(1))
+                    )
+                else:
+                    adversarial_output_audio = self.domain_classifier(feature_audio)
+
+            return (
+                [x_rgb, x_flow, x_audio],
+                class_output,
+                [adversarial_output_rgb, adversarial_output_flow, adversarial_output_audio],
+            )
+
+    def compute_loss(self, batch, split_name="V"):
         # _s refers to source, _tu refers to unlabeled target
-        x_s_rgb = x_tu_rgb = x_s_flow = x_tu_flow = None
-        if self.rgb:
-            if self.flow:  # For joint input
-                (x_s_rgb, y_s), (x_s_flow, y_s_flow), (x_tu_rgb, y_tu), (x_tu_flow, y_tu_flow) = batch
-            else:  # For rgb input
-                (x_s_rgb, y_s), (x_tu_rgb, y_tu) = batch
-        else:  # For flow input
-            (x_s_flow, y_s), (x_tu_flow, y_tu) = batch
+        (
+            x_s_rgb,
+            x_tu_rgb,
+            x_s_flow,
+            x_tu_flow,
+            x_s_audio,
+            x_tu_audio,
+            y_s,
+            y_tu,
+            s_id,
+            tu_id,
+        ) = self.get_inputs_from_batch(batch)
 
-        _, y_hat, [d_hat_rgb, d_hat_flow] = self.forward({"rgb": x_s_rgb, "flow": x_s_flow})
-        _, y_t_hat, [d_t_hat_rgb, d_t_hat_flow] = self.forward({"rgb": x_tu_rgb, "flow": x_tu_flow})
-        batch_size = len(y_s)
+        _, y_hat, [d_hat_rgb, d_hat_flow, d_hat_audio] = self.forward(
+            {"rgb": x_s_rgb, "flow": x_s_flow, "audio": x_s_audio}
+        )
+        _, y_t_hat, [d_t_hat_rgb, d_t_hat_flow, d_t_hat_audio] = self.forward(
+            {"rgb": x_tu_rgb, "flow": x_tu_flow, "audio": x_tu_audio}
+        )
+        source_batch_size = len(y_s[0])
+        target_batch_size = len(y_tu[0])
 
+        # # Only use verb class to get entropy weights
         if self.entropy:
             e_s = self._compute_entropy_weights(y_hat[0])
             e_t = self._compute_entropy_weights(y_t_hat[0])
@@ -594,55 +800,83 @@ class CDANTrainerVideo(BaseAdaptTrainerVideo, CDANTrainer):
 
         if self.rgb:
             loss_dmn_src_rgb, dok_src_rgb = losses.cross_entropy_logits(
-                d_hat_rgb, torch.zeros(batch_size), source_weight
+                d_hat_rgb, torch.zeros(source_batch_size), source_weight
             )
             loss_dmn_tgt_rgb, dok_tgt_rgb = losses.cross_entropy_logits(
-                d_t_hat_rgb, torch.ones(batch_size), target_weight
+                d_t_hat_rgb, torch.ones(target_batch_size), target_weight
             )
 
         if self.flow:
             loss_dmn_src_flow, dok_src_flow = losses.cross_entropy_logits(
-                d_hat_flow, torch.zeros(batch_size), source_weight
+                d_hat_flow, torch.zeros(source_batch_size), source_weight
             )
             loss_dmn_tgt_flow, dok_tgt_flow = losses.cross_entropy_logits(
-                d_t_hat_flow, torch.ones(batch_size), target_weight
+                d_t_hat_flow, torch.ones(target_batch_size), target_weight
+            )
+
+        if self.audio:
+            loss_dmn_src_audio, dok_src_audio = losses.cross_entropy_logits(
+                d_hat_audio, torch.zeros(source_batch_size), source_weight
+            )
+            loss_dmn_tgt_audio, dok_tgt_audio = losses.cross_entropy_logits(
+                d_t_hat_audio, torch.ones(target_batch_size), target_weight
             )
 
         # ok is abbreviation for (all) correct, dok refers to domain correct
-        if self.rgb and self.flow:  # For joint input
-            loss_dmn_src = loss_dmn_src_rgb + loss_dmn_src_flow
-            loss_dmn_tgt = loss_dmn_tgt_rgb + loss_dmn_tgt_flow
-            dok = torch.cat((dok_src_rgb, dok_src_flow, dok_tgt_rgb, dok_tgt_flow))
-            dok_src = torch.cat((dok_src_rgb, dok_src_flow))
-            dok_tgt = torch.cat((dok_tgt_rgb, dok_tgt_flow))
+        if self.rgb:
+            if self.flow:
+                if self.audio:  # For all inputs
+                    loss_dmn_src = loss_dmn_src_rgb + loss_dmn_src_flow + loss_dmn_src_audio
+                    loss_dmn_tgt = loss_dmn_tgt_rgb + loss_dmn_tgt_flow + loss_dmn_tgt_audio
+                    dok = torch.cat(
+                        (dok_src_rgb, dok_src_flow, dok_src_audio, dok_tgt_rgb, dok_tgt_flow, dok_tgt_audio)
+                    )
+                    dok_src = torch.cat((dok_src_rgb, dok_src_flow, dok_src_audio))
+                    dok_tgt = torch.cat((dok_tgt_rgb, dok_tgt_flow, dok_tgt_audio))
+                else:  # For joint(rgb+flow) input
+                    loss_dmn_src = loss_dmn_src_rgb + loss_dmn_src_flow
+                    loss_dmn_tgt = loss_dmn_tgt_rgb + loss_dmn_tgt_flow
+                    dok = torch.cat((dok_src_rgb, dok_src_flow, dok_tgt_rgb, dok_tgt_flow))
+                    dok_src = torch.cat((dok_src_rgb, dok_src_flow))
+                    dok_tgt = torch.cat((dok_tgt_rgb, dok_tgt_flow))
+            else:
+                if self.audio:  # For rgb+audio input
+                    loss_dmn_src = loss_dmn_src_rgb + loss_dmn_src_audio
+                    loss_dmn_tgt = loss_dmn_tgt_rgb + loss_dmn_tgt_audio
+                    dok = torch.cat((dok_src_rgb, dok_src_audio, dok_tgt_rgb, dok_tgt_audio))
+                    dok_src = torch.cat((dok_src_rgb, dok_src_audio))
+                    dok_tgt = torch.cat((dok_tgt_rgb, dok_tgt_audio))
+                else:  # For rgb input
+                    loss_dmn_src = loss_dmn_src_rgb
+                    loss_dmn_tgt = loss_dmn_tgt_rgb
+                    dok = torch.cat((dok_src_rgb, dok_tgt_rgb))
+                    dok_src = dok_src_rgb
+                    dok_tgt = dok_tgt_rgb
         else:
-            if self.rgb:  # For rgb input
-                d_hat = d_hat_rgb
-                d_t_hat = d_t_hat_rgb
-            else:  # For flow input
-                d_hat = d_hat_flow
-                d_t_hat = d_t_hat_flow
-
-            loss_dmn_src, dok_src = losses.cross_entropy_logits(d_hat, torch.zeros(batch_size))
-            loss_dmn_tgt, dok_tgt = losses.cross_entropy_logits(d_t_hat, torch.ones(batch_size))
-            dok = torch.cat((dok_src, dok_tgt))
-
-        # loss_cls, ok_src = losses.cross_entropy_logits(y_hat[0], y_s)
-        # _, ok_tgt = losses.cross_entropy_logits(y_t_hat[0], y_tu)
-        # adv_loss = loss_dmn_src + loss_dmn_tgt  # adv_loss = src + tgt
-        # task_loss = loss_cls
-        #
-        # log_metrics = {
-        #     f"{split_name}_source_acc": ok_src,
-        #     f"{split_name}_target_acc": ok_tgt,
-        #     f"{split_name}_domain_acc": dok,
-        #     f"{split_name}_source_domain_acc": dok_src,
-        #     f"{split_name}_target_domain_acc": dok_tgt,
-        # }
+            if self.flow:
+                if self.audio:  # For flow+audio input
+                    loss_dmn_src = loss_dmn_src_flow + loss_dmn_src_audio
+                    loss_dmn_tgt = loss_dmn_tgt_flow + loss_dmn_tgt_audio
+                    dok = torch.cat((dok_src_flow, dok_src_audio, dok_tgt_flow, dok_tgt_audio))
+                    dok_src = torch.cat((dok_src_flow, dok_src_audio))
+                    dok_tgt = torch.cat((dok_tgt_flow, dok_tgt_audio))
+                else:  # For flow input
+                    loss_dmn_src = loss_dmn_src_flow
+                    loss_dmn_tgt = loss_dmn_tgt_flow
+                    dok = torch.cat((dok_src_flow, dok_tgt_flow))
+                    dok_src = dok_src_flow
+                    dok_tgt = dok_tgt_flow
+            else:  # For audio input
+                loss_dmn_src = loss_dmn_src_audio
+                loss_dmn_tgt = loss_dmn_tgt_audio
+                dok = torch.cat((dok_src_audio, dok_tgt_audio))
+                dok_src = dok_src_audio
+                dok_tgt = dok_tgt_audio
 
         task_loss, log_metrics = self.get_loss_log_metrics(split_name, y_hat, y_t_hat, y_s, y_tu, dok)
         adv_loss = loss_dmn_src + loss_dmn_tgt  # adv_loss = src + tgt
         log_metrics.update({f"{split_name}_source_domain_acc": dok_src, f"{split_name}_target_domain_acc": dok_tgt})
+
         return task_loss, adv_loss, log_metrics
 
 
@@ -667,13 +901,16 @@ class WDGRLTrainerVideo(BaseAdaptTrainerVideo, WDGRLTrainer):
         )
         self.image_modality = image_modality
         self.rgb, self.flow, self.audio = get_image_modality(self.image_modality)
-        self.verb, self.noun = get_class_type(class_type)
+        self.class_type = class_type
+        self.verb, self.noun = get_class_type(self.class_type)
         self.rgb_feat = self.feat["rgb"]
         self.flow_feat = self.feat["flow"]
+        self.audio_feat = self.feat["audio"]
 
     def forward(self, x):
         if self.feat is not None:
-            x_rgb = x_flow = adversarial_output_rgb = adversarial_output_flow = None
+            x_rgb = x_flow = x_audio = None
+            adversarial_output_rgb = adversarial_output_flow = adversarial_output_audio = None
 
             # For joint input, both two ifs are used
             if self.rgb:
@@ -684,90 +921,132 @@ class WDGRLTrainerVideo(BaseAdaptTrainerVideo, WDGRLTrainer):
                 x_flow = self.flow_feat(x["flow"])
                 x_flow = x_flow.view(x_flow.size(0), -1)
                 adversarial_output_flow = self.domain_classifier(x_flow)
+            if self.audio:
+                x_audio = self.audio_feat(x["audio"])
+                x_audio = x_audio.view(x_audio.size(0), -1)
+                adversarial_output_audio = self.domain_classifier(x_audio)
 
-            if self.rgb:
-                if self.flow:  # For joint input
-                    x = torch.cat((x_rgb, x_flow), dim=1)
-                else:  # For rgb input
-                    x = x_rgb
-            else:  # For flow input
-                x = x_flow
+            x = self.concatenate(x_rgb, x_flow, x_audio)
+
             class_output = self.classifier(x)
 
-            return [x_rgb, x_flow], class_output, [adversarial_output_rgb, adversarial_output_flow]
+            return (
+                [x_rgb, x_flow, x_audio],
+                class_output,
+                [adversarial_output_rgb, adversarial_output_flow, adversarial_output_audio],
+            )
 
-    def compute_loss(self, batch, split_name="valid"):
+    def compute_loss(self, batch, split_name="V"):
         # _s refers to source, _tu refers to unlabeled target
-        x_s_rgb = x_tu_rgb = x_s_flow = x_tu_flow = None
-        if self.rgb:
-            if self.flow:  # For joint input
-                (x_s_rgb, y_s), (x_s_flow, y_s_flow), (x_tu_rgb, y_tu), (x_tu_flow, y_tu_flow) = batch
-            else:  # For rgb input
-                (x_s_rgb, y_s), (x_tu_rgb, y_tu) = batch
-        else:  # For flow input
-            (x_s_flow, y_s), (x_tu_flow, y_tu) = batch
+        (
+            x_s_rgb,
+            x_tu_rgb,
+            x_s_flow,
+            x_tu_flow,
+            x_s_audio,
+            x_tu_audio,
+            y_s,
+            y_tu,
+            s_id,
+            tu_id,
+        ) = self.get_inputs_from_batch(batch)
 
-        _, y_hat, [d_hat_rgb, d_hat_flow] = self.forward({"rgb": x_s_rgb, "flow": x_s_flow})
-        _, y_t_hat, [d_t_hat_rgb, d_t_hat_flow] = self.forward({"rgb": x_tu_rgb, "flow": x_tu_flow})
-        batch_size = len(y_s)
+        _, y_hat, [d_hat_rgb, d_hat_flow, d_hat_audio] = self.forward(
+            {"rgb": x_s_rgb, "flow": x_s_flow, "audio": x_s_audio}
+        )
+        _, y_t_hat, [d_t_hat_rgb, d_t_hat_flow, d_t_hat_audio] = self.forward(
+            {"rgb": x_tu_rgb, "flow": x_tu_flow, "audio": x_tu_audio}
+        )
+        source_batch_size = len(y_s[0])
+        target_batch_size = len(y_tu[0])
 
-        # ok is abbreviation for (all) correct, dok refers to domain correct
         if self.rgb:
-            _, dok_src_rgb = losses.cross_entropy_logits(d_hat_rgb, torch.zeros(batch_size))
-            _, dok_tgt_rgb = losses.cross_entropy_logits(d_t_hat_rgb, torch.ones(batch_size))
+            loss_dmn_src_rgb, dok_src_rgb = losses.cross_entropy_logits(d_hat_rgb, torch.zeros(source_batch_size))
+            loss_dmn_tgt_rgb, dok_tgt_rgb = losses.cross_entropy_logits(d_t_hat_rgb, torch.ones(target_batch_size))
         if self.flow:
-            _, dok_src_flow = losses.cross_entropy_logits(d_hat_flow, torch.zeros(batch_size))
-            _, dok_tgt_flow = losses.cross_entropy_logits(d_t_hat_flow, torch.ones(batch_size))
+            loss_dmn_src_flow, dok_src_flow = losses.cross_entropy_logits(d_hat_flow, torch.zeros(source_batch_size))
+            loss_dmn_tgt_flow, dok_tgt_flow = losses.cross_entropy_logits(d_t_hat_flow, torch.ones(target_batch_size))
+        if self.audio:
+            loss_dmn_src_audio, dok_src_audio = losses.cross_entropy_logits(d_hat_audio, torch.zeros(source_batch_size))
+            loss_dmn_tgt_audio, dok_tgt_audio = losses.cross_entropy_logits(
+                d_t_hat_audio, torch.ones(target_batch_size)
+            )
 
-        if self.rgb and self.flow:  # For joint input
-            dok = torch.cat((dok_src_rgb, dok_src_flow, dok_tgt_rgb, dok_tgt_flow))
-            dok_src = torch.cat((dok_src_rgb, dok_src_flow))
-            dok_tgt = torch.cat((dok_tgt_rgb, dok_tgt_flow))
-            wasserstein_distance_rgb = d_hat_rgb.mean() - (1 + self._beta_ratio) * d_t_hat_rgb.mean()
-            wasserstein_distance_flow = d_hat_flow.mean() - (1 + self._beta_ratio) * d_t_hat_flow.mean()
-            wasserstein_distance = (wasserstein_distance_rgb + wasserstein_distance_flow) / 2
+        if self.rgb:
+            if self.flow:
+                if self.audio:  # For all inputs
+                    dok = torch.cat(
+                        (dok_src_rgb, dok_src_flow, dok_src_audio, dok_tgt_rgb, dok_tgt_flow, dok_tgt_audio)
+                    )
+                    dok_src = torch.cat((dok_src_rgb, dok_src_flow, dok_src_audio))
+                    dok_tgt = torch.cat((dok_tgt_rgb, dok_tgt_flow, dok_tgt_audio))
+                    wasserstein_distance_rgb = d_hat_rgb.mean() - (1 + self._beta_ratio) * d_t_hat_rgb.mean()
+                    wasserstein_distance_flow = d_hat_flow.mean() - (1 + self._beta_ratio) * d_t_hat_flow.mean()
+                    wasserstein_distance_audio = d_hat_audio.mean() - (1 + self._beta_ratio) * d_t_hat_audio.mean()
+                    wasserstein_distance = (
+                        wasserstein_distance_rgb + wasserstein_distance_flow + wasserstein_distance_audio
+                    ) / 3
+                else:  # For joint(rgb+flow) input
+                    dok = torch.cat((dok_src_rgb, dok_src_flow, dok_tgt_rgb, dok_tgt_flow))
+                    dok_src = torch.cat((dok_src_rgb, dok_src_flow))
+                    dok_tgt = torch.cat((dok_tgt_rgb, dok_tgt_flow))
+                    wasserstein_distance_rgb = d_hat_rgb.mean() - (1 + self._beta_ratio) * d_t_hat_rgb.mean()
+                    wasserstein_distance_flow = d_hat_flow.mean() - (1 + self._beta_ratio) * d_t_hat_flow.mean()
+                    wasserstein_distance = (wasserstein_distance_rgb + wasserstein_distance_flow) / 2
+            else:
+                if self.audio:  # For rgb+audio input
+                    dok = torch.cat((dok_src_rgb, dok_src_audio, dok_tgt_rgb, dok_tgt_audio))
+                    dok_src = torch.cat((dok_src_rgb, dok_src_audio))
+                    dok_tgt = torch.cat((dok_tgt_rgb, dok_tgt_audio))
+                    wasserstein_distance_rgb = d_hat_rgb.mean() - (1 + self._beta_ratio) * d_t_hat_rgb.mean()
+                    wasserstein_distance_audio = d_hat_audio.mean() - (1 + self._beta_ratio) * d_t_hat_audio.mean()
+                    wasserstein_distance = (wasserstein_distance_rgb + wasserstein_distance_audio) / 2
+                else:  # For rgb input
+                    d_hat = d_hat_rgb
+                    d_t_hat = d_t_hat_rgb
+                    dok_src = dok_src_rgb
+                    dok_tgt = dok_tgt_rgb
+                    wasserstein_distance = d_hat.mean() - (1 + self._beta_ratio) * d_t_hat.mean()
+                    dok = torch.cat((dok_src, dok_tgt))
         else:
-            if self.rgb:  # For rgb input
-                d_hat = d_hat_rgb
-                d_t_hat = d_t_hat_rgb
-                dok_src = dok_src_rgb
-                dok_tgt = dok_tgt_rgb
-            else:  # For flow input
-                d_hat = d_hat_flow
-                d_t_hat = d_t_hat_flow
-                dok_src = dok_src_flow
-                dok_tgt = dok_tgt_flow
-
-            wasserstein_distance = d_hat.mean() - (1 + self._beta_ratio) * d_t_hat.mean()
-            dok = torch.cat((dok_src, dok_tgt))
-
-        # loss_cls, ok_src = losses.cross_entropy_logits(y_hat[0], y_s)
-        # _, ok_tgt = losses.cross_entropy_logits(y_t_hat[0], y_tu)
-        # adv_loss = wasserstein_distance
-        # task_loss = loss_cls
-        #
-        # log_metrics = {
-        #     f"{split_name}_source_acc": ok_src,
-        #     f"{split_name}_target_acc": ok_tgt,
-        #     f"{split_name}_domain_acc": dok,
-        #     f"{split_name}_source_domain_acc": dok_src,
-        #     f"{split_name}_target_domain_acc": dok_tgt,
-        #     f"{split_name}_wasserstein_dist": wasserstein_distance,
-        # }
+            if self.flow:
+                if self.audio:  # For flow+audio input
+                    dok = torch.cat((dok_src_audio, dok_src_flow, dok_tgt_audio, dok_tgt_flow))
+                    dok_src = torch.cat((dok_src_audio, dok_src_flow))
+                    dok_tgt = torch.cat((dok_tgt_audio, dok_tgt_flow))
+                    wasserstein_distance_audio = d_hat_audio.mean() - (1 + self._beta_ratio) * d_t_hat_audio.mean()
+                    wasserstein_distance_flow = d_hat_flow.mean() - (1 + self._beta_ratio) * d_t_hat_flow.mean()
+                    wasserstein_distance = (wasserstein_distance_audio + wasserstein_distance_flow) / 2
+                else:  # For flow input
+                    d_hat = d_hat_flow
+                    d_t_hat = d_t_hat_flow
+                    dok_src = dok_src_flow
+                    dok_tgt = dok_tgt_flow
+                    wasserstein_distance = d_hat.mean() - (1 + self._beta_ratio) * d_t_hat.mean()
+                    dok = torch.cat((dok_src, dok_tgt))
+            else:  # For audio input
+                d_hat = d_hat_audio
+                d_t_hat = d_t_hat_audio
+                dok_src = dok_src_audio
+                dok_tgt = dok_tgt_audio
+                wasserstein_distance = d_hat.mean() - (1 + self._beta_ratio) * d_t_hat.mean()
+                dok = torch.cat((dok_src, dok_tgt))
 
         task_loss, log_metrics = self.get_loss_log_metrics(split_name, y_hat, y_t_hat, y_s, y_tu, dok)
         adv_loss = wasserstein_distance
         log_metrics.update({f"{split_name}_source_domain_acc": dok_src, f"{split_name}_target_domain_acc": dok_tgt})
+
         return task_loss, adv_loss, log_metrics
 
     def configure_optimizers(self):
-        if self.image_modality in ["rgb", "flow"]:
-            if self.rgb_feat is not None:
-                nets = [self.rgb_feat, self.classifier]
-            else:
-                nets = [self.flow_feat, self.classifier]
-        elif self.image_modality == "joint":
-            nets = [self.rgb_feat, self.flow_feat, self.classifier]
+        nets = [self.classifier]
+        if self.rgb:
+            nets.append(self.rgb_feat)
+        if self.flow:
+            nets.append(self.flow_feat)
+        if self.audio:
+            nets.append(self.audio_feat)
+
         parameters = set()
 
         for net in nets:
@@ -792,19 +1071,25 @@ class WDGRLTrainerVideo(BaseAdaptTrainerVideo, WDGRLTrainer):
 
         set_requires_grad(self.domain_classifier, requires_grad=True)
 
-        if self.image_modality in ["rgb", "flow"]:
-            if self.rgb_feat is not None:
+        if self.image_modality in ["rgb", "flow", "audio"]:
+            if self.rgb:
                 set_requires_grad(self.rgb_feat, requires_grad=False)
                 (x_s, y_s), (x_tu, _) = batch
                 with torch.no_grad():
                     h_s = self.rgb_feat(x_s).data.view(x_s.shape[0], -1)
                     h_t = self.rgb_feat(x_tu).data.view(x_tu.shape[0], -1)
-            else:
+            if self.flow:
                 set_requires_grad(self.flow_feat, requires_grad=False)
                 (x_s, y_s), (x_tu, _) = batch
                 with torch.no_grad():
                     h_s = self.flow_feat(x_s).data.view(x_s.shape[0], -1)
                     h_t = self.flow_feat(x_tu).data.view(x_tu.shape[0], -1)
+            if self.audio:
+                set_requires_grad(self.audio_feat, requires_grad=False)
+                (x_s, y_s), (x_tu, _) = batch
+                with torch.no_grad():
+                    h_s = self.audio_feat(x_s).data.view(x_s.shape[0], -1)
+                    h_t = self.audio_feat(x_tu).data.view(x_tu.shape[0], -1)
 
             for _ in range(self._k_critic):
                 # gp refers to gradient penelty in Wasserstein distance.
@@ -822,10 +1107,12 @@ class WDGRLTrainerVideo(BaseAdaptTrainerVideo, WDGRLTrainer):
                 if self.critic_sched:
                     self.critic_sched.step()
 
-            if self.rgb_feat is not None:
+            if self.rgb:
                 set_requires_grad(self.rgb_feat, requires_grad=True)
-            else:
+            if self.flow:
                 set_requires_grad(self.flow_feat, requires_grad=True)
+            if self.audio:
+                set_requires_grad(self.audio_feat, requires_grad=True)
             set_requires_grad(self.domain_classifier, requires_grad=False)
 
         elif self.image_modality == "joint":
@@ -837,12 +1124,12 @@ class WDGRLTrainerVideo(BaseAdaptTrainerVideo, WDGRLTrainer):
                 h_t_rgb = self.rgb_feat(x_tu_rgb).data.view(x_tu_rgb.shape[0], -1)
                 h_s_flow = self.flow_feat(x_s_flow).data.view(x_s_flow.shape[0], -1)
                 h_t_flow = self.flow_feat(x_tu_flow).data.view(x_tu_flow.shape[0], -1)
-                h_s = torch.cat((h_s_rgb, h_s_flow), dim=1)
-                h_t = torch.cat((h_t_rgb, h_t_flow), dim=1)
+                # h_s = torch.cat((h_s_rgb, h_s_flow), dim=1)
+                # h_t = torch.cat((h_t_rgb, h_t_flow), dim=1)
 
             # Need to improve to process rgb and flow separately in the future.
             for _ in range(self._k_critic):
-                # gp_x refers to gradient penelty for the input with the modality x.
+                # gp_x refers to gradient penelty for the input with the image_modality x.
                 gp_rgb = losses.gradient_penalty(self.domain_classifier, h_s_rgb, h_t_rgb)
                 gp_flow = losses.gradient_penalty(self.domain_classifier, h_s_flow, h_t_flow)
 
@@ -868,4 +1155,56 @@ class WDGRLTrainerVideo(BaseAdaptTrainerVideo, WDGRLTrainer):
 
             set_requires_grad(self.rgb_feat, requires_grad=True)
             set_requires_grad(self.flow_feat, requires_grad=True)
+            set_requires_grad(self.domain_classifier, requires_grad=False)
+
+        elif self.image_modality == "all":
+            set_requires_grad(self.rgb_feat, requires_grad=False)
+            set_requires_grad(self.flow_feat, requires_grad=False)
+            set_requires_grad(self.audio_feat, requires_grad=False)
+            (x_s_rgb, y_s), (x_s_flow, _), (x_s_audio, _), (x_tu_rgb, _), (x_tu_flow, _), (x_tu_audio, _) = batch
+            with torch.no_grad():
+                h_s_rgb = self.rgb_feat(x_s_rgb).data.view(x_s_rgb.shape[0], -1)
+                h_t_rgb = self.rgb_feat(x_tu_rgb).data.view(x_tu_rgb.shape[0], -1)
+                h_s_flow = self.flow_feat(x_s_flow).data.view(x_s_flow.shape[0], -1)
+                h_t_flow = self.flow_feat(x_tu_flow).data.view(x_tu_flow.shape[0], -1)
+                h_s_audio = self.audio_feat(x_s_audio).data.view(x_s_audio.shape[0], -1)
+                h_t_audio = self.audio_feat(x_tu_audio).data.view(x_tu_audio.shape[0], -1)
+                # h_s = torch.cat((h_s_rgb, h_s_flow), dim=1)
+                # h_t = torch.cat((h_t_rgb, h_t_flow), dim=1)
+
+            # Need to improve to process rgb and flow separately in the future.
+            for _ in range(self._k_critic):
+                # gp_x refers to gradient penelty for the input with the image_modality x.
+                gp_rgb = losses.gradient_penalty(self.domain_classifier, h_s_rgb, h_t_rgb)
+                gp_flow = losses.gradient_penalty(self.domain_classifier, h_s_flow, h_t_flow)
+                gp_audio = losses.gradient_penalty(self.domain_classifier, h_s_audio, h_t_audio)
+
+                critic_s_rgb = self.domain_classifier(h_s_rgb)
+                critic_s_flow = self.domain_classifier(h_s_flow)
+                critic_s_audio = self.domain_classifier(h_s_audio)
+                critic_t_rgb = self.domain_classifier(h_t_rgb)
+                critic_t_flow = self.domain_classifier(h_t_flow)
+                critic_t_audio = self.domain_classifier(h_t_audio)
+                wasserstein_distance_rgb = critic_s_rgb.mean() - (1 + self._beta_ratio) * critic_t_rgb.mean()
+                wasserstein_distance_flow = critic_s_flow.mean() - (1 + self._beta_ratio) * critic_t_flow.mean()
+                wasserstein_distance_audio = critic_s_audio.mean() - (1 + self._beta_ratio) * critic_t_audio.mean()
+
+                critic_cost = (
+                    -wasserstein_distance_rgb
+                    + -wasserstein_distance_flow
+                    + -wasserstein_distance_audio
+                    + self._gamma * gp_rgb
+                    + self._gamma * gp_flow
+                    + self._gamma * gp_audio
+                ) * 0.5
+
+                self.critic_opt.zero_grad()
+                critic_cost.backward()
+                self.critic_opt.step()
+                if self.critic_sched:
+                    self.critic_sched.step()
+
+            set_requires_grad(self.rgb_feat, requires_grad=True)
+            set_requires_grad(self.flow_feat, requires_grad=True)
+            set_requires_grad(self.audio_feat, requires_grad=True)
             set_requires_grad(self.domain_classifier, requires_grad=False)

--- a/kale/pipeline/video_domain_adapter.py
+++ b/kale/pipeline/video_domain_adapter.py
@@ -113,16 +113,19 @@ class BaseAdaptTrainerVideo(BaseAdaptTrainer):
     """Base class for all domain adaptation architectures on videos. Inherited from BaseAdaptTrainer."""
 
     def train_dataloader(self):
-        dataloader = self._dataset.get_domain_loaders(split="train", batch_size=self._batch_size)
+        dataloader, target_batch_size = self._dataset.get_domain_loaders(split="train", batch_size=self._batch_size)
         self._nb_training_batches = len(dataloader)
+        self._target_batch_size = target_batch_size
         return dataloader
 
     def val_dataloader(self):
-        dataloader = self._dataset.get_domain_loaders(split="valid", batch_size=self._batch_size)
+        dataloader, target_batch_size = self._dataset.get_domain_loaders(split="valid", batch_size=self._batch_size)
+        self._target_batch_size = target_batch_size
         return dataloader
 
     def test_dataloader(self):
-        dataloader = self._dataset.get_domain_loaders(split="test", batch_size=self._batch_size)
+        dataloader, target_batch_size = self._dataset.get_domain_loaders(split="test", batch_size=self._batch_size)
+        self._target_batch_size = target_batch_size
         return dataloader
 
     def training_step(self, batch, batch_nb):
@@ -402,7 +405,7 @@ class DANNTrainerVideo(BaseAdaptTrainerVideo, DANNTrainer):
             dataset, feature_extractor, task_classifier, critic, method, **base_params
         )
         self.image_modality = image_modality
-        self.rgb, self.flow = get_image_modality(self.image_modality)
+        self.rgb, self.flow, self.audio = get_image_modality(self.image_modality)
         self.verb, self.noun = get_class_type(class_type)
         self.rgb_feat = self.feat["rgb"]
         self.flow_feat = self.feat["flow"]
@@ -515,7 +518,7 @@ class CDANTrainerVideo(BaseAdaptTrainerVideo, CDANTrainer):
             dataset, feature_extractor, task_classifier, critic, use_entropy, use_random, random_dim, **base_params
         )
         self.image_modality = image_modality
-        self.rgb, self.flow = get_image_modality(image_modality)
+        self.rgb, self.flow, self.audio = get_image_modality(image_modality)
         self.verb, self.noun = get_class_type(class_type)
         self.rgb_feat = self.feat["rgb"]
         self.flow_feat = self.feat["flow"]
@@ -663,7 +666,7 @@ class WDGRLTrainerVideo(BaseAdaptTrainerVideo, WDGRLTrainer):
             dataset, feature_extractor, task_classifier, critic, k_critic, gamma, beta_ratio, **base_params
         )
         self.image_modality = image_modality
-        self.rgb, self.flow = get_image_modality(self.image_modality)
+        self.rgb, self.flow, self.audio = get_image_modality(self.image_modality)
         self.verb, self.noun = get_class_type(class_type)
         self.rgb_feat = self.feat["rgb"]
         self.flow_feat = self.feat["flow"]

--- a/kale/pipeline/video_domain_adapter.py
+++ b/kale/pipeline/video_domain_adapter.py
@@ -288,10 +288,10 @@ class BaseAdaptTrainerVideo(BaseAdaptTrainer):
         """Get the loss, top-k accuracy and metrics for a given split."""
 
         if self.verb and not self.noun:
-            loss_cls, ok_src = losses.cross_entropy_logits(y_hat[0], y_s)
-            _, ok_tgt = losses.cross_entropy_logits(y_t_hat[0], y_tu)
-            prec1_src, prec5_src = losses.topk_accuracy(y_hat[0], y_s, topk=(1, 5))
-            prec1_tgt, prec5_tgt = losses.topk_accuracy(y_t_hat[0], y_tu, topk=(1, 5))
+            loss_cls, ok_src = losses.cross_entropy_logits(y_hat[0], y_s[0])
+            _, ok_tgt = losses.cross_entropy_logits(y_t_hat[0], y_tu[0])
+            prec1_src, prec5_src = losses.topk_accuracy(y_hat[0], y_s[0], topk=(1, 5))
+            prec1_tgt, prec5_tgt = losses.topk_accuracy(y_t_hat[0], y_tu[0], topk=(1, 5))
             task_loss = loss_cls
 
             log_metrics = {

--- a/kale/pipeline/video_domain_adapter.py
+++ b/kale/pipeline/video_domain_adapter.py
@@ -499,8 +499,8 @@ class JANTrainerVideo(BaseMMDLikeVideo):
 
     def _compute_mmd(self, phi_s, phi_t, y_hat, y_t_hat):
         softmax_layer = torch.nn.Softmax(dim=-1)
-        source_list = [phi_s, softmax_layer(y_hat[0])]
-        target_list = [phi_t, softmax_layer(y_t_hat[0])]
+        source_list = [phi_s, softmax_layer(y_hat)]
+        target_list = [phi_t, softmax_layer(y_t_hat)]
         batch_size = int(phi_s.size()[0])
 
         joint_kernels = None

--- a/kale/prepdata/video_transform.py
+++ b/kale/prepdata/video_transform.py
@@ -79,6 +79,8 @@ def get_transform(kind, image_modality):
             }
         else:
             raise ValueError("Input modality is not in [rgb, flow, joint]. Current is {}".format(image_modality))
+    elif kind is None:
+        return
     else:
         raise ValueError(f"Unknown transform kind '{kind}'")
     return transform

--- a/kale/utils/logger.py
+++ b/kale/utils/logger.py
@@ -84,8 +84,7 @@ def create_single_result_dict(pred_cpu, pred_id, name="verb"):
 
 
 def save_results_to_json(
-        y_hat, y_t_hat, y_ids, y_t_ids, y_hat_noun=None, y_t_hat_noun=None, verb=True, noun=False,
-        file_name="test.json",
+    y_hat, y_t_hat, y_ids, y_t_ids, y_hat_noun=None, y_t_hat_noun=None, verb=True, noun=False, file_name="test.json",
 ):
     """Save the output for each class to a json file.
     Args:

--- a/kale/utils/logger.py
+++ b/kale/utils/logger.py
@@ -1,6 +1,7 @@
 """Logging functions, based on https://github.com/HaozhiQi/ISONet/blob/master/isonet/utils/logger.py"""
 
 import datetime
+import json
 import logging
 import os
 import uuid
@@ -39,3 +40,89 @@ def construct_logger(name, save_dir):
     os.system(f"git diff HEAD > {gitdiff_patch}")
 
     return logger
+
+
+def create_multi_results_dict(pred_verb_cpu, pred_noun_cpu, pred_id, name1="verb", name2="noun"):
+    """Construct a dictionary to save multi class results (verb and noun).
+    Args:
+        pred_verb_cpu (list): results for verb class.
+        pred_noun_cpu (list): results for noun class.
+        pred_id (tuple): corresponding segment ids to results.
+        name1 (string): the name of the first class.
+        name2 (string): the name of the second class.
+    Returns:
+        results_dict (dict): the dictionary covering class names and results.
+    """
+    results_dict = {}
+    for p_verb, p_noun, p_id in zip(pred_verb_cpu, pred_noun_cpu, pred_id):
+        verb_dict = {}
+        noun_dict = {}
+        for i, prob in enumerate(p_verb):
+            verb_dict[str(i)] = prob
+        for i, prob in enumerate(p_noun):
+            noun_dict[str(i)] = prob
+        results_dict[p_id] = {name1: verb_dict, name2: noun_dict}
+    return results_dict
+
+
+def create_single_result_dict(pred_cpu, pred_id, name="verb"):
+    """Construct a dictionary to save single class results.
+    Args:
+        pred_cpu (list): results for the class.
+        pred_id (tuple): corresponding segment ids to results.
+        name (string): the name of the class.
+    Returns:
+        results_dict (dict): the dictionary covering class name and results.
+    """
+    results_dict = {}
+    for p, p_id in zip(pred_cpu, pred_id):
+        d = {}
+        for i, prob in enumerate(p):
+            d[str(i)] = prob
+        results_dict[p_id] = {name: d}
+    return results_dict
+
+
+def save_results_to_json(
+        y_hat, y_t_hat, y_ids, y_t_ids, y_hat_noun=None, y_t_hat_noun=None, verb=True, noun=False,
+        file_name="test.json",
+):
+    """Save the output for each class to a json file.
+    Args:
+        y_hat (list): results for verb classes from the source data.
+        y_t_hat (list): results for verb classes from the target data.
+        y_ids (list): corresponding segment ids to source data results.
+        y_t_ids (list): corresponding segment ids to target data results.
+        y_hat_noun (list): results for noun classes from the source data.
+        y_t_hat_noun (list): results for noun classes from the target data.
+        verb (bool): check if results covers verb class.
+        noun (bool): check if results covers noun class.
+        file_name (string): the name of the file to save.
+    """
+    if verb:
+        pred_verb_cpu = y_hat
+        pred_t_verb_cpu = y_t_hat
+    if noun:
+        pred_noun_cpu = y_hat_noun
+        pred_t_noun_cpu = y_t_hat_noun
+
+    if verb and noun:
+        results_dict = create_multi_results_dict(pred_verb_cpu, pred_noun_cpu, y_ids)
+        results_t_dict = create_multi_results_dict(pred_t_verb_cpu, pred_t_noun_cpu, y_t_ids)
+    elif verb and not noun:
+        results_dict = create_single_result_dict(pred_verb_cpu, y_ids)
+        results_t_dict = create_single_result_dict(pred_t_verb_cpu, y_t_ids)
+
+    with open(file_name, "w") as f:
+        json.dump(
+            {
+                "results_source": results_dict,
+                "results_target": results_t_dict,
+                "version": "0.2",
+                "challenge": "domain_adaptation",
+                "sls_pt": 2,
+                "sls_tl": 3,
+                "sls_td": 3,
+            },
+            f,
+        )

--- a/kale/utils/logger.py
+++ b/kale/utils/logger.py
@@ -42,19 +42,19 @@ def construct_logger(name, save_dir):
     return logger
 
 
-def create_multi_results_dict(pred_verb_cpu, pred_noun_cpu, pred_id, name1="verb", name2="noun"):
+def create_multi_results_dict(pred_verb, pred_noun, pred_id, name1="verb", name2="noun"):
     """Construct a dictionary to save multi class results (verb and noun).
     Args:
-        pred_verb_cpu (list): results for verb class.
-        pred_noun_cpu (list): results for noun class.
-        pred_id (tuple): corresponding segment ids to results.
+        pred_verb (list): results for verb class.
+        pred_noun (list): results for noun class.
+        pred_id (tuple, optional): corresponding segment ids to results.
         name1 (string): the name of the first class.
         name2 (string): the name of the second class.
     Returns:
         results_dict (dict): the dictionary covering class names and results.
     """
     results_dict = {}
-    for p_verb, p_noun, p_id in zip(pred_verb_cpu, pred_noun_cpu, pred_id):
+    for p_verb, p_noun, p_id in zip(pred_verb, pred_noun, pred_id):
         verb_dict = {}
         noun_dict = {}
         for i, prob in enumerate(p_verb):
@@ -65,17 +65,17 @@ def create_multi_results_dict(pred_verb_cpu, pred_noun_cpu, pred_id, name1="verb
     return results_dict
 
 
-def create_single_result_dict(pred_cpu, pred_id, name="verb"):
+def create_single_result_dict(pred, pred_id, name="verb"):
     """Construct a dictionary to save single class results.
     Args:
-        pred_cpu (list): results for the class.
-        pred_id (tuple): corresponding segment ids to results.
+        pred (list): results for the class.
+        pred_id (tuple, optional): corresponding segment ids to results.
         name (string): the name of the class.
     Returns:
         results_dict (dict): the dictionary covering class name and results.
     """
     results_dict = {}
-    for p, p_id in zip(pred_cpu, pred_id):
+    for p, p_id in zip(pred, pred_id):
         d = {}
         for i, prob in enumerate(p):
             d[str(i)] = prob
@@ -90,8 +90,8 @@ def save_results_to_json(
     Args:
         y_hat (list): results for verb classes from the source data.
         y_t_hat (list): results for verb classes from the target data.
-        y_ids (list): corresponding segment ids to source data results.
-        y_t_ids (list): corresponding segment ids to target data results.
+        y_ids (tuple, optional): corresponding segment ids to source data results.
+        y_t_ids (tuple, optional): corresponding segment ids to target data results.
         y_hat_noun (list): results for noun classes from the source data.
         y_t_hat_noun (list): results for noun classes from the target data.
         verb (bool): check if results covers verb class.

--- a/tests/embed/test_attention_cnn.py
+++ b/tests/embed/test_attention_cnn.py
@@ -1,8 +1,9 @@
 import numpy.testing as testing
+import pytest
 import torch
 import torch.nn as nn
 
-from kale.embed.attention_cnn import CNNTransformer
+from kale.embed.attention_cnn import CNNTransformer, SelfAttention, TransformerBlock, TransformerSENet
 from kale.prepdata.tensor_reshape import seq_to_spatial
 from kale.utils.seed import set_seed
 
@@ -45,3 +46,28 @@ def test_shapes():
     out_spatial_2 = seq_to_spatial(out_seq, CNN_OUT_HEIGHT, CNN_OUT_WIDTH)
 
     testing.assert_almost_equal(out_spatial.detach().numpy(), out_spatial_2.detach().numpy())
+
+
+@pytest.mark.parametrize("causal", [True, False])
+def test_SelfAttention(causal):
+    INPUT_BATCH = torch.randn(2, 8, 8)
+    model = SelfAttention(8, 2, 0.1, 0.1, causal, 9)
+    model.eval()
+    output_batch = model(INPUT_BATCH)
+    assert output_batch.size() == (2, 8, 8)
+
+
+def test_TransformerBlock():
+    INPUT_BATCH = torch.randn(2, 8, 8)
+    model = TransformerBlock(8, 8, 0.1, 0.1, 0.1, 9, 10, False)
+    model.eval()
+    output_batch = model(INPUT_BATCH)
+    assert output_batch.size() == (2, 8, 8)
+
+
+def test_TransformerSENet():
+    INPUT_BATCH = torch.randn(2, 8, 32)
+    model = TransformerSENet(input_size=32, n_channel=10, output_size=5)
+    model.eval()
+    output_batch = model(INPUT_BATCH)
+    assert output_batch.size() == (2, 8, 5)

--- a/tests/embed/test_video_feature_extractor.py
+++ b/tests/embed/test_video_feature_extractor.py
@@ -13,7 +13,7 @@ NUM_CLASSES = {"verb": 6, "noun": 7}
 @pytest.mark.parametrize("attention", ["SELayerC", "SELayerT", "SELayerCT", "SELayerTC", "None"])
 def test_get_video_feat_extractor(model_name, image_modality, attention):
     feature_network, class_feature_dim, domain_feature_dim = get_extractor_video(
-        model_name, image_modality, attention, NUM_CLASSES
+        model_name, image_modality, attention, NUM_CLASSES["verb"]
     )
 
     assert isinstance(feature_network, dict)

--- a/tests/embed/test_video_feature_extractor.py
+++ b/tests/embed/test_video_feature_extractor.py
@@ -1,19 +1,16 @@
 import pytest
 import torch
 
-from kale.embed.video_feature_extractor import get_extractor_video
+from kale.embed.video_feature_extractor import get_extractor_feat, get_extractor_video
 
-MODEL_NAME = ["I3D", "R3D_18", "R2PLUS1D_18", "MC3_18"]
-IMAGE_MODALITY = ["rgb", "flow", "joint"]
 # ATTENTION = ["SELayerC", "SELayerT", "SELayerCoC", "SELayerMC", "SELayerCT", "SELayerTC", "SELayerMAC", "None"]
-ATTENTION = ["SELayerC", "SELayerT", "SELayerCT", "SELayerTC", "None"]
 
 NUM_CLASSES = {"verb": 6, "noun": 7}
 
 
-@pytest.mark.parametrize("model_name", MODEL_NAME)
-@pytest.mark.parametrize("image_modality", IMAGE_MODALITY)
-@pytest.mark.parametrize("attention", ATTENTION)
+@pytest.mark.parametrize("model_name", ["I3D", "R3D_18", "R2PLUS1D_18", "MC3_18"])
+@pytest.mark.parametrize("image_modality", ["rgb", "flow", "joint"])
+@pytest.mark.parametrize("attention", ["SELayerC", "SELayerT", "SELayerCT", "SELayerTC", "None"])
 def test_get_video_feat_extractor(model_name, image_modality, attention):
     feature_network, class_feature_dim, domain_feature_dim = get_extractor_video(
         model_name, image_modality, attention, NUM_CLASSES
@@ -38,3 +35,39 @@ def test_get_video_feat_extractor(model_name, image_modality, attention):
     else:
         assert domain_feature_dim == 512
         assert class_feature_dim == 1024 if image_modality == "joint" else class_feature_dim == 512
+
+
+@pytest.mark.parametrize("image_modality", ["rgb", "flow", "audio", "joint", "all"])
+def test_get_vector_feat_extractor(image_modality):
+    feature_network, class_feature_dim, domain_feature_dim = get_extractor_feat("test", image_modality, 32, 5, 2)
+
+    assert isinstance(feature_network, dict)
+
+    if image_modality == "rgb":
+        assert isinstance(feature_network["rgb"], torch.nn.Module)
+        assert feature_network["flow"] is None
+        assert feature_network["audio"] is None
+    elif image_modality == "flow":
+        assert isinstance(feature_network["flow"], torch.nn.Module)
+        assert feature_network["rgb"] is None
+        assert feature_network["audio"] is None
+    elif image_modality == "audio":
+        assert isinstance(feature_network["audio"], torch.nn.Module)
+        assert feature_network["flow"] is None
+        assert feature_network["rgb"] is None
+    elif image_modality == "joint":
+        assert isinstance(feature_network["rgb"], torch.nn.Module)
+        assert isinstance(feature_network["flow"], torch.nn.Module)
+        assert feature_network["audio"] is None
+    elif image_modality == "all":
+        assert isinstance(feature_network["rgb"], torch.nn.Module)
+        assert isinstance(feature_network["flow"], torch.nn.Module)
+        assert isinstance(feature_network["audio"], torch.nn.Module)
+
+    assert domain_feature_dim == 10
+    if image_modality in ["rgb", "flow", "audio"]:
+        assert class_feature_dim == 10
+    elif image_modality == "joint":
+        assert class_feature_dim == 20
+    elif image_modality == "all":
+        assert class_feature_dim == 30

--- a/tests/embed/test_video_feature_extractor.py
+++ b/tests/embed/test_video_feature_extractor.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from kale.embed.video_feature_extractor import get_video_feat_extractor
+from kale.embed.video_feature_extractor import get_extractor_video
 
 MODEL_NAME = ["I3D", "R3D_18", "R2PLUS1D_18", "MC3_18"]
 IMAGE_MODALITY = ["rgb", "flow", "joint"]
@@ -15,7 +15,7 @@ NUM_CLASSES = {"verb": 6, "noun": 7}
 @pytest.mark.parametrize("image_modality", IMAGE_MODALITY)
 @pytest.mark.parametrize("attention", ATTENTION)
 def test_get_video_feat_extractor(model_name, image_modality, attention):
-    feature_network, class_feature_dim, domain_feature_dim = get_video_feat_extractor(
+    feature_network, class_feature_dim, domain_feature_dim = get_extractor_video(
         model_name, image_modality, attention, NUM_CLASSES
     )
 

--- a/tests/embed/test_video_feature_extractor.py
+++ b/tests/embed/test_video_feature_extractor.py
@@ -7,17 +7,16 @@ MODEL_NAME = ["I3D", "R3D_18", "R2PLUS1D_18", "MC3_18"]
 IMAGE_MODALITY = ["rgb", "flow", "joint"]
 # ATTENTION = ["SELayerC", "SELayerT", "SELayerCoC", "SELayerMC", "SELayerCT", "SELayerTC", "SELayerMAC", "None"]
 ATTENTION = ["SELayerC", "SELayerT", "SELayerCT", "SELayerTC", "None"]
-# NUM_CLASSES = [6, 7, 8]
-NUM_CLASSES = [6]
+
+NUM_CLASSES = {"verb": 6, "noun": 7}
 
 
 @pytest.mark.parametrize("model_name", MODEL_NAME)
 @pytest.mark.parametrize("image_modality", IMAGE_MODALITY)
 @pytest.mark.parametrize("attention", ATTENTION)
-@pytest.mark.parametrize("num_classes", NUM_CLASSES)
-def test_get_video_feat_extractor(model_name, image_modality, attention, num_classes):
+def test_get_video_feat_extractor(model_name, image_modality, attention):
     feature_network, class_feature_dim, domain_feature_dim = get_video_feat_extractor(
-        model_name, image_modality, attention, num_classes
+        model_name, image_modality, attention, NUM_CLASSES
     )
 
     assert isinstance(feature_network, dict)

--- a/tests/helpers/boring_model.py
+++ b/tests/helpers/boring_model.py
@@ -7,10 +7,10 @@ import torch.nn as nn
 
 
 class VideoBoringModel(nn.Module):
-    def __init__(self, in_channel):
+    def __init__(self, in_channel, out_channel):
         super().__init__()
         self.avg_pool3d = nn.AdaptiveAvgPool3d(1)
-        self.fc = nn.Linear(in_channel, 1024)
+        self.fc = nn.Linear(in_channel, out_channel)
 
     def forward(self, x):
         x = self.avg_pool3d(x).squeeze()
@@ -19,3 +19,13 @@ class VideoBoringModel(nn.Module):
 
     def output_size(self):
         return self.fc.in_features
+
+
+class VideoVectorBoringModel(nn.Module):
+    def __init__(self, in_channel, out_channel):
+        super().__init__()
+        self.fc = nn.Linear(in_channel, out_channel)
+
+    def forward(self, x):
+        x = self.fc(x)
+        return x

--- a/tests/helpers/pipe_test_helper.py
+++ b/tests/helpers/pipe_test_helper.py
@@ -20,8 +20,17 @@ class ModelTestHelper:
 
 class DASetupHelper:
     @staticmethod
-    def setup_da(da_method, dataset, feature_network, classifier_network, class_type, train_params, domain_feature_dim,
-                 dict_num_classes, cfg):
+    def setup_da(
+        da_method,
+        dataset,
+        feature_network,
+        classifier_network,
+        class_type,
+        train_params,
+        domain_feature_dim,
+        dict_num_classes,
+        cfg,
+    ):
         method_params = {}
         method = domain_adapter.Method(da_method)
 

--- a/tests/helpers/pipe_test_helper.py
+++ b/tests/helpers/pipe_test_helper.py
@@ -1,6 +1,7 @@
 import pytorch_lightning as pl
 
-from kale.pipeline import domain_adapter
+from kale.pipeline import domain_adapter, video_domain_adapter
+from kale.predict.class_domain_nets import DomainNetVideo
 
 
 class ModelTestHelper:
@@ -15,3 +16,49 @@ class ModelTestHelper:
         trainer.test()
         metric_values = trainer.callback_metrics
         assert isinstance(metric_values, dict)
+
+
+class DASetupHelper:
+    @staticmethod
+    def setup_da(da_method, dataset, feature_network, classifier_network, class_type, train_params, domain_feature_dim,
+                 dict_num_classes, cfg):
+        method_params = {}
+        method = domain_adapter.Method(da_method)
+
+        # setup DA method
+        if method.is_mmd_method():
+            model = video_domain_adapter.create_mmd_based_video(
+                method=method,
+                dataset=dataset,
+                image_modality=cfg.DATASET.IMAGE_MODALITY,
+                feature_extractor=feature_network,
+                task_classifier=classifier_network,
+                class_type=class_type,
+                **method_params,
+                **train_params,
+            )
+        else:
+            critic_input_size = domain_feature_dim
+            # setup critic network
+            if method.is_cdan_method():
+                if cfg.DAN.USERANDOM:
+                    critic_input_size = 10
+                else:
+                    critic_input_size = domain_feature_dim * dict_num_classes["verb"]
+            critic_network = DomainNetVideo(input_size=critic_input_size)
+
+            if da_method == "CDAN":
+                method_params["use_random"] = cfg.DAN.USERANDOM
+
+            model = video_domain_adapter.create_dann_like_video(
+                method=method,
+                dataset=dataset,
+                image_modality=cfg.DATASET.IMAGE_MODALITY,
+                feature_extractor=feature_network,
+                task_classifier=classifier_network,
+                critic=critic_network,
+                class_type=class_type,
+                **method_params,
+                **train_params,
+            )
+        return model

--- a/tests/loaddata/test_image_access.py
+++ b/tests/loaddata/test_image_access.py
@@ -49,7 +49,7 @@ TARGETS = ["MNISTM", "SVHN"]
 ALL = SOURCES + TARGETS  # ["SVHN", "USPS", "MNISTM"]  # SOURCES + TARGETS
 
 WEIGHT_TYPE = ["natural", "balanced", "preset0"]
-DATASIZE_TYPE = ["max", "source"]
+DATASIZE_TYPE = ["max", "source", "adaptive"]
 VALID_RATIO = 0.1
 CLASS_SUBSETS = [1, 3, 8]
 

--- a/tests/loaddata/test_image_access.py
+++ b/tests/loaddata/test_image_access.py
@@ -50,9 +50,8 @@ ALL = SOURCES + TARGETS  # ["SVHN", "USPS", "MNISTM"]  # SOURCES + TARGETS
 
 WEIGHT_TYPE = ["natural", "balanced", "preset0"]
 DATASIZE_TYPE = ["max", "source"]
-VALID_RATIO = [0.1]
-
-CLASS_SUBSETS = [[1, 3, 8]]
+VALID_RATIO = 0.1
+CLASS_SUBSETS = [1, 3, 8]
 
 
 @pytest.mark.parametrize("source_name", SOURCES)
@@ -92,29 +91,27 @@ def test_get_train_test(dataset_name, download_path):
     assert isinstance(source_test, torch.utils.data.Dataset)
 
 
-@pytest.mark.parametrize("class_subset", CLASS_SUBSETS)
-@pytest.mark.parametrize("valid_ratio", VALID_RATIO)
-def test_class_subsets(class_subset, valid_ratio, download_path):
+def test_class_subsets(download_path):
     dataset_name = ALL[1]
     source, target, num_channels = DigitDataset.get_source_target(
         DigitDataset(dataset_name), DigitDataset(dataset_name), download_path
     )
 
     dataset_subset = MultiDomainDatasets(
-        source, target, config_weight_type=WEIGHT_TYPE[0], config_size_type=DATASIZE_TYPE[1], class_ids=class_subset,
+        source, target, config_weight_type=WEIGHT_TYPE[0], config_size_type=DATASIZE_TYPE[1], class_ids=CLASS_SUBSETS,
     )
 
-    train, valid = source.get_train_valid(valid_ratio)
+    train, valid = source.get_train_valid(VALID_RATIO)
     test = source.get_test()
-    dataset_subset._source_by_split["train"] = get_class_subset(train, class_subset)
+    dataset_subset._source_by_split["train"] = get_class_subset(train, CLASS_SUBSETS)
     dataset_subset._target_by_split["train"] = dataset_subset._source_by_split["train"]
-    dataset_subset._source_by_split["valid"] = get_class_subset(valid, class_subset)
-    dataset_subset._source_by_split["test"] = get_class_subset(test, class_subset)
+    dataset_subset._source_by_split["valid"] = get_class_subset(valid, CLASS_SUBSETS)
+    dataset_subset._source_by_split["test"] = get_class_subset(test, CLASS_SUBSETS)
 
     # Ground truth lengths
-    train_dataset_subset_length = len([1 for data in train if data[1] in class_subset])
-    valid_dataset_subset_length = len([1 for data in valid if data[1] in class_subset])
-    test_dataset_subset_length = len([1 for data in test if data[1] in class_subset])
+    train_dataset_subset_length = len([1 for data in train if data[1] in CLASS_SUBSETS])
+    valid_dataset_subset_length = len([1 for data in valid if data[1] in CLASS_SUBSETS])
+    test_dataset_subset_length = len([1 for data in test if data[1] in CLASS_SUBSETS])
 
     assert len(dataset_subset._source_by_split["train"]) == train_dataset_subset_length
     assert len(dataset_subset._source_by_split["valid"]) == valid_dataset_subset_length

--- a/tests/loaddata/test_video_access.py
+++ b/tests/loaddata/test_video_access.py
@@ -7,7 +7,7 @@ from yacs.config import CfgNode as CN
 
 from kale.loaddata.dataset_access import get_class_subset
 from kale.loaddata.multi_domain import DomainsDatasetBase
-from kale.loaddata.video_access import get_image_modality, VideoDataset, VideoDatasetAccess
+from kale.loaddata.video_access import get_image_modality, VideoDataset, VideoDatasetAccess, get_class_type
 from kale.loaddata.video_multi_domain import VideoMultiDomainDatasets
 from kale.utils.download import download_file_by_url
 from kale.utils.seed import set_seed
@@ -26,6 +26,7 @@ TARGETS = [
 ]
 ALL = SOURCES + TARGETS
 IMAGE_MODALITY = ["rgb", "flow", "joint"]
+CLASS_TYPE = ["verb", "verb+noun"]
 WEIGHT_TYPE = ["natural", "balanced", "preset0"]
 # DATASIZE_TYPE = ["max", "source"]
 DATASIZE_TYPE = ["max"]
@@ -54,6 +55,32 @@ def test_get_image_modality(image_modality):
 
     assert isinstance(rgb, bool)
     assert isinstance(flow, bool)
+
+    if image_modality == "rgb":
+        assert rgb
+        assert not flow
+    elif image_modality == "flow":
+        assert not rgb
+        assert flow
+    elif image_modality == "joint":
+        assert rgb
+        assert flow
+
+
+@pytest.mark.parametrize("class_type", CLASS_TYPE)
+def test_get_class_type(class_type):
+    verb, noun = get_class_type(class_type)
+
+    assert isinstance(verb, bool)
+    assert isinstance(noun, bool)
+
+    if class_type == "verb":
+        assert verb
+        assert not noun
+
+    elif class_type == "verb+noun":
+        assert verb
+        assert noun
 
 
 @pytest.mark.parametrize("source_cfg", SOURCES)

--- a/tests/loaddata/test_video_access.py
+++ b/tests/loaddata/test_video_access.py
@@ -210,6 +210,7 @@ def test_get_source_target(source_cfg, target_cfg, weight_type, datasize_type, t
         assert len(dataset_subset._rgb_source_by_split["train"]) == train_dataset_subset_length
         assert len(dataset_subset._rgb_source_by_split["valid"]) == valid_dataset_subset_length
         assert len(dataset_subset._rgb_source_by_split["test"]) == test_dataset_subset_length
+        assert len(dataset_subset) == train_dataset_subset_length
 
 
 def test_get_source_target_epic100(testing_cfg_epic100):

--- a/tests/loaddata/test_video_access.py
+++ b/tests/loaddata/test_video_access.py
@@ -50,6 +50,19 @@ def testing_cfg(download_path):
     yield cfg
 
 
+#
+#
+# @pytest.fixture(scope="module")
+# def testing_cfg_epic100(download_path):
+#     cfg = CN()
+#     cfg.DATASET = CN()
+#     # cfg.DATASET.ROOT = root_dir + "/" + download_path + "/video_test_data/"
+#     cfg.DATASET.ROOT = root_dir + "/" + download_path + "/video_test_data/"
+#     cfg.DATASET.IMAGE_MODALITY = "rgb"
+#     cfg.DATASET.FRAMES_PER_SEGMENT = 16
+#     yield cfg
+
+
 @pytest.mark.parametrize("image_modality", IMAGE_MODALITY)
 def test_get_image_modality(image_modality):
     rgb, flow = get_image_modality(image_modality)
@@ -182,3 +195,46 @@ def test_get_source_target(source_cfg, target_cfg, valid_ratio, weight_type, dat
         assert len(dataset_subset._rgb_source_by_split["test"]) == test_dataset_subset_length
         assert len(dataset_subset) == train_dataset_subset_length
 
+
+#
+#
+# @pytest.mark.parametrize("domain", DOMAIN)
+# @pytest.mark.parametrize("target_cfg", TARGETS)
+# @pytest.mark.parametrize("valid_ratio", VALID_RATIO)
+# def test_get_source_target_feature_vector(source_cfg, target_cfg, valid_ratio, weight_type, datasize_type, testing_cfg):
+#     # get cfg parameters
+#     cfg = testing_cfg
+#     cfg.DATASET.SOURCE = source_name
+#     cfg.DATASET.SRC_TRAINLIST = source_trainlist
+#     cfg.DATASET.SRC_TESTLIST = source_testlist
+#     cfg.DATASET.TARGET = target_name
+#     cfg.DATASET.TGT_TRAINLIST = target_trainlist
+#     cfg.DATASET.TGT_TESTLIST = target_testlist
+#     cfg.DATASET.WEIGHT_TYPE = weight_type
+#     cfg.DATASET.SIZE_TYPE = datasize_type
+#
+#     download_file_by_url(
+#         url=url,
+#         output_directory=str(Path(cfg.DATASET.ROOT).parent.absolute()),
+#         output_file_name="video_test_data.zip",
+#         file_format="zip",
+#     )
+#
+#     # test get_source_target
+#     source, target, num_classes = VideoDataset.get_source_target(
+#         VideoDataset(source_name), VideoDataset(target_name), seed, cfg
+#     )
+#
+#     assert num_classes == n_class
+#     assert isinstance(source, dict)
+#     assert isinstance(target, dict)
+#     assert isinstance(source["rgb"], VideoDatasetAccess)
+#     assert isinstance(target["rgb"], VideoDatasetAccess)
+#     assert isinstance(source["flow"], VideoDatasetAccess)
+#     assert isinstance(target["flow"], VideoDatasetAccess)
+#
+#     # test get_train & get_test
+#     assert isinstance(source["rgb"].get_train(), torch.utils.data.Dataset)
+#     assert isinstance(source["rgb"].get_test(), torch.utils.data.Dataset)
+#     assert isinstance(source["flow"].get_train(), torch.utils.data.Dataset)
+#     assert isinstance(source["flow"].get_test(), torch.utils.data.Dataset)

--- a/tests/loaddata/test_video_access.py
+++ b/tests/loaddata/test_video_access.py
@@ -54,13 +54,13 @@ def testing_cfg_epic100(download_path):
     cfg = CN()
     cfg.DATASET = CN()
     # cfg.DATASET.ROOT = root_dir + "/" + download_path + "/video_test_data/"
-    cfg.DATASET.ROOT = "J:/Datasets/EgoAction/"
+    cfg.DATASET.ROOT = root_dir + "/" + download_path + "/video_test_data/"
     cfg.DATASET.SOURCE = "EPIC100"
-    cfg.DATASET.SRC_TRAINLIST = "val/EPIC_100_uda_source_train.pkl"
-    cfg.DATASET.SRC_TESTLIST = "val/EPIC_100_uda_source_test_timestamps.pkl"
+    cfg.DATASET.SRC_TRAINLIST = "EPIC_100_uda_source_train.pkl"
+    cfg.DATASET.SRC_TESTLIST = "EPIC_100_uda_source_test_timestamps.pkl"
     cfg.DATASET.TARGET = "EPIC100"
-    cfg.DATASET.TGT_TRAINLIST = "val/EPIC_100_uda_target_train_timestamps.pkl"
-    cfg.DATASET.TGT_TESTLIST = "val/EPIC_100_uda_target_test_timestamps.pkl"
+    cfg.DATASET.TGT_TRAINLIST = "EPIC_100_uda_target_train_timestamps.pkl"
+    cfg.DATASET.TGT_TESTLIST = "EPIC_100_uda_target_test_timestamps.pkl"
     cfg.DATASET.IMAGE_MODALITY = "joint"
     cfg.DATASET.INPUT_TYPE = "feature"
     cfg.DATASET.NUM_SEGMENTS = 8
@@ -209,12 +209,12 @@ def test_get_source_target_epic100(testing_cfg_epic100):
     # get cfg parameters
     cfg = testing_cfg_epic100
 
-    # download_file_by_url(
-    #     url=url,
-    #     output_directory=str(Path(cfg.DATASET.ROOT).parent.absolute()),
-    #     output_file_name="video_test_data.zip",
-    #     file_format="zip",
-    # )
+    download_file_by_url(
+        url=url,
+        output_directory=str(Path(cfg.DATASET.ROOT).parent.absolute()),
+        output_file_name="video_test_data.zip",
+        file_format="zip",
+    )
 
     # test get_source_target
     source, target, num_classes = VideoDataset.get_source_target(

--- a/tests/loaddata/test_video_access.py
+++ b/tests/loaddata/test_video_access.py
@@ -34,7 +34,6 @@ VALID_RATIO = [0.1]
 seed = 36
 set_seed(seed)
 CLASS_SUBSETS = [[1, 3, 8]]
-DOMAIN = ["source", "target"]
 
 root_dir = os.path.dirname(os.path.dirname(os.getcwd()))
 url = "https://github.com/pykale/data/raw/main/videos/video_test_data.zip"
@@ -50,17 +49,27 @@ def testing_cfg(download_path):
     yield cfg
 
 
-#
-#
-# @pytest.fixture(scope="module")
-# def testing_cfg_epic100(download_path):
-#     cfg = CN()
-#     cfg.DATASET = CN()
-#     # cfg.DATASET.ROOT = root_dir + "/" + download_path + "/video_test_data/"
-#     cfg.DATASET.ROOT = root_dir + "/" + download_path + "/video_test_data/"
-#     cfg.DATASET.IMAGE_MODALITY = "rgb"
-#     cfg.DATASET.FRAMES_PER_SEGMENT = 16
-#     yield cfg
+@pytest.fixture(scope="module")
+def testing_cfg_epic100(download_path):
+    cfg = CN()
+    cfg.DATASET = CN()
+    # cfg.DATASET.ROOT = root_dir + "/" + download_path + "/video_test_data/"
+    cfg.DATASET.ROOT = "J:/Datasets/EgoAction/"
+    cfg.DATASET.SOURCE = "EPIC100"
+    cfg.DATASET.SRC_TRAINLIST = "val/EPIC_100_uda_source_train.pkl"
+    cfg.DATASET.SRC_TESTLIST = "val/EPIC_100_uda_source_test_timestamps.pkl"
+    cfg.DATASET.TARGET = "EPIC100"
+    cfg.DATASET.TGT_TRAINLIST = "val/EPIC_100_uda_target_train_timestamps.pkl"
+    cfg.DATASET.TGT_TESTLIST = "val/EPIC_100_uda_target_test_timestamps.pkl"
+    cfg.DATASET.IMAGE_MODALITY = "joint"
+    cfg.DATASET.INPUT_TYPE = "feature"
+    cfg.DATASET.NUM_SEGMENTS = 8
+    cfg.DATASET.FRAMES_PER_SEGMENT = 2
+    cfg.DATASET.SIZE_TYPE = "adaptive"
+    cfg.DATASET.CLASS_TYPE = "verb+noun"
+    cfg.DATASET.WEIGHT_TYPE = "natural"
+    cfg.DATASET.SIZE_TYPE = "max"
+    yield cfg
 
 
 @pytest.mark.parametrize("image_modality", IMAGE_MODALITY)
@@ -196,45 +205,33 @@ def test_get_source_target(source_cfg, target_cfg, valid_ratio, weight_type, dat
         assert len(dataset_subset) == train_dataset_subset_length
 
 
-#
-#
-# @pytest.mark.parametrize("domain", DOMAIN)
-# @pytest.mark.parametrize("target_cfg", TARGETS)
-# @pytest.mark.parametrize("valid_ratio", VALID_RATIO)
-# def test_get_source_target_feature_vector(source_cfg, target_cfg, valid_ratio, weight_type, datasize_type, testing_cfg):
-#     # get cfg parameters
-#     cfg = testing_cfg
-#     cfg.DATASET.SOURCE = source_name
-#     cfg.DATASET.SRC_TRAINLIST = source_trainlist
-#     cfg.DATASET.SRC_TESTLIST = source_testlist
-#     cfg.DATASET.TARGET = target_name
-#     cfg.DATASET.TGT_TRAINLIST = target_trainlist
-#     cfg.DATASET.TGT_TESTLIST = target_testlist
-#     cfg.DATASET.WEIGHT_TYPE = weight_type
-#     cfg.DATASET.SIZE_TYPE = datasize_type
-#
-#     download_file_by_url(
-#         url=url,
-#         output_directory=str(Path(cfg.DATASET.ROOT).parent.absolute()),
-#         output_file_name="video_test_data.zip",
-#         file_format="zip",
-#     )
-#
-#     # test get_source_target
-#     source, target, num_classes = VideoDataset.get_source_target(
-#         VideoDataset(source_name), VideoDataset(target_name), seed, cfg
-#     )
-#
-#     assert num_classes == n_class
-#     assert isinstance(source, dict)
-#     assert isinstance(target, dict)
-#     assert isinstance(source["rgb"], VideoDatasetAccess)
-#     assert isinstance(target["rgb"], VideoDatasetAccess)
-#     assert isinstance(source["flow"], VideoDatasetAccess)
-#     assert isinstance(target["flow"], VideoDatasetAccess)
-#
-#     # test get_train & get_test
-#     assert isinstance(source["rgb"].get_train(), torch.utils.data.Dataset)
-#     assert isinstance(source["rgb"].get_test(), torch.utils.data.Dataset)
-#     assert isinstance(source["flow"].get_train(), torch.utils.data.Dataset)
-#     assert isinstance(source["flow"].get_test(), torch.utils.data.Dataset)
+def test_get_source_target_epic100(testing_cfg_epic100):
+    # get cfg parameters
+    cfg = testing_cfg_epic100
+
+    # download_file_by_url(
+    #     url=url,
+    #     output_directory=str(Path(cfg.DATASET.ROOT).parent.absolute()),
+    #     output_file_name="video_test_data.zip",
+    #     file_format="zip",
+    # )
+
+    # test get_source_target
+    source, target, num_classes = VideoDataset.get_source_target(
+        VideoDataset(cfg.DATASET.SOURCE.upper()), VideoDataset(cfg.DATASET.TARGET.upper()), seed, cfg
+    )
+
+    assert num_classes["verb"] == 97
+    assert num_classes["noun"] == 300
+    assert isinstance(source, dict)
+    assert isinstance(target, dict)
+    assert isinstance(source["rgb"], VideoDatasetAccess)
+    assert isinstance(target["rgb"], VideoDatasetAccess)
+    assert isinstance(source["flow"], VideoDatasetAccess)
+    assert isinstance(target["flow"], VideoDatasetAccess)
+
+    # test get_train & get_test
+    assert isinstance(source["rgb"].get_train(), torch.utils.data.Dataset)
+    assert isinstance(source["rgb"].get_test(), torch.utils.data.Dataset)
+    assert isinstance(source["flow"].get_train(), torch.utils.data.Dataset)
+    assert isinstance(source["flow"].get_test(), torch.utils.data.Dataset)

--- a/tests/loaddata/test_video_access.py
+++ b/tests/loaddata/test_video_access.py
@@ -7,7 +7,7 @@ from yacs.config import CfgNode as CN
 
 from kale.loaddata.dataset_access import get_class_subset
 from kale.loaddata.multi_domain import DomainsDatasetBase
-from kale.loaddata.video_access import get_image_modality, VideoDataset, VideoDatasetAccess, get_class_type
+from kale.loaddata.video_access import get_class_type, get_image_modality, VideoDataset, VideoDatasetAccess
 from kale.loaddata.video_multi_domain import VideoMultiDomainDatasets
 from kale.utils.download import download_file_by_url
 from kale.utils.seed import set_seed
@@ -34,6 +34,7 @@ VALID_RATIO = [0.1]
 seed = 36
 set_seed(seed)
 CLASS_SUBSETS = [[1, 3, 8]]
+DOMAIN = ["source", "target"]
 
 root_dir = os.path.dirname(os.path.dirname(os.getcwd()))
 url = "https://github.com/pykale/data/raw/main/videos/video_test_data.zip"
@@ -104,6 +105,9 @@ def test_get_source_target(source_cfg, target_cfg, valid_ratio, weight_type, dat
     cfg.DATASET.TGT_TESTLIST = target_testlist
     cfg.DATASET.WEIGHT_TYPE = weight_type
     cfg.DATASET.SIZE_TYPE = datasize_type
+    cfg.DATASET.INPUT_TYPE = "image"
+    cfg.DATASET.CLASS_TYPE = "verb"
+    cfg.DATASET.NUM_SEGMENTS = 1
 
     download_file_by_url(
         url=url,
@@ -117,7 +121,7 @@ def test_get_source_target(source_cfg, target_cfg, valid_ratio, weight_type, dat
         VideoDataset(source_name), VideoDataset(target_name), seed, cfg
     )
 
-    assert num_classes == n_class
+    assert num_classes["verb"] == n_class
     assert isinstance(source, dict)
     assert isinstance(target, dict)
     assert isinstance(source["rgb"], VideoDatasetAccess)
@@ -177,3 +181,4 @@ def test_get_source_target(source_cfg, target_cfg, valid_ratio, weight_type, dat
         assert len(dataset_subset._rgb_source_by_split["valid"]) == valid_dataset_subset_length
         assert len(dataset_subset._rgb_source_by_split["test"]) == test_dataset_subset_length
         assert len(dataset_subset) == train_dataset_subset_length
+

--- a/tests/pipeline/test_video_domain_adapter.py
+++ b/tests/pipeline/test_video_domain_adapter.py
@@ -21,12 +21,9 @@ TARGETS = [
     "EPIC100;EPIC_100_uda_source_test_timestamps.pkl;EPIC_100_uda_source_train.pkl",
 ]
 IMAGE_MODALITY = ["rgb", "flow", "joint"]
-# IMAGE_MODALITY = ["rgb"]
 IMAGE_MODALITY_FEAT = ["rgb", "flow", "audio", "all"]
-# CLASS_TYPE = ["verb", "verb+noun"]
-CLASS_TYPE = ["verb+noun"]
+CLASS_TYPE = ["verb", "verb+noun"]
 DA_METHODS = ["DANN", "CDAN", "CDAN-E", "WDGRL", "DAN", "JAN", "Source"]
-# DA_METHODS = ["JAN"]
 WEIGHT_TYPE = "natural"
 DATASIZE_TYPE = "max"
 VALID_RATIO = 0.1
@@ -193,11 +190,11 @@ def test_video_domain_adapter_feature_vector(
     # setup feature extractor
     feat_rgb = feat_flow = feat_audio = None
     if cfg.DATASET.IMAGE_MODALITY in ["rgb", "all"]:
-        feat_rgb = VideoVectorBoringModel(1024, 10)
+        feat_rgb = VideoVectorBoringModel(10, 10)
     if cfg.DATASET.IMAGE_MODALITY in ["flow", "all"]:
-        feat_flow = VideoVectorBoringModel(1024, 10)
+        feat_flow = VideoVectorBoringModel(10, 10)
     if cfg.DATASET.IMAGE_MODALITY in ["audio", "all"]:
-        feat_audio = VideoVectorBoringModel(1024, 10)
+        feat_audio = VideoVectorBoringModel(10, 10)
 
     domain_feature_dim = int(10 * cfg.DATASET.NUM_SEGMENTS)
     if cfg.DATASET.IMAGE_MODALITY in ["rgb", "flow", "audio"]:

--- a/tests/pipeline/test_video_domain_adapter.py
+++ b/tests/pipeline/test_video_domain_adapter.py
@@ -78,7 +78,7 @@ def test_video_domain_adapter(source_cfg, target_cfg, image_modality, da_method,
     cfg.DATASET.IMAGE_MODALITY = image_modality
     cfg.DATASET.INPUT_TYPE = "image"
     cfg.DATASET.CLASS_TYPE = "verb"
-    cfg.DATASET.NUM_SEGMENTS = 1  # = 1, if image input; = 8, if feature input.
+    cfg.DATASET.NUM_SEGMENTS = 1
     cfg.DATASET.WEIGHT_TYPE = WEIGHT_TYPE
     cfg.DATASET.SIZE_TYPE = DATASIZE_TYPE
     cfg.DAN.USERANDOM = False

--- a/tests/pipeline/test_video_domain_adapter.py
+++ b/tests/pipeline/test_video_domain_adapter.py
@@ -123,6 +123,7 @@ def test_video_domain_adapter(source_cfg, target_cfg, image_modality, da_method,
     train_params = testing_training_cfg["train_params"]
     method_params = {}
     method = domain_adapter.Method(da_method)
+    class_type = cfg.DATASET.CLASS_TYPE
 
     # setup DA method
     if method.is_mmd_method():
@@ -132,6 +133,7 @@ def test_video_domain_adapter(source_cfg, target_cfg, image_modality, da_method,
             image_modality=cfg.DATASET.IMAGE_MODALITY,
             feature_extractor=feature_network,
             task_classifier=classifier_network,
+            class_type=class_type,
             **method_params,
             **train_params,
         )
@@ -155,6 +157,7 @@ def test_video_domain_adapter(source_cfg, target_cfg, image_modality, da_method,
             feature_extractor=feature_network,
             task_classifier=classifier_network,
             critic=critic_network,
+            class_type=class_type,
             **method_params,
             **train_params,
         )

--- a/tests/predict/test_class_domain_nets.py
+++ b/tests/predict/test_class_domain_nets.py
@@ -18,7 +18,8 @@ BATCH_SIZE = 2
 # batch_size * num_channel * frame_per_segment * height * weight.
 INPUT_BATCH = torch.randn(BATCH_SIZE, 128)
 INPUT_BATCH_AVERAGE = torch.randn(BATCH_SIZE, 1024, 1, 1, 1)
-CLASSNET_MODEL = [ClassNetSmallImage, ClassNetVideo]
+CLASSNET_MODEL = [ClassNetSmallImage]
+MULTITASK_CLASSNET_MODEL = [ClassNetVideo]
 DOMAINNET_MODEL = [DomainNetSmallImage, DomainNetVideo]
 
 
@@ -35,6 +36,16 @@ def test_classnet_shapes(model):
     model.eval()
     output_batch = model(INPUT_BATCH)
     assert output_batch.size() == (BATCH_SIZE, 8)
+
+
+@pytest.mark.parametrize("model", MULTITASK_CLASSNET_MODEL)
+def test_multitask_classnet_shapes(model):
+    model = model(input_size=128, dict_n_class={"verb": 8, "noun": 6}, class_type="verb+noun")
+    model.eval()
+    output_batch = model(INPUT_BATCH)
+    assert len(output_batch) == 2
+    assert output_batch[0].size() == (BATCH_SIZE, 8)
+    assert output_batch[1].size() == (BATCH_SIZE, 6)
 
 
 def test_classnetvideoconv_shapes():

--- a/tests/utils/test.json
+++ b/tests/utils/test.json
@@ -1,1 +1,0 @@
-{"results_source": {"a": {"verb": {"0": 0.1, "1": 0.1, "2": 0.1}}, "b": {"verb": {"0": 0.2, "1": 0.2, "2": 0.2}}}, "results_target": {"c": {"verb": {"0": 0.3, "1": 0.3, "2": 0.3}}, "d": {"verb": {"0": 0.4, "1": 0.4, "2": 0.4}}}, "version": "0.2", "challenge": "domain_adaptation", "sls_pt": 2, "sls_tl": 3, "sls_td": 3}

--- a/tests/utils/test.json
+++ b/tests/utils/test.json
@@ -1,0 +1,1 @@
+{"results_source": {"a": {"verb": {"0": 0.1, "1": 0.1, "2": 0.1}}, "b": {"verb": {"0": 0.2, "1": 0.2, "2": 0.2}}}, "results_target": {"c": {"verb": {"0": 0.3, "1": 0.3, "2": 0.3}}, "d": {"verb": {"0": 0.4, "1": 0.4, "2": 0.4}}}, "version": "0.2", "challenge": "domain_adaptation", "sls_pt": 2, "sls_tl": 3, "sls_td": 3}

--- a/tests/utils/test_logger.py
+++ b/tests/utils/test_logger.py
@@ -55,3 +55,34 @@ def test_log_file_exists(log_file_name):
 
 def test_gitdiff_file_exists(gitdiff_file_name):
     assert os.path.isfile(gitdiff_file_name)
+
+
+def test_create_single_result_dict():
+    result_dict = logger.create_single_result_dict([[0.1, 0.1, 0.1], [0.2, 0.2, 0.2]], ("a", "b"))
+    assert isinstance(result_dict, dict)
+
+
+def test_create_multi_results_dict():
+    result_dict = logger.create_multi_results_dict(
+        [[0.1, 0.1, 0.1], [0.2, 0.2, 0.2]], [[0.3, 0.3, 0.3], [0.4, 0.4, 0.4]], ("a", "b")
+    )
+    assert isinstance(result_dict, dict)
+
+
+@pytest.mark.parametrize("noun", [True, False])
+def test_save_results_to_json(noun):
+    y_hat = [[0.1, 0.1, 0.1], [0.2, 0.2, 0.2]]
+    y_t_hat = [[0.3, 0.3, 0.3], [0.4, 0.4, 0.4]]
+    y_ids = ("a", "b")
+    y_t_ids = ("c", "d")
+    file_name = "test.json"
+    if noun:
+        y_hat_noun = [[0.1, 0.1, 0.1], [0.2, 0.2, 0.2]]
+        y_t_hat_noun = [[0.3, 0.3, 0.3], [0.4, 0.4, 0.4]]
+    else:
+        y_hat_noun = None
+        y_t_hat_noun = None
+    logger.save_results_to_json(
+        y_hat, y_t_hat, y_ids, y_t_ids, y_hat_noun, y_t_hat_noun, verb=True, noun=noun, file_name=file_name
+    )
+    assert os.path.isfile(file_name)

--- a/tests/utils/test_logger.py
+++ b/tests/utils/test_logger.py
@@ -75,7 +75,7 @@ def test_save_results_to_json(noun):
     y_t_hat = [[0.3, 0.3, 0.3], [0.4, 0.4, 0.4]]
     y_ids = ("a", "b")
     y_t_ids = ("c", "d")
-    file_name = "test.json"
+    file_name = "../test_data/test_logger.json"
     if noun:
         y_hat_noun = [[0.1, 0.1, 0.1], [0.2, 0.2, 0.2]]
         y_t_hat_noun = [[0.3, 0.3, 0.3], [0.4, 0.4, 0.4]]


### PR DESCRIPTION
### Description
This PR follows PR #291 and #292, upgrading DA Trainers for feature vector input. Trainers on video image input and video feature vector input have two main differences below:
1. Three modality choices in image input: RGB, Flow and joint (RGB+Flow), due to no Audio available now; Five in feature vector: RGB, Flow, Audio, joint and all (RGB+Flow+Audio).
2. One class type in image input: verb; Two in feature: verb, verb+noun.

The main changes are below:
1. Add Audio branch into the pipeline.
2. Update optimizer work with SGD and ADAM.
3. Add adaptive choice into source/target dataset sampling.
4. Add JSON logger for EPIC UDA challenge.
5. Reduce dummy network dimension in test_video_domain_adapter. 

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
