### PR TITLE
Change testing data directory paths

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,15 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
+
+      - name: Cache .testmondata
+        uses: actions/cache@v2
+        with:
+          path: .testmondata
+          key: ${{ runner.os }}-testmon-${{ hashFiles('**/*.py') }}
+          restore-keys: |
+            ${{ runner.os }}-testmon-
+
       - name: Install dependencies
         run: |
           pip install rdkit
@@ -48,7 +57,7 @@ jobs:
       - name: Run tests
         id: run_tests
         run: |
-          pytest --nbmake --nbmake-timeout=3000 --cov=kale
+          pytest --testmon --nbmake --nbmake-timeout=3000 --cov=kale
         shell: bash -l {0}
       - name: Determine coverage
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,12 @@ jobs:
             python-version: "3.8"
           - os: windows-latest
             python-version: "3.9"
+        include:
+          - os: ubuntu-latest
+            path: ~/.cache/pip
+          - os: windows-latest
+            path: ~\AppData\Local\pip\Cache
+
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python using Miniconda
@@ -32,6 +38,14 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ matrix.path }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
 
       - name: Cache .testmondata
         uses: actions/cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache pip dependencies
+        id: cache-pip
         uses: actions/cache@v2
         with:
           path: ${{ matrix.path }}
@@ -47,11 +48,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-python${{ matrix.python-version }}-pip-
 
-#          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-#          restore-keys: |
-#            ${{ runner.os }}-pip-
-
       - name: Cache .testmondata
+        id: cache-testmon
         uses: actions/cache@v2
         with:
           path: .testmondata
@@ -59,11 +57,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-python${{ matrix.python-version }}-testmon-
 
-#          key: ${{ runner.os }}-testmon-${{ hashFiles('**/*.py') }}
-#          restore-keys: |
-#            ${{ runner.os }}-testmon-
-
       - name: Install dependencies
+        if: steps.cache-pip.outputs.cache-hit != 'true'
         run: |
           pip install rdkit
           pip install pyparsing==3.0.9
@@ -76,14 +71,17 @@ jobs:
           pip install torch_geometric==2.3.0
           pip install -e .[dev]
         shell: bash -l {0}
+
       - name: Run tests
         id: run_tests
         run: |
           pytest --testmon --nbmake --nbmake-timeout=3000 --cov=kale
         shell: bash -l {0}
+
       - name: Determine coverage
         run: |
           coverage xml
         shell: bash -l {0}
+
       - name: Report coverage
         uses: codecov/codecov-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,6 @@ jobs:
             ${{ runner.os }}-python${{ matrix.python-version }}-testmon-
 
       - name: Install dependencies
-        if: steps.cache-pip.outputs.cache-hit != 'true'
         run: |
           pip install rdkit
           pip install pyparsing==3.0.9

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,17 +43,25 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ matrix.path }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          key: ${{ runner.os }}-python${{ matrix.python-version }}-pip-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            ${{ runner.os }}-python${{ matrix.python-version }}-pip-
+
+#          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+#          restore-keys: |
+#            ${{ runner.os }}-pip-
 
       - name: Cache .testmondata
         uses: actions/cache@v2
         with:
           path: .testmondata
-          key: ${{ runner.os }}-testmon-${{ hashFiles('**/*.py') }}
+          key: ${{ runner.os }}-python${{ matrix.python-version }}-testmon-${{ hashFiles('**/*.py') }}
           restore-keys: |
-            ${{ runner.os }}-testmon-
+            ${{ runner.os }}-python${{ matrix.python-version }}-testmon-
+
+#          key: ${{ runner.os }}-testmon-${{ hashFiles('**/*.py') }}
+#          restore-keys: |
+#            ${{ runner.os }}-testmon-
 
       - name: Install dependencies
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,8 @@ tests/pipeline/tests
 
 # Lightning
 lightning_logs
