### PR TITLE
Upgrade changlog-ci to v1.1.2

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run changelog
-        uses: saadmk11/changelog-ci@v1.1.1
+        uses: saadmk11/changelog-ci@v1.1.2
         with:
           changelog_filename: .github/CHANGELOG.md
           config_file: .github/changelog-ci-config.json


### PR DESCRIPTION
Fixes #404.

### Description
Upgrade `saadmk11/changelog-ci` from v1.1.1 to v1.1.2. 

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
