### PR TITLE
Fix tensorly version and update flake8 github link

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,8 +19,8 @@ repos:
     -   id: check-yaml
         exclude: .conda/meta.yaml
     -   id: requirements-txt-fixer
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.3
+-   repo: https://github.com/pycqa/flake8.git
+    rev: 3.9.2
     hooks:
     -   id: flake8
         additional_dependencies: [flake8-print, "importlib-metadata<5.0.0"]

--- a/kale/embed/factorization.py
+++ b/kale/embed/factorization.py
@@ -16,8 +16,6 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.metrics.pairwise import pairwise_kernels
 from sklearn.preprocessing import KernelCenterer, LabelBinarizer
 from sklearn.utils.validation import check_is_fitted
-
-# import tensorly as tl
 from tensorly.base import fold, unfold
 from tensorly.tenalg import multi_mode_dot
 
@@ -89,7 +87,7 @@ class MPCA(BaseEstimator, TransformerMixin):
 
     Examples:
         >>> import numpy as np
-        >>> from kale.embed.mpca import MPCA
+        >>> from kale.embed.factorization import MPCA
         >>> x = np.random.random((40, 20, 25, 20))
         >>> x.shape
         (40, 20, 25, 20)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ install_requires = [
     "pytorch-lightning>=1.3.0,<=1.6.5",  # in pipeline API only
     "scikit-learn>=0.23.2",  # sure
     "scipy>=1.5.4",  # in factorization API only
-    "tensorly>=0.5.1",  # in factorization and model_weights API only
+    "tensorly>=0.5.1,<=0.7.0",  # in factorization and model_weights API only
     "torch>=1.11.0",  # sure
     "torchvision>=0.12.0",  # in download, sampler (NON-ideal), and vision API only
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,12 @@
 import os
 
 import pytest
+import tensorly as tl
 from scipy.io import loadmat
 
 from kale.utils.download import download_file_by_url
+
+tl.set_backend("pytorch")
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,9 @@
 import os
 
 import pytest
-import tensorly as tl
 from scipy.io import loadmat
 
 from kale.utils.download import download_file_by_url
-
-tl.set_backend("pytorch")
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
### Description
Update versions TensorLy to pass the tests, and update the GitHub link of flake8 (was GitLab).

Related issues in TensorLy:
https://github.com/tensorly/tensorly/issues/473#issuecomment-1383266339
https://github.com/tensorly/tensorly/issues/479#issue-1536788979

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