-tb_logs/*
+tb_logs
+outputs
 
 # Jupyter Notebook Checkpoints
 *-checkpoint.ipynb

--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,10 @@ docs/build/
 docs/source/backup
 
 # Testing
+.testmondata
 .coverage
 cov*.xml
+collect_env.py
 tests/test_data
 tests/loaddata/tests
 tests/pipeline/tests

--- a/kale/embed/feature_fusion.py
+++ b/kale/embed/feature_fusion.py
@@ -174,6 +174,9 @@ class LowRankTensorFusion(nn.Module):
             ones = Variable(torch.ones(batch_size, 1).type(modality.dtype), requires_grad=False).to(
                 torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
             )
+            modality = modality.to(torch.device("cuda:0" if torch.cuda.is_available() else "cpu"))
+            factor = factor.to(torch.device("cuda:0" if torch.cuda.is_available() else "cpu"))
+
             if self.flatten:
                 modality_withones = torch.cat((ones, torch.flatten(modality, start_dim=1)), dim=1)
             else:

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ dev_requires = full_requires + [
     "pre-commit",
     "pytest",
     "pytest-cov",
+    "pytest-testmon",
     "recommonmark",
     "sphinx",
     "sphinx-rtd-theme",

--- a/tests/helpers/pipe_test_helper.py
+++ b/tests/helpers/pipe_test_helper.py
@@ -9,6 +9,7 @@ class ModelTestHelper:
         assert isinstance(model, domain_adapter.BaseAdaptTrainer)
         # training process
         trainer = pl.Trainer(
+            default_root_dir="tests/outputs",
             min_epochs=train_params["nb_init_epochs"], max_epochs=train_params["nb_adapt_epochs"], devices=1, **kwargs
         )
         trainer.fit(model)

--- a/tests/helpers/pipe_test_helper.py
+++ b/tests/helpers/pipe_test_helper.py
@@ -10,7 +10,10 @@ class ModelTestHelper:
         # training process
         trainer = pl.Trainer(
             default_root_dir="tests/outputs",
-            min_epochs=train_params["nb_init_epochs"], max_epochs=train_params["nb_adapt_epochs"], devices=1, **kwargs
+            min_epochs=train_params["nb_init_epochs"],
+            max_epochs=train_params["nb_adapt_epochs"],
+            devices=1,
+            **kwargs,
         )
         trainer.fit(model)
         trainer.test()

--- a/tests/loaddata/test_video_access.py
+++ b/tests/loaddata/test_video_access.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import pytest
@@ -34,7 +33,7 @@ seed = 36
 set_seed(seed)
 CLASS_SUBSETS = [[1, 3, 8]]
 
-root_dir = os.path.dirname(os.path.dirname(os.getcwd()))
+
 url = "https://github.com/pykale/data/raw/main/videos/video_test_data.zip"
 
 
@@ -42,7 +41,8 @@ url = "https://github.com/pykale/data/raw/main/videos/video_test_data.zip"
 def testing_cfg(download_path):
     cfg = CfgNode()
     cfg.DATASET = CfgNode()
-    cfg.DATASET.ROOT = root_dir + "/" + download_path + "/video_test_data/"
+
+    cfg.DATASET.ROOT = download_path + "/video_test_data/"
     cfg.DATASET.IMAGE_MODALITY = "joint"
     cfg.DATASET.FRAMES_PER_SEGMENT = 16
     yield cfg

--- a/tests/pipeline/test_deepdta.py
+++ b/tests/pipeline/test_deepdta.py
@@ -28,7 +28,7 @@ def test_deep_data(download_path):
     # test deep_dta trainer
     save_parameters = {"seed": 2020, "batch_size": 256}
     model = DeepDTATrainer(drug_encoder, target_encoder, decoder, lr=0.001, ci_metric=True, **save_parameters).eval()
-    trainer = pl.Trainer(accelerator="cpu", max_epochs=1, devices=1)
+    trainer = pl.Trainer(default_root_dir="./tests/outputs", accelerator="cpu", max_epochs=1, devices=1)
     trainer.fit(model, train_dataloaders=train_dataloader, val_dataloaders=valid_dataloader)
     trainer.test(dataloaders=test_dataloader)
     assert isinstance(model.drug_encoder, CNNEncoder)

--- a/tests/pipeline/test_multiomics_trainer.py
+++ b/tests/pipeline/test_multiomics_trainer.py
@@ -143,7 +143,7 @@ def test_forward2(test_model, num_classes, url, multimodal):
 @pytest.mark.parametrize("num_classes, url", [(2, binary_class_data_url), (5, multi_class_data_url)])
 def test_pipeline(test_model, num_classes, url):
     set_seed(2023)
-    trainer_pretrain = pl.Trainer(max_epochs=2, accelerator="cpu", enable_model_summary=False,)
+    trainer_pretrain = pl.Trainer(default_root_dir="./tests/outputs",            max_epochs=2, accelerator="cpu", enable_model_summary=False,)
 
     trainer_pretrain.fit(test_model)
     result = trainer_pretrain.test(test_model)

--- a/tests/pipeline/test_multiomics_trainer.py
+++ b/tests/pipeline/test_multiomics_trainer.py
@@ -143,7 +143,9 @@ def test_forward2(test_model, num_classes, url, multimodal):
 @pytest.mark.parametrize("num_classes, url", [(2, binary_class_data_url), (5, multi_class_data_url)])
 def test_pipeline(test_model, num_classes, url):
     set_seed(2023)
-    trainer_pretrain = pl.Trainer(default_root_dir="./tests/outputs",            max_epochs=2, accelerator="cpu", enable_model_summary=False,)
+    trainer_pretrain = pl.Trainer(
+        default_root_dir="./tests/outputs", max_epochs=2, accelerator="cpu", enable_model_summary=False,
+    )
 
     trainer_pretrain.fit(test_model)
     result = trainer_pretrain.test(test_model)

--- a/tests/pipeline/test_video_domain_adapter.py
+++ b/tests/pipeline/test_video_domain_adapter.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import pytest
@@ -28,7 +27,6 @@ VALID_RATIO = 0.1
 seed = 36
 set_seed(seed)
 
-root_dir = os.path.dirname(os.path.dirname(os.getcwd()))
 url = "https://github.com/pykale/data/raw/main/videos/video_test_data.zip"
 
 
@@ -37,7 +35,7 @@ def testing_cfg(download_path):
     cfg = CfgNode()
     cfg.DATASET = CfgNode()
     cfg.DAN = CfgNode()
-    cfg.DATASET.ROOT = root_dir + "/" + download_path + "/video_test_data/"
+    cfg.DATASET.ROOT = download_path + "/video_test_data/"
     cfg.DATASET.FRAMES_PER_SEGMENT = 16
     yield cfg
 

--- a/tests/utils/test_download.py
+++ b/tests/utils/test_download.py
@@ -5,7 +5,6 @@ import pytest
 
 from kale.utils.download import download_file_by_url, download_file_gdrive
 
-# output_directory = Path().absolute().parent.joinpath("test_data/download")
 output_directory = Path().absolute().joinpath("tests/test_data/download")
 PARAM = [
     "https://github.com/pykale/data/raw/main/videos/video_test_data/ADL/annotations/labels_train_test/adl_P_11_train.pkl;a.pkl;pkl",

--- a/tests/utils/test_download.py
+++ b/tests/utils/test_download.py
@@ -5,7 +5,8 @@ import pytest
 
 from kale.utils.download import download_file_by_url, download_file_gdrive
 
-output_directory = Path().absolute().parent.joinpath("test_data/download")
+# output_directory = Path().absolute().parent.joinpath("test_data/download")
+output_directory = Path().absolute().joinpath("tests/test_data/download")
 PARAM = [
     "https://github.com/pykale/data/raw/main/videos/video_test_data/ADL/annotations/labels_train_test/adl_P_11_train.pkl;a.pkl;pkl",
     "https://github.com/pykale/data/raw/main/videos/video_test_data.zip;video_test_data.zip;zip",

--- a/tests/utils/test_logger.py
+++ b/tests/utils/test_logger.py
@@ -30,7 +30,7 @@ def testing_logger():
 def test_construct_logger_terminal(caplog):
     """Test that logger outputs to terminal when log_to_terminal is True."""
     logger_name = "test_logger"
-    save_dir = "./outputs"
+    save_dir = "./tests/outputs"
     os.makedirs(save_dir, exist_ok=True)
 
     t_logger = logger.construct_logger(logger_name, save_dir, log_to_terminal=True)


### PR DESCRIPTION
Fixes #412.

### Description
Some testing data were not downloaded into `pykale/tests` while running `pytest`. 
  
`tests/loaddata/test_video_access.py`, `tests/pipeline/test_video_domain_adapter.py` and `tests/utils/test_download.py` directory paths have been changed to `pykale/tests/test_data`.  
  
Logs and trainer outputs from `tests/helpers/pipe_test_helper.py`, `tests/pipeline/test_deepdta.py`, `tests/pipeline/test_multiomics_trainer.py` and `tests/utils/test_logger.py` have been changed to `pykale/tests/outputs`.

### Status
**Ready**



### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
