### PR TITLE
Update keyword param for pretrained ResNet

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,14 @@ jobs:
       - name: Install dependencies
         run: |
           pip install rdkit
-          conda install pytorch==1.13.0 torchvision==0.14.0 torchaudio==0.13.0 cpuonly -c pytorch
-          conda install pyg==2.2.0 -c pyg
+          pip install pyparsing==2.4.7
+          pip install torch==1.12.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+          pip install torchvision==0.13.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+          pip install torch-scatter==2.0.9 -f https://data.pyg.org/whl/torch-1.12.0+cpu.html
+          pip install torch-sparse==0.6.15 -f https://data.pyg.org/whl/torch-1.12.0+cpu.html
+          pip install torch-cluster==1.6.0 -f https://data.pyg.org/whl/torch-1.12.0+cpu.html
+          pip install torch-spline-conv==1.2.1 -f https://data.pyg.org/whl/torch-1.12.0+cpu.html
+          pip install torch-geometric==2.2.0
           pip install -e .[dev]
         shell: bash -l {0}
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,10 +38,10 @@ jobs:
           pip install pyparsing==2.4.7
           pip install torch==1.13.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
           pip install torchvision==0.14.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
-          pip install torch-scatter==2.0.9 -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
-          pip install torch-sparse==0.6.14 -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
+          pip install torch-scatter==2.1.1 -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
+          pip install torch-sparse==0.6.17 -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
           pip install torch-cluster==1.6.0 -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
