### PR TITLE
Do not raise issue on scheduled test failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,10 +56,3 @@ jobs:
         shell: bash -l {0}
       - name: Report coverage
         uses: codecov/codecov-action@v1
-      - name: Report failure via issue
-        uses: JasonEtco/create-an-issue@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          filename: .github/ISSUE_TEMPLATE/action-fail.md
-        if: ${{ always() && steps.run_tests.outcome == 'failure' && github.event_name == 'schedule'}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6]  # Keep only 3.6 first, 3.7, 3.8]
         exclude:
           - os: windows-latest
             python-version: "3.6"


### PR DESCRIPTION
### Description
Tests are failing more regularly than we'd like and creating lots of spurious issues. This PR stops an issue being raised when a scheduled test fails.

### Status
**Ready**

If you've been given access to pykale with role Triage or above, on the right (delete these after selection):

- Select **one most appropriate** label.
- **When** your pull request is **ready** for review, select a reviewer. Use the suggested one if unsure.

If you cannot see an option to select a reviewer/label, that means one maintainer will get notified upon your pull request and then select for you.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).

