### PR TITLE
Add pre-commit dependency for black and click

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,7 @@ repos:
     hooks:
     -   id: black
         language_version: python3
+        additional_dependencies: ['click==8.0.4']
 -   repo: https://github.com/pre-commit/mirrors-isort
     rev: v4.3.21
     hooks:


### PR DESCRIPTION


Fixes issue with Black and Click compatibility when running pre-commit. 

### Description
Fixes issue with Black and Click compatibility when running pre-commit. Adds a dependency version for Click in the pre-commit yaml file .

### Status
**Ready**



### Types of changes

- [x] Non-breaking change (fix or new feature that would not break existing functionality).

