### PR TITLE
Support for Flake8-print 5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.pth
 *.zip
 *.ckpt
+*.json
 
 # Distribution / packaging
 build/
@@ -23,8 +24,10 @@ examples/data/
 examples/*/data/
 examples/*/outputs/
 examples/*/lightning_logs/
+examples/*/tb_logs/
+examples/*/logs/
 examples/*/demo*/
-examples/action_dann_lightn/configs_xianyuan/
+examples/*/configs_experiment/
 
 # Logs
 log-*.txt

--- a/kale/utils/print.py
+++ b/kale/utils/print.py
@@ -3,17 +3,17 @@
 
 def tprint(*args):
     """Temporarily prints things on the screen so that it won't be flooded"""
-    print("\r", end="")  # noqa: T001
-    print(*args, end="")  # noqa: T001
+    print("\r", end="")  # noqa: T201
+    print(*args, end="")  # noqa: T201
 
 
-def pprint(*args):  # noqa: T004
+def pprint(*args):  # noqa: T204
     """Permanently prints things on the screen to have all info displayed"""
-    print("\r", end="")  # noqa: T001
-    print(*args)  # noqa: T001
+    print("\r", end="")  # noqa: T201
+    print(*args)  # noqa: T201
 
 
 def pprint_without_newline(*args):
     """Permanently prints things on the screen, separated by space rather than newline"""
-    print("\r", end="")  # noqa: T001
-    print(*args, end=" ")  # noqa: T001
+    print("\r", end="")  # noqa: T201
+    print(*args, end=" ")  # noqa: T201

--- a/tests/utils/test_print.py
+++ b/tests/utils/test_print.py
@@ -13,7 +13,7 @@ def test_tprint(capsys):
 
 
 def test_pprint(capsys):
-    pprint("hello")  # noqa: T003
+    pprint("hello")  # noqa: T203
     captured = capsys.readouterr()
     assert captured.out == "\rhello\n"
 


### PR DESCRIPTION
Fixes #323.

### Description
1. Update `noqa: T0*` to `noqa: T2*`.
2. Update .gitignore (add exclusion for logs/tb_logs/lightning_logs, .json file and private experiment configure folder)

### Status
**WIP**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
