### PR TITLE
Update IPython version from <9.0 to <8.13

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,7 +8,7 @@ https://data.pyg.org/whl/torch-1.9.0%2Bcpu/torch_scatter-2.0.7-cp37-cp37m-linux_
 https://data.pyg.org/whl/torch-1.9.0%2Bcpu/torch_sparse-0.6.10-cp37-cp37m-linux_x86_64.whl
 https://download.pytorch.org/whl/cpu/torch-1.9.1%2Bcpu-cp37-cp37m-linux_x86_64.whl
 
-ipython<8.13
+ipython<=8.12
 
 nbsphinx
 nbsphinx-link

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,7 +8,7 @@ https://data.pyg.org/whl/torch-1.9.0%2Bcpu/torch_scatter-2.0.7-cp37-cp37m-linux_
 https://data.pyg.org/whl/torch-1.9.0%2Bcpu/torch_sparse-0.6.10-cp37-cp37m-linux_x86_64.whl
 https://download.pytorch.org/whl/cpu/torch-1.9.1%2Bcpu-cp37-cp37m-linux_x86_64.whl
 
-ipython<9.0
+ipython<8.13
 
 nbsphinx
 nbsphinx-link

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,7 +8,7 @@ https://data.pyg.org/whl/torch-1.9.0%2Bcpu/torch_scatter-2.0.7-cp37-cp37m-linux_
 https://data.pyg.org/whl/torch-1.9.0%2Bcpu/torch_sparse-0.6.10-cp37-cp37m-linux_x86_64.whl
 https://download.pytorch.org/whl/cpu/torch-1.9.1%2Bcpu-cp37-cp37m-linux_x86_64.whl
 
-ipython<=8.12
+ipython<8.13
 
 nbsphinx
 nbsphinx-link

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,7 +8,7 @@ https://data.pyg.org/whl/torch-1.9.0%2Bcpu/torch_scatter-2.0.7-cp37-cp37m-linux_
 https://data.pyg.org/whl/torch-1.9.0%2Bcpu/torch_sparse-0.6.10-cp37-cp37m-linux_x86_64.whl
 https://download.pytorch.org/whl/cpu/torch-1.9.1%2Bcpu-cp37-cp37m-linux_x86_64.whl
 
-ipython<8.13
+ipython<=8.12.0
 
 nbsphinx
 nbsphinx-link

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ image_requires = [
 # Dependencies for all examples and tutorials
 example_requires = [
     "ipykernel",
-    "ipython<8.13",  # IPython 8.13+ support Python 3.9+ only and IPython 8.0-8.12 supports Python 3.8+.
+    "ipython<=8.12.0",  # IPython 8.13+ support Python 3.9+ only and IPython 8.0-8.12 supports Python 3.8+.
     "matplotlib<=3.5.2",
     "nilearn",
     "Pillow",

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ image_requires = [
 # Dependencies for all examples and tutorials
 example_requires = [
     "ipykernel",
-    "ipython",
+    "ipython<8.13",  # IPython 8.13+ support Python 3.9+ only and IPython 8.0-8.12 supports Python 3.8+.
     "matplotlib<=3.5.2",
     "nilearn",
     "Pillow",

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ image_requires = [
 # Dependencies for all examples and tutorials
 example_requires = [
     "ipykernel",
-    "ipython<=8.12",  # IPython 8.13+ support Python 3.9+ only and IPython 8.0-8.12 supports Python 3.8+.
+    "ipython<8.13",  # IPython 8.13+ support Python 3.9+ only and IPython 8.0-8.12 supports Python 3.8+.
     "matplotlib<=3.5.2",
     "nilearn",
     "Pillow",

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ image_requires = [
 # Dependencies for all examples and tutorials
 example_requires = [
     "ipykernel",
-    "ipython<8.13",  # IPython 8.13+ support Python 3.9+ only and IPython 8.0-8.12 supports Python 3.8+.
+    "ipython<=8.12",  # IPython 8.13+ support Python 3.9+ only and IPython 8.0-8.12 supports Python 3.8+.
     "matplotlib<=3.5.2",
     "nilearn",
     "Pillow",


### PR DESCRIPTION
Fixes #371.

### Description
Updates the version of [IPython](https://github.com/ipython/ipython) in the requirements and setup to support Python 3.8.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
