### PR TITLE
Change testing data directory paths 

### DIFF
--- a/kale/embed/feature_fusion.py
+++ b/kale/embed/feature_fusion.py
@@ -174,6 +174,9 @@ class LowRankTensorFusion(nn.Module):
             ones = Variable(torch.ones(batch_size, 1).type(modality.dtype), requires_grad=False).to(
                 torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
             )
+            modality = modality.to(torch.device("cuda:0" if torch.cuda.is_available() else "cpu"))
+            factor = factor.to(torch.device("cuda:0" if torch.cuda.is_available() else "cpu"))
+
             if self.flatten:
                 modality_withones = torch.cat((ones, torch.flatten(modality, start_dim=1)), dim=1)
             else:

--- a/tests/helpers/pipe_test_helper.py
+++ b/tests/helpers/pipe_test_helper.py
@@ -9,7 +9,11 @@ class ModelTestHelper:
         assert isinstance(model, domain_adapter.BaseAdaptTrainer)
         # training process
         trainer = pl.Trainer(
-            min_epochs=train_params["nb_init_epochs"], max_epochs=train_params["nb_adapt_epochs"], devices=1, **kwargs
+            default_root_dir="tests/outputs",
+            min_epochs=train_params["nb_init_epochs"],
+            max_epochs=train_params["nb_adapt_epochs"],
+            devices=1,
+            **kwargs,
         )
         trainer.fit(model)
         trainer.test()

--- a/tests/loaddata/test_video_access.py
+++ b/tests/loaddata/test_video_access.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import pytest
@@ -34,7 +33,6 @@ seed = 36
 set_seed(seed)
 CLASS_SUBSETS = [[1, 3, 8]]
 
-root_dir = os.path.dirname(os.path.dirname(os.getcwd()))
 url = "https://github.com/pykale/data/raw/main/videos/video_test_data.zip"
 
 
@@ -42,7 +40,8 @@ url = "https://github.com/pykale/data/raw/main/videos/video_test_data.zip"
 def testing_cfg(download_path):
     cfg = CfgNode()
     cfg.DATASET = CfgNode()
-    cfg.DATASET.ROOT = root_dir + "/" + download_path + "/video_test_data/"
+
+    cfg.DATASET.ROOT = download_path + "/video_test_data/"
     cfg.DATASET.IMAGE_MODALITY = "joint"
     cfg.DATASET.FRAMES_PER_SEGMENT = 16
     yield cfg

--- a/tests/pipeline/test_deepdta.py
+++ b/tests/pipeline/test_deepdta.py
@@ -28,7 +28,7 @@ def test_deep_data(download_path):
     # test deep_dta trainer
     save_parameters = {"seed": 2020, "batch_size": 256}
     model = DeepDTATrainer(drug_encoder, target_encoder, decoder, lr=0.001, ci_metric=True, **save_parameters).eval()
-    trainer = pl.Trainer(accelerator="cpu", max_epochs=1, devices=1)
+    trainer = pl.Trainer(default_root_dir="./tests/outputs", accelerator="cpu", max_epochs=1, devices=1)
     trainer.fit(model, train_dataloaders=train_dataloader, val_dataloaders=valid_dataloader)
     trainer.test(dataloaders=test_dataloader)
     assert isinstance(model.drug_encoder, CNNEncoder)

--- a/tests/pipeline/test_multiomics_trainer.py
+++ b/tests/pipeline/test_multiomics_trainer.py
@@ -143,8 +143,9 @@ def test_forward2(test_model, num_classes, url, multimodal):
 @pytest.mark.parametrize("num_classes, url", [(2, binary_class_data_url), (5, multi_class_data_url)])
 def test_pipeline(test_model, num_classes, url):
     set_seed(2023)
-    trainer_pretrain = pl.Trainer(max_epochs=2, accelerator="cpu", enable_model_summary=False,)
-
+    trainer_pretrain = pl.Trainer(
+        default_root_dir="./tests/outputs", max_epochs=2, accelerator="cpu", enable_model_summary=False,
+    )
     trainer_pretrain.fit(test_model)
     result = trainer_pretrain.test(test_model)
     if num_classes > 2:

--- a/tests/pipeline/test_video_domain_adapter.py
+++ b/tests/pipeline/test_video_domain_adapter.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import pytest
@@ -28,7 +27,6 @@ VALID_RATIO = 0.1
 seed = 36
 set_seed(seed)
 
-root_dir = os.path.dirname(os.path.dirname(os.getcwd()))
 url = "https://github.com/pykale/data/raw/main/videos/video_test_data.zip"
 
 
@@ -37,7 +35,7 @@ def testing_cfg(download_path):
     cfg = CfgNode()
     cfg.DATASET = CfgNode()
     cfg.DAN = CfgNode()
-    cfg.DATASET.ROOT = root_dir + "/" + download_path + "/video_test_data/"
+    cfg.DATASET.ROOT = download_path + "/video_test_data/"
     cfg.DATASET.FRAMES_PER_SEGMENT = 16
     yield cfg
 

--- a/tests/utils/test_download.py
+++ b/tests/utils/test_download.py
@@ -5,7 +5,7 @@ import pytest
 
 from kale.utils.download import download_file_by_url, download_file_gdrive
 
-output_directory = Path().absolute().parent.joinpath("test_data/download")
+output_directory = Path().absolute().joinpath("tests/test_data/download")
 PARAM = [
     "https://github.com/pykale/data/raw/main/videos/video_test_data/ADL/annotations/labels_train_test/adl_P_11_train.pkl;a.pkl;pkl",
     "https://github.com/pykale/data/raw/main/videos/video_test_data.zip;video_test_data.zip;zip",

--- a/tests/utils/test_logger.py
+++ b/tests/utils/test_logger.py
@@ -30,7 +30,7 @@ def testing_logger():
 def test_construct_logger_terminal(caplog):
     """Test that logger outputs to terminal when log_to_terminal is True."""
     logger_name = "test_logger"
-    save_dir = "./outputs"
+    save_dir = "./tests/outputs"
     os.makedirs(save_dir, exist_ok=True)
 
     t_logger = logger.construct_logger(logger_name, save_dir, log_to_terminal=True)


### PR DESCRIPTION
Fixes #412.

### Description

1. Some testing data were not downloaded into `pykale/tests` while running `pytest`. 

- `tests/loaddata/test_video_access.py`, `tests/pipeline/test_video_domain_adapter.py` and `tests/utils/test_download.py` directory paths have been changed to `pykale/tests/test_data`.  

  
- Logs and trainer outputs from `tests/helpers/pipe_test_helper.py`, `tests/pipeline/test_deepdta.py`, `tests/pipeline/test_multiomics_trainer.py` and `tests/utils/test_logger.py` have been changed to `pykale/tests/outputs`.

2. Updated device used in `LowRankTensorFusion` in`tests/pipeline/test_video_domain_adapter.py`. Cuda is used when available. 

### Status
**Ready**



### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
