### PR TITLE
Refactor documentation and resolve module visibility issues in PyKale

### DIFF
--- a/docs/source/kale.embed.rst
+++ b/docs/source/kale.embed.rst
@@ -15,7 +15,7 @@ kale.embed.attention\_cnn module
    :show-inheritance:
 
 kale.embed.factorization module
-----------------------
+-------------------------------
 
 .. automodule:: kale.embed.factorization
    :members:
@@ -23,7 +23,7 @@ kale.embed.factorization module
    :show-inheritance:
 
 kale.embed.gcn module
-----------------------------
+---------------------
 
 .. automodule:: kale.embed.gcn
    :members:
@@ -32,7 +32,7 @@ kale.embed.gcn module
    :exclude-members: message, update
 
 kale.embed.gripnet module
-----------------------------
+-------------------------
 
 .. automodule:: kale.embed.gripnet
    :members:
@@ -58,7 +58,7 @@ kale.embed.positional\_encoding module
    :show-inheritance:
 
 kale.embed.seq\_nn module
---------------------------------
+-------------------------
 
 .. automodule:: kale.embed.seq_nn
    :members:

--- a/docs/source/kale.embed.rst
+++ b/docs/source/kale.embed.rst
@@ -90,14 +90,6 @@ kale.embed.video\_res3d module
    :undoc-members:
    :show-inheritance:
 
-kale.embed.video\_selayer module
---------------------------------
-
-.. automodule:: kale.embed.video_selayer
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 kale.embed.video\_se\_i3d module
 --------------------------------
 
@@ -110,6 +102,14 @@ kale.embed.video\_se\_res3d module
 ----------------------------------
 
 .. automodule:: kale.embed.video_se_res3d
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+kale.embed.video\_selayer module
+--------------------------------
+
+.. automodule:: kale.embed.video_selayer
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/kale.evaluate.rst
+++ b/docs/source/kale.evaluate.rst
@@ -7,7 +7,7 @@ Submodules
 ----------
 
 kale.evaluate.metrics module
---------------------------------------
+----------------------------
 
 .. automodule:: kale.evaluate.metrics
    :members:

--- a/docs/source/kale.interpret.rst
+++ b/docs/source/kale.interpret.rst
@@ -7,7 +7,7 @@ Submodules
 ----------
 
 kale.interpret.model\_weights module
-----------------------------------------
+------------------------------------
 
 .. automodule:: kale.interpret.model_weights
    :members:
@@ -15,7 +15,7 @@ kale.interpret.model\_weights module
    :show-inheritance:
 
 kale.interpret.visualize module
-----------------------------------------
+-------------------------------
 
 .. automodule:: kale.interpret.visualize
    :members:

--- a/docs/source/kale.loaddata.rst
+++ b/docs/source/kale.loaddata.rst
@@ -14,16 +14,8 @@ kale.loaddata.dataset\_access module
    :undoc-members:
    :show-inheritance:
 
-kale.loaddata.videos module
----------------------------
-
-.. automodule:: kale.loaddata.videos
-   :members:
-   :exclude-members: VideoRecord
-   :show-inheritance:
-
 kale.loaddata.image\_access
-------------------------------------------
+---------------------------
 
 .. automodule:: kale.loaddata.image_access
    :members:
@@ -31,7 +23,7 @@ kale.loaddata.image\_access
    :show-inheritance:
 
 kale.loaddata.mnistm module
------------------------------------
+---------------------------
 
 .. automodule:: kale.loaddata.mnistm
    :members:
@@ -39,25 +31,25 @@ kale.loaddata.mnistm module
    :show-inheritance:
 
 kale.loaddata.multi\_domain module
------------------------------------
+----------------------------------
 
 .. automodule:: kale.loaddata.multi_domain
    :members:
    :undoc-members:
    :show-inheritance:
 
-kale.loaddata.sampler module
------------------------------------
+kale.loaddata.polypharmacy\_datasets module
+-------------------------------------------
 
-.. automodule:: kale.loaddata.sampler
+.. automodule:: kale.loaddata.polypharmacy_datasets
    :members:
    :undoc-members:
    :show-inheritance:
 
-kale.loaddata.usps module
------------------------------------
+kale.loaddata.sampler module
+----------------------------
 
