### PR TITLE
Add pyg version in CI envs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
           pip install torch-sparse==0.6.13 -f https://pytorch-geometric.com/whl/torch-1.11.0+cpu.html
           pip install torch-cluster==1.6.0 -f https://pytorch-geometric.com/whl/torch-1.11.0+cpu.html
           pip install torch-spline-conv==1.2.1 -f https://pytorch-geometric.com/whl/torch-1.11.0+cpu.html
-          pip install torch-geometric
+          pip install torch-geometric==2.2.0
           pip install -e .[dev]
         shell: bash -l {0}
       - name: Run tests


### PR DESCRIPTION
Fixes test issue in Actions.

### Description
This PR will fix the dependency library issue for testing `test_gcn_encoder`-- causing "AttributeError: module 'torch' has no attribute 'sparse_csc'" in `torch_geometric/utils/sparse.py:68`.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