-          pip install torch-spline-conv==1.2.1 -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
+          pip install torch-spline-conv==1.2.2 -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
           pip install torch-geometric==2.2.0
           pip install -e .[dev]
         shell: bash -l {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,15 +35,8 @@ jobs:
       - name: Install dependencies
         run: |
           pip install rdkit
-          pip install pyparsing==2.4.7
-          pip install torch==1.13.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
-          pip install torchvision==0.14.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
-          pip install pyg-lib==0.2.0 -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
-          pip install torch-scatter==2.1.1 -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
-          pip install torch-sparse==0.6.16 -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
-          pip install torch-cluster==1.6.1 -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
-          pip install torch-spline-conv==1.2.2 -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
-          pip install torch-geometric==2.2.0
+          conda install pytorch==1.13.0 torchvision==0.14.0 torchaudio==0.13.0 cpuonly -c pytorch
+          conda install pyg==2.2.0 -c pyg
           pip install -e .[dev]
         shell: bash -l {0}
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,10 +38,10 @@ jobs:
           pip install pyparsing==2.4.7
           pip install torch==1.13.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
           pip install torchvision==0.13.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
-          pip install torch-scatter==2.0.9 -f https://pytorch-geometric.com/whl/torch-1.11.0+cpu.html
-          pip install torch-sparse==0.6.17 -f https://pytorch-geometric.com/whl/torch-1.11.0+cpu.html
-          pip install torch-cluster==1.6.0 -f https://pytorch-geometric.com/whl/torch-1.11.0+cpu.html
-          pip install torch-spline-conv==1.2.1 -f https://pytorch-geometric.com/whl/torch-1.11.0+cpu.html
+          pip install torch-scatter==2.1.1 -f https://pytorch-geometric.com/whl/torch-1.13.0+cpu.html
+          pip install torch-sparse==0.6.17 -f https://pytorch-geometric.com/whl/torch-1.13.0+cpu.html
+          pip install torch-cluster==1.6.0 -f https://pytorch-geometric.com/whl/torch-1.13.0+cpu.html
+          pip install torch-spline-conv==1.2.1 -f https://pytorch-geometric.com/whl/torch-1.13.0+cpu.html
           pip install torch-geometric==2.2.0
           pip install -e .[dev]
         shell: bash -l {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,12 +36,12 @@ jobs:
         run: |
           pip install rdkit
           pip install pyparsing==2.4.7
-          pip install torch==1.13.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+          pip install torch==1.12.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
           pip install torchvision==0.13.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
-          pip install torch-scatter==2.1.0 -f https://pytorch-geometric.com/whl/torch-1.13.0+cpu.html
-          pip install torch-sparse==0.6.17 -f https://pytorch-geometric.com/whl/torch-1.13.0+cpu.html
-          pip install torch-cluster==1.6.0 -f https://pytorch-geometric.com/whl/torch-1.13.0+cpu.html
-          pip install torch-spline-conv==1.2.1 -f https://pytorch-geometric.com/whl/torch-1.13.0+cpu.html
+          pip install torch-scatter==2.1.0 -f https://pytorch-geometric.com/whl/torch-1.12.1+cpu.html
+          pip install torch-sparse==0.6.16 -f https://pytorch-geometric.com/whl/torch-1.12.1+cpu.html
+          pip install torch-cluster==1.6.0 -f https://pytorch-geometric.com/whl/torch-1.12.1+cpu.html
+          pip install torch-spline-conv==1.2.1 -f https://pytorch-geometric.com/whl/torch-1.12.1+cpu.html
           pip install torch-geometric==2.2.0
           pip install -e .[dev]
         shell: bash -l {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           pip install pyparsing==2.4.7
           pip install torch==1.12.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
           pip install torchvision==0.13.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
-          pip install torch-scatter==2.1.0 -f https://pytorch-geometric.com/whl/torch-1.12.1+cpu.html
+          pip install torch-scatter==2.0.9 -f https://pytorch-geometric.com/whl/torch-1.12.1+cpu.html
           pip install torch-sparse==0.6.16 -f https://pytorch-geometric.com/whl/torch-1.12.1+cpu.html
           pip install torch-cluster==1.6.0 -f https://pytorch-geometric.com/whl/torch-1.12.1+cpu.html
           pip install torch-spline-conv==1.2.1 -f https://pytorch-geometric.com/whl/torch-1.12.1+cpu.html

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
           pip install torch==1.12.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
           pip install torchvision==0.13.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
           pip install torch-scatter==2.0.9 -f https://pytorch-geometric.com/whl/torch-1.12.1+cpu.html
-          pip install torch-sparse==0.6.16 -f https://pytorch-geometric.com/whl/torch-1.12.1+cpu.html
+          pip install torch-sparse==0.6.14 -f https://pytorch-geometric.com/whl/torch-1.12.1+cpu.html
           pip install torch-cluster==1.6.0 -f https://pytorch-geometric.com/whl/torch-1.12.1+cpu.html
           pip install torch-spline-conv==1.2.1 -f https://pytorch-geometric.com/whl/torch-1.12.1+cpu.html
           pip install torch-geometric==2.2.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           pip install pyparsing==2.4.7
           pip install torch==1.13.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
           pip install torchvision==0.13.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
-          pip install torch-scatter==2.1.1 -f https://pytorch-geometric.com/whl/torch-1.13.0+cpu.html
+          pip install torch-scatter==2.1.0 -f https://pytorch-geometric.com/whl/torch-1.13.0+cpu.html
           pip install torch-sparse==0.6.17 -f https://pytorch-geometric.com/whl/torch-1.13.0+cpu.html
           pip install torch-cluster==1.6.0 -f https://pytorch-geometric.com/whl/torch-1.13.0+cpu.html
           pip install torch-spline-conv==1.2.1 -f https://pytorch-geometric.com/whl/torch-1.13.0+cpu.html

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,12 +36,12 @@ jobs:
         run: |
           pip install rdkit
           pip install pyparsing==2.4.7
-          pip install torch==1.12.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
-          pip install torchvision==0.13.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
-          pip install torch-scatter==2.0.9 -f https://pytorch-geometric.com/whl/torch-1.12.1+cpu.html
-          pip install torch-sparse==0.6.14 -f https://pytorch-geometric.com/whl/torch-1.12.1+cpu.html
-          pip install torch-cluster==1.6.0 -f https://pytorch-geometric.com/whl/torch-1.12.1+cpu.html
-          pip install torch-spline-conv==1.2.1 -f https://pytorch-geometric.com/whl/torch-1.12.1+cpu.html
+          pip install torch==1.13.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+          pip install torchvision==0.14.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+          pip install torch-scatter==2.0.9 -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
+          pip install torch-sparse==0.6.14 -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
+          pip install torch-cluster==1.6.0 -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
+          pip install torch-spline-conv==1.2.1 -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
           pip install torch-geometric==2.2.0
           pip install -e .[dev]
         shell: bash -l {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,12 +36,12 @@ jobs:
         run: |
           pip install rdkit
           pip install pyparsing==2.4.7
-          pip install torch==1.12.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
-          pip install torchvision==0.13.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
-          pip install torch-scatter==2.0.9 -f https://data.pyg.org/whl/torch-1.12.0+cpu.html
-          pip install torch-sparse==0.6.15 -f https://data.pyg.org/whl/torch-1.12.0+cpu.html
-          pip install torch-cluster==1.6.0 -f https://data.pyg.org/whl/torch-1.12.0+cpu.html
-          pip install torch-spline-conv==1.2.1 -f https://data.pyg.org/whl/torch-1.12.0+cpu.html
+          pip install torch==1.13.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+          pip install torchvision==0.14.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+          pip install torch-scatter==2.0.9 -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
+          pip install torch-sparse==0.6.15 -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
+          pip install torch-cluster==1.6.0 -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
+          pip install torch-spline-conv==1.2.1 -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
           pip install torch-geometric==2.2.0
           pip install -e .[dev]
         shell: bash -l {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,10 @@ jobs:
           pip install pyparsing==2.4.7
           pip install torch==1.13.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
           pip install torchvision==0.14.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+          pip install pyg-lib==0.2.0 -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
           pip install torch-scatter==2.1.1 -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
-          pip install torch-sparse==0.6.17 -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
-          pip install torch-cluster==1.6.0 -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
+          pip install torch-sparse==0.6.16 -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
+          pip install torch-cluster==1.6.1 -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
           pip install torch-spline-conv==1.2.2 -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
           pip install torch-geometric==2.2.0
           pip install -e .[dev]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,10 +36,10 @@ jobs:
         run: |
           pip install rdkit
           pip install pyparsing==2.4.7
-          pip install torch==1.11.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
-          pip install torchvision==0.12.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+          pip install torch==1.13.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+          pip install torchvision==0.13.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
           pip install torch-scatter==2.0.9 -f https://pytorch-geometric.com/whl/torch-1.11.0+cpu.html
-          pip install torch-sparse==0.6.13 -f https://pytorch-geometric.com/whl/torch-1.11.0+cpu.html
+          pip install torch-sparse==0.6.17 -f https://pytorch-geometric.com/whl/torch-1.11.0+cpu.html
           pip install torch-cluster==1.6.0 -f https://pytorch-geometric.com/whl/torch-1.11.0+cpu.html
           pip install torch-spline-conv==1.2.1 -f https://pytorch-geometric.com/whl/torch-1.11.0+cpu.html
           pip install torch-geometric==2.2.0

--- a/examples/office_multisource_adapt/model.py
+++ b/examples/office_multisource_adapt/model.py
@@ -68,7 +68,7 @@ def get_model(cfg, dataset, num_channels):
     if cfg.DATASET.NAME.upper() == "DIGITS":
         feature_network = SmallCNNFeature(num_channels)
     else:
-        feature_network = ResNet18Feature(num_channels)
+        feature_network = ResNet18Feature()
 
     if cfg.DAN.METHOD == "MFSAN":
         feature_network = torch.nn.Sequential(*(list(feature_network.children())[:-1]))

--- a/kale/embed/image_cnn.py
+++ b/kale/embed/image_cnn.py
@@ -156,7 +156,7 @@ class ResNet18Feature(nn.Module):
     Args:
         weights (bool): The pretrained weights to use. See
          https://pytorch.org/vision/stable/models/generated/torchvision.models.resnet18.html#torchvision.models.ResNet18_Weights
-        for more details. By default, ResNet50_Weights.DEFAULT will be used.
+        for more details. By default, ResNet18_Weights.DEFAULT will be used.
     Note:
         Code adapted by pytorch-ada from https://github.com/thuml/Xlearn/blob/master/pytorch/src/network.py
     """
@@ -199,7 +199,7 @@ class ResNet34Feature(nn.Module):
     Args:
         weights (bool): The pretrained weights to use. See
          https://pytorch.org/vision/stable/models/generated/torchvision.models.resnet34.html#torchvision.models.ResNet34_Weights
-        for more details. By default, ResNet50_Weights.DEFAULT will be used.
+        for more details. By default, ResNet34_Weights.DEFAULT will be used.
 
     Note:
         Code adapted by pytorch-ada from https://github.com/thuml/Xlearn/blob/master/pytorch/src/network.py
@@ -287,7 +287,7 @@ class ResNet101Feature(nn.Module):
     Args:
         weights (bool): The pretrained weights to use. See
          https://pytorch.org/vision/stable/models/generated/torchvision.models.resnet101.html#torchvision.models.ResNet101_Weights
-        for more details. By default, ResNet50_Weights.DEFAULT will be used.
+        for more details. By default, ResNet101_Weights.DEFAULT will be used.
 
     Note:
         Code adapted by pytorch-ada from https://github.com/thuml/Xlearn/blob/master/pytorch/src/network.py
@@ -331,7 +331,7 @@ class ResNet152Feature(nn.Module):
     Args:
         weights (bool): The pretrained weights to use. See
          https://pytorch.org/vision/stable/models/generated/torchvision.models.resnet152.html#torchvision.models.ResNet152_Weights
-        for more details. By default, ResNet50_Weights.DEFAULT will be used.
+        for more details. By default, ResNet152_Weights.DEFAULT will be used.
 
     Note:
         Code adapted by pytorch-ada from https://github.com/thuml/Xlearn/blob/master/pytorch/src/network.py

--- a/kale/embed/image_cnn.py
+++ b/kale/embed/image_cnn.py
@@ -154,15 +154,16 @@ class ResNet18Feature(nn.Module):
     Modified ResNet18 (without the last layer) feature extractor for regular 224x224 images.
 
     Args:
-        pretrained (bool): If True, returns a model pre-trained on ImageNet
-
+        weights (bool): The pretrained weights to use. See
+         https://pytorch.org/vision/stable/models/generated/torchvision.models.resnet18.html#torchvision.models.ResNet18_Weights
+        for more details. By default, ResNet50_Weights.DEFAULT will be used.
     Note:
         Code adapted by pytorch-ada from https://github.com/thuml/Xlearn/blob/master/pytorch/src/network.py
     """
 
-    def __init__(self, pretrained=True):
+    def __init__(self, weights=models.ResNet18_Weights.DEFAULT):
         super(ResNet18Feature, self).__init__()
-        model_resnet18 = models.resnet18(pretrained)
+        model_resnet18 = models.resnet18(weights=weights)
         self.conv1 = model_resnet18.conv1
         self.bn1 = model_resnet18.bn1
         self.relu = model_resnet18.relu
@@ -196,15 +197,17 @@ class ResNet34Feature(nn.Module):
     Modified ResNet34 (without the last layer) feature extractor for regular 224x224 images.
 
     Args:
-        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        weights (bool): The pretrained weights to use. See
+         https://pytorch.org/vision/stable/models/generated/torchvision.models.resnet34.html#torchvision.models.ResNet34_Weights
+        for more details. By default, ResNet50_Weights.DEFAULT will be used.
 
     Note:
         Code adapted by pytorch-ada from https://github.com/thuml/Xlearn/blob/master/pytorch/src/network.py
     """
 
-    def __init__(self, pretrained=True):
+    def __init__(self, weights=models.ResNet34_Weights.DEFAULT):
         super(ResNet34Feature, self).__init__()
-        model_resnet34 = models.resnet34(pretrained)
+        model_resnet34 = models.resnet34(weights=weights)
         self.conv1 = model_resnet34.conv1
         self.bn1 = model_resnet34.bn1
         self.relu = model_resnet34.relu
@@ -238,15 +241,17 @@ class ResNet50Feature(nn.Module):
     Modified ResNet50 (without the last layer) feature extractor for regular 224x224 images.
 
     Args:
-        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        weights (bool): The pretrained weights to use. See
+         https://pytorch.org/vision/stable/models/generated/torchvision.models.resnet50.html#torchvision.models.ResNet50_Weights
+        for more details. By default, ResNet50_Weights.DEFAULT will be used.
 
     Note:
         Code adapted by pytorch-ada from https://github.com/thuml/Xlearn/blob/master/pytorch/src/network.py
     """
 
-    def __init__(self, pretrained=True):
+    def __init__(self, weights=models.ResNet50_Weights.DEFAULT):
         super(ResNet50Feature, self).__init__()
-        model_resnet50 = models.resnet50(pretrained)
+        model_resnet50 = models.resnet50(weights=weights)
         self.conv1 = model_resnet50.conv1
         self.bn1 = model_resnet50.bn1
         self.relu = model_resnet50.relu
@@ -280,15 +285,17 @@ class ResNet101Feature(nn.Module):
     Modified ResNet101 (without the last layer) feature extractor for regular 224x224 images.
 
     Args:
-        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        weights (bool): The pretrained weights to use. See
+         https://pytorch.org/vision/stable/models/generated/torchvision.models.resnet101.html#torchvision.models.ResNet101_Weights
+        for more details. By default, ResNet50_Weights.DEFAULT will be used.
 
     Note:
         Code adapted by pytorch-ada from https://github.com/thuml/Xlearn/blob/master/pytorch/src/network.py
     """
 
-    def __init__(self, pretrained=True):
+    def __init__(self, weights=models.ResNet101_Weights.DEFAULT):
         super(ResNet101Feature, self).__init__()
-        model_resnet101 = models.resnet101(pretrained)
+        model_resnet101 = models.resnet101(weights=weights)
         self.conv1 = model_resnet101.conv1
         self.bn1 = model_resnet101.bn1
         self.relu = model_resnet101.relu
@@ -322,15 +329,17 @@ class ResNet152Feature(nn.Module):
     Modified ResNet152 (without the last layer) feature extractor for regular 224x224 images.
 
     Args:
-        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        weights (bool): The pretrained weights to use. See
+         https://pytorch.org/vision/stable/models/generated/torchvision.models.resnet152.html#torchvision.models.ResNet152_Weights
+        for more details. By default, ResNet50_Weights.DEFAULT will be used.
 
     Note:
         Code adapted by pytorch-ada from https://github.com/thuml/Xlearn/blob/master/pytorch/src/network.py
     """
 
-    def __init__(self, pretrained=True):
+    def __init__(self, weights=models.ResNet152_Weights.DEFAULT):
         super(ResNet152Feature, self).__init__()
-        model_resnet152 = models.resnet152(pretrained)
+        model_resnet152 = models.resnet152(weights=weights)
         self.conv1 = model_resnet152.conv1
         self.bn1 = model_resnet152.bn1
         self.relu = model_resnet152.relu

--- a/kale/embed/image_cnn.py
+++ b/kale/embed/image_cnn.py
@@ -154,7 +154,7 @@ class ResNet18Feature(nn.Module):
     Modified ResNet18 (without the last layer) feature extractor for regular 224x224 images.
 
     Args:
-        weights (bool): The pretrained weights to use. See
+        weights (models.ResNet18_Weights or string): The pretrained weights to use. See
          https://pytorch.org/vision/stable/models/generated/torchvision.models.resnet18.html#torchvision.models.ResNet18_Weights
         for more details. By default, ResNet18_Weights.DEFAULT will be used.
     Note:
@@ -197,7 +197,7 @@ class ResNet34Feature(nn.Module):
     Modified ResNet34 (without the last layer) feature extractor for regular 224x224 images.
 
     Args:
-        weights (bool): The pretrained weights to use. See
+        weights (models.ResNet34_Weights or string): The pretrained weights to use. See
          https://pytorch.org/vision/stable/models/generated/torchvision.models.resnet34.html#torchvision.models.ResNet34_Weights
         for more details. By default, ResNet34_Weights.DEFAULT will be used.
 
@@ -241,7 +241,7 @@ class ResNet50Feature(nn.Module):
     Modified ResNet50 (without the last layer) feature extractor for regular 224x224 images.
 
     Args:
-        weights (bool): The pretrained weights to use. See
+        weights (models.ResNet50_Weights or string): The pretrained weights to use. See
          https://pytorch.org/vision/stable/models/generated/torchvision.models.resnet50.html#torchvision.models.ResNet50_Weights
         for more details. By default, ResNet50_Weights.DEFAULT will be used.
 
@@ -285,7 +285,7 @@ class ResNet101Feature(nn.Module):
     Modified ResNet101 (without the last layer) feature extractor for regular 224x224 images.
 
     Args:
-        weights (bool): The pretrained weights to use. See
+        weights (models.ResNet101_Weights or string): The pretrained weights to use. See
          https://pytorch.org/vision/stable/models/generated/torchvision.models.resnet101.html#torchvision.models.ResNet101_Weights
         for more details. By default, ResNet101_Weights.DEFAULT will be used.
 
@@ -329,7 +329,7 @@ class ResNet152Feature(nn.Module):
     Modified ResNet152 (without the last layer) feature extractor for regular 224x224 images.
 
     Args:
-        weights (bool): The pretrained weights to use. See
+        weights (models.ResNet152_Weights or string): The pretrained weights to use. See
          https://pytorch.org/vision/stable/models/generated/torchvision.models.resnet152.html#torchvision.models.ResNet152_Weights
         for more details. By default, ResNet152_Weights.DEFAULT will be used.
 

--- a/tests/embed/test_image_cnn.py
+++ b/tests/embed/test_image_cnn.py
@@ -43,7 +43,7 @@ def test_simplecnnbuilder_shapes():
 @pytest.mark.parametrize("param", PARAM)
 def test_shapes(param):
     model, out_size = param
-    model = model(pretrained=False)
+    model = model(weights="Default")
     model.eval()
     output_batch = model(INPUT_BATCH)
     assert output_batch.size() == (BATCH_SIZE, out_size)

--- a/tests/embed/test_image_cnn.py
+++ b/tests/embed/test_image_cnn.py
@@ -43,7 +43,7 @@ def test_simplecnnbuilder_shapes():
 @pytest.mark.parametrize("param", PARAM)
 def test_shapes(param):
     model, out_size = param
-    model = model(weights="Default")
+    model = model(weights="DEFAULT")
     model.eval()
     output_batch = model(INPUT_BATCH)
     assert output_batch.size() == (BATCH_SIZE, out_size)


### PR DESCRIPTION
### Description
The keyword parameter `pretrained=True/Flase` has been deprecated from torchvision>=0.13. Update to keep PyKale compatible with the newer version of torchvision.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