-.. automodule:: kale.loaddata.usps
+.. automodule:: kale.loaddata.sampler
    :members:
    :undoc-members:
    :show-inheritance:
@@ -66,6 +58,14 @@ kale.loaddata.tdc\_datasets module
 ----------------------------------
 
 .. automodule:: kale.loaddata.tdc_datasets
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+kale.loaddata.usps module
+-------------------------
+
+.. automodule:: kale.loaddata.usps
    :members:
    :undoc-members:
    :show-inheritance:
@@ -87,11 +87,19 @@ kale.loaddata.video\_datasets module
    :show-inheritance:
 
 kale.loaddata.video\_multi\_domain module
-------------------------------------------
+-----------------------------------------
 
 .. automodule:: kale.loaddata.video_multi_domain
    :members:
    :undoc-members:
+   :show-inheritance:
+
+kale.loaddata.videos module
+---------------------------
+
+.. automodule:: kale.loaddata.videos
+   :members:
+   :exclude-members: VideoRecord
    :show-inheritance:
 
 Module contents

--- a/docs/source/kale.pipeline.rst
+++ b/docs/source/kale.pipeline.rst
@@ -7,7 +7,7 @@ Submodules
 ----------
 
 kale.pipeline.base\_nn\_trainer module
-----------------------
+--------------------------------------
 
 .. automodule:: kale.pipeline.base_nn_trainer
    :members:
@@ -15,7 +15,7 @@ kale.pipeline.base\_nn\_trainer module
    :show-inheritance:
 
 kale.pipeline.deepdta module
-------------------------------------
+----------------------------
 
 .. automodule:: kale.pipeline.deepdta
    :members:
@@ -31,7 +31,7 @@ kale.pipeline.domain\_adapter module
    :show-inheritance:
 
 kale.pipeline.mpca\_trainer module
-------------------------------------
+----------------------------------
 
 .. automodule:: kale.pipeline.mpca_trainer
    :members:
@@ -39,7 +39,7 @@ kale.pipeline.mpca\_trainer module
    :show-inheritance:
 
 kale.pipeline.multi\_domain\_adapter module
-------------------------------------
+-------------------------------------------
 
 .. automodule:: kale.pipeline.multi_domain_adapter
    :members:
@@ -47,7 +47,7 @@ kale.pipeline.multi\_domain\_adapter module
    :show-inheritance:
 
 kale.pipeline.video\_domain\_adapter module
---------------------------------------------
+-------------------------------------------
 
 .. automodule:: kale.pipeline.video_domain_adapter
    :members:

--- a/docs/source/kale.predict.rst
+++ b/docs/source/kale.predict.rst
@@ -14,6 +14,14 @@ kale.predict.class\_domain\_nets module
    :undoc-members:
    :show-inheritance:
 
+kale.predict.decode module
+--------------------------
+
+.. automodule:: kale.predict.decode
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 kale.predict.isonet module
 --------------------------
 
@@ -26,14 +34,6 @@ kale.predict.losses module
 --------------------------
 
 .. automodule:: kale.predict.losses
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-kale.predict.decode module
---------------------------
-
-.. automodule:: kale.predict.decode
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/kale.prepdata.rst
+++ b/docs/source/kale.prepdata.rst
@@ -14,6 +14,14 @@ kale.prepdata.chem\_transform module
    :undoc-members:
    :show-inheritance:
 
+kale.prepdata.graph\_negative\_sampling module
+----------------------------------------------
+
+.. automodule:: kale.prepdata.graph_negative_sampling
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 kale.prepdata.image\_transform module
 -------------------------------------
 
@@ -23,7 +31,7 @@ kale.prepdata.image\_transform module
    :show-inheritance:
 
 kale.prepdata.supergraph\_construct module
--------------------------------------
+------------------------------------------
 
 .. automodule:: kale.prepdata.supergraph_construct
    :members:


### PR DESCRIPTION
### Description
The PyKale documentation currently lacks documentation for a few modules, and there are issues where the body of certain modules is not visible (as shown in the provided image). To address these concerns, it is necessary to update the PyKale documentation by adding the missing modules, fixing errors that prevent modules from being displayed, and reordering the modules to ensure an alphabetically-sorted arrangement. This update will improve the PyKale documentation.

![image](https://github.com/pykale/pykale/assets/17015016/b2790579-dc0f-4b0f-a910-d3afd8067a66)

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [x] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
