### PR TITLE
Upgrade flack8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         exclude: .conda/meta.yaml
     -   id: requirements-txt-fixer
 -   repo: https://github.com/pycqa/flake8.git
-    rev: 3.9.2
+    rev: 6.1.0
     hooks:
     -   id: flake8
         additional_dependencies: [flake8-print, "importlib-metadata<5.0.0"]

--- a/kale/embed/factorization.py
+++ b/kale/embed/factorization.py
@@ -321,7 +321,7 @@ class MIDA(BaseEstimator, TransformerMixin):
             Unsupervised MIDA is performed if y is None.
             Semi-supervised MIDA is performed is y is not None.
         """
-        if self.augmentation and type(covariates) == np.ndarray:
+        if self.augmentation and isinstance(covariates, np.ndarray):
             x = np.concatenate((x, covariates), axis=1)
 
         # Kernel matrix
@@ -352,7 +352,7 @@ class MIDA(BaseEstimator, TransformerMixin):
         ctr_mat = unit_mat - 1.0 / n_samples * np.ones((n_samples, n_samples))
 
         kernel_x = self._centerer.fit_transform(kernel_x)
-        if type(covariates) == np.ndarray:
+        if isinstance(covariates, np.ndarray):
             kernel_c = np.dot(covariates, covariates.T)
         else:
             kernel_c = np.zeros((n_samples, n_samples))
@@ -409,7 +409,7 @@ class MIDA(BaseEstimator, TransformerMixin):
             x_transformed : array-like, shape (n_samples, n_components)
         """
         check_is_fitted(self, "x_fit")
-        if type(covariates) == np.ndarray and self.augmentation:
+        if isinstance(covariates, np.ndarray) and self.augmentation:
             x = np.concatenate((x, covariates), axis=1)
         kernel_x = self._centerer.transform(
             pairwise_kernels(x, self.x_fit, metric=self.kernel, filter_params=True, **self.kernel_params)

--- a/kale/embed/feature_fusion.py
+++ b/kale/embed/feature_fusion.py
@@ -2,7 +2,8 @@
 1. Concat
 2. BimodalInteractionFusion
 3. LowRankTensorFusion
-Each of these fusion methods are designed to work with input modalities as PyTorch tensors and perform different operations to combine and create a joint representation of the input data.
+Each of these fusion methods are designed to work with input modalities as PyTorch tensors and perform different
+operations to combine and create a joint representation of the input data.
 Reference: https://github.com/pliang279/MultiBench/blob/main/fusions/common_fusions.py
 """
 
@@ -13,8 +14,11 @@ from torch.autograd import Variable
 
 class Concat(nn.Module):
     """Concat is a simple PyTorch module for fusing multimodal data by concatenating tensors along dimension 1.
-    This fusion method is often used in multimodal learning where data from different modalities (e.g., image, audio) are processed separately and then fused together for further processing or decision making. Each modality data is first flattened from its second dimension onward and then these flattened tensors are concatenated together.
-    This approach to fusion maintains the independence of the modalities before the fusion point, allowing the network to learn separate representations for each modality before combining them.
+    This fusion method is often used in multimodal learning where data from different modalities (e.g., image, audio)
+    are processed separately and then fused together for further processing or decision-making. Each modality data is
+    first flattened from its second dimension onward and then these flattened tensors are concatenated together.
+    This approach to fusion maintains the independence of the modalities before the fusion point, allowing the network
+    to learn separate representations for each modality before combining them.
     """
 
     def __init__(self):
@@ -28,13 +32,21 @@ class Concat(nn.Module):
 
 
 class BimodalInteractionFusion(nn.Module):
-    """BimodalInteractionFusion is a PyTorch module that performs fusion of two data modalities through a hypernetwork-based interaction mechanism. The 'input_dims' argument specifies the input dimensions of the two modalities. The 'output_dim' argument specifies the output dimension after the fusion. The 'output' argument defines the type of bimodal matrix interactions to be performed, which can be 'matrix', 'vector', or 'scalar'.
+    """BimodalInteractionFusion is a PyTorch module that performs fusion of two data modalities through a
+    hypernetwork-based interaction mechanism. The 'input_dims' argument specifies the input dimensions of the two
+    modalities. The 'output_dim' argument specifies the output dimension after the fusion. The 'output' argument
+    defines the type of bimodal matrix interactions to be performed, which can be 'matrix', 'vector', or 'scalar'.
         This fusion method  supports three types of bimodal interactions:
-            - Matrix: It implements a general hypernetwork mechanism where the interaction is multiplicative. It uses separate weight matrices and biases for the two modalities.
-            - Vector: It uses diagonal forms and gating mechanisms, applying element-wise multiplication to combine the modalities.
+            - Matrix: It implements a general hypernetwork mechanism where the interaction is multiplicative. It uses
+            separate weight matrices and biases for the two modalities.
+            - Vector: It uses diagonal forms and gating mechanisms, applying element-wise multiplication to combine the
+            modalities.
             - Scalar: It applies scales and biases to the input modalities before combining them.
-        This fusion method uses xavier normal distribution for initializing the weight matrices and normal distribution for the biases. It also provides options to clip the parameter values and their gradients within specified ranges to prevent them from exploding or vanishing.
-        This fusion approach allows for complex interactions between the modalities and is well-suited for tasks that require the integration of heterogeneous data.
+        This fusion method uses xavier normal distribution for initializing the weight matrices and normal distribution
+        for the biases. It also provides options to clip the parameter values and their gradients within specified
+        ranges to prevent them from exploding or vanishing.
+        This fusion approach allows for complex interactions between the modalities and is well-suited for tasks that
+        require the integration of heterogeneous data.
     Args:
         input_dims (int): list or tuple of 2 integers indicating input dimensions of the 2 modalities
         output_dim (int): output dimension after the fusion
@@ -126,12 +138,23 @@ class BimodalInteractionFusion(nn.Module):
 
 class LowRankTensorFusion(nn.Module):
     """LowRankTensorFusion is a PyTorch module that performs multimodal fusion using a low-rank tensor-based approach.
-       The 'input_dims' argument specifies the input dimensions of each modality. The 'output_dim' argument defines the output dimension after the fusion. The 'rank' argument is a hyperparameter specifying the rank for the low-rank tensor decomposition.
-       This fusion method performs fusion by assuming a low-rank structure for the interaction tensor, effectively compressing the interaction space. It leverages a set of low-rank factors, one for each modality, that are learned during training.
-       These factors are initialized with xavier normal distribution and are applied to their corresponding modalities during the forward pass. A tensor product is computed across all modalities and their respective factors, resulting in a fused tensor.
-       Next, a weighted summation of this fused tensor is computed using fusion weights, followed by the addition of a fusion bias. Both fusion weights and bias are learnable parameters initialized with xavier normal distribution and zero respectively.
-       The final output is reshaped to the specified 'output_dim' and returned. If 'flatten' is set to True, each modality is first flattened before concatenation with a ones tensor and the subsequent multiplication with its factor.
-       This approach provides an efficient and compact representation for capturing interactions among multiple modalities, making it suitable for tasks involving high-dimensional multimodal data.
+       The 'input_dims' argument specifies the input dimensions of each modality. The 'output_dim' argument defines the
+       output dimension after the fusion. The 'rank' argument is a hyperparameter specifying the rank for the low-rank
+       tensor decomposition.
+       This fusion method performs fusion by assuming a low-rank structure for the interaction tensor, effectively
+       compressing the interaction space. It leverages a set of low-rank factors, one for each modality, that are
+       learned during training.
+       These factors are initialized with xavier normal distribution and are applied to their corresponding modalities
+       during the forward pass. A tensor product is computed across all modalities and their respective factors,
+       resulting in a fused tensor.
+       Next, a weighted summation of this fused tensor is computed using fusion weights, followed by the addition of a
+       fusion bias. Both fusion weights and bias are learnable parameters initialized with xavier normal distribution
+       and zero respectively.
+       The final output is reshaped to the specified 'output_dim' and returned. If 'flatten' is set to True, each
+       modality is first flattened before concatenation with a ones tensor and the subsequent multiplication with its
+       factor.
+       This approach provides an efficient and compact representation for capturing interactions among multiple
+       modalities, making it suitable for tasks involving high-dimensional multimodal data.
     Args:
         input_dims (int): A list or tuple of integers indicating input dimensions of the modalities.
         output_dim (int): output dimension after the fusion.

--- a/kale/embed/gripnet.py
+++ b/kale/embed/gripnet.py
@@ -156,17 +156,18 @@ class GripNetInternalModule(Module):
     def __repr__(self):
         tmp = [f"\n    ({i}): {l}" for i, l in enumerate(self.inter_agg_layers)]
 
-        return "{}: ModuleList(\n  (0): InternalFeatureLayer: Embedding({}, {})\n  (1): InternalFeatureAggregationModule: ModuleList({}\n  )\n)".format(
-            self.__class__.__name__, self.in_channels, self.setting.inter_feat_channels, "".join(tmp)
-        )
+        return (
+            "{}: ModuleList(\n  (0): InternalFeatureLayer: Embedding({}, {})\n  "
+            "(1): InternalFeatureAggregationModule: ModuleList({}\n  )\n)"
+        ).format(self.__class__.__name__, self.in_channels, self.setting.inter_feat_channels, "".join(tmp))
 
 
 class GripNetExternalModule(Module):
     """The internal module of a supervertex, which is an external feature layer.
 
     Args:
-        in_channels (int): Size of each input sample. In GripNet, it should be the dimension of the output embedding of the
-            corresponding parent supervertex.
+        in_channels (int): Size of each input sample. In GripNet, it should be the dimension of the output embedding of
+        the corresponding parent supervertex.
         out_channels (int): Size of each output sample. In GripNet, it is the dimension of the output embedding of
             the supervertex.
         num_out_node (int): the number of output nodes.

--- a/kale/embed/image_cnn.py
+++ b/kale/embed/image_cnn.py
@@ -11,7 +11,8 @@ from torchvision import models
 class Flatten(nn.Module):
     """Flatten layer
     This module is to replace the last fc layer of the pre-trained model with a flatten layer. It flattens the input
-    tensor to a 2D vector, which is (B, N). B is the batch size and N is the product of all dimensions except the batch size.
+    tensor to a 2D vector, which is (B, N). B is the batch size and N is the product of all dimensions except
+    the batch size.
 
     Examples:
         >>> x = torch.randn(8, 3, 224, 224)
@@ -304,10 +305,17 @@ class ResNet152Feature(nn.Module):
 
 
 class LeNet(nn.Module):
-    """LeNet is a customizable Convolutional Neural Network (CNN) model based on the LeNet architecture, designed for feature extraction from image and audio modalities.
-       LeNet supports several layers of 2D convolution, followed by batch normalization, max pooling, and adaptive average pooling, with a configurable number of channels. The depth of the network (number of convolutional blocks) is adjustable with the 'additional_layers' parameter.
-       An optional linear layer can be added at the end for further transformation of the output, which could be useful for various tasks such as classification or regression. The 'output_each_layer' option allows for returning the output of each layer instead of just the final output, which can be beneficial for certain tasks or for analyzing the intermediate representations learned by the network.
-       By default, the output tensor is squeezed before being returned, removing dimensions of size one, but this can be configured with the 'squeeze_output' parameter.
+    """LeNet is a customizable Convolutional Neural Network (CNN) model based on the LeNet architecture, designed for
+    feature extraction from image and audio modalities.
+       LeNet supports several layers of 2D convolution, followed by batch normalization, max pooling, and adaptive
+       average pooling, with a configurable number of channels.
+       The depth of the network (number of convolutional blocks) is adjustable with the 'additional_layers' parameter.
+       An optional linear layer can be added at the end for further transformation of the output, which could be useful
+       for various tasks such as classification or regression. The 'output_each_layer' option allows for returning the
+       output of each layer instead of just the final output, which can be beneficial for certain tasks or for analyzing
+       the intermediate representations learned by the network.
+       By default, the output tensor is squeezed before being returned, removing dimensions of size one, but this can be
+       configured with the 'squeeze_output' parameter.
 
     Args:
         input_channels (int): Input channel number.

--- a/kale/embed/seq_nn.py
+++ b/kale/embed/seq_nn.py
@@ -9,9 +9,9 @@ from torch_geometric.nn import GCNConv, global_max_pool
 
 class CNNEncoder(nn.Module):
     r"""
-    The DeepDTA's CNN encoder module, which comprises three 1D-convolutional layers and one max-pooling layer. The module
-    is applied to encoding drug/target sequence information, and the input should be transformed information with
-    integer/label encoding. The original paper is `"DeepDTA: deep drug–target binding affinity prediction"
+    The DeepDTA's CNN encoder module, which comprises three 1D-convolutional layers and one max-pooling layer.
+    The module is applied to encoding drug/target sequence information, and the input should be transformed information
+    with integer/label encoding. The original paper is `"DeepDTA: deep drug–target binding affinity prediction"
     <https://academic.oup.com/bioinformatics/article/34/17/i821/5093245>`_ .
 
     Args:

--- a/kale/embed/uncertainty_fitting.py
+++ b/kale/embed/uncertainty_fitting.py
@@ -90,7 +90,8 @@ def fit_and_predict(
                 validation_pairs = apply_confidence_inversion(validation_pairs, uncertainty_measure)
                 testing_pairs = apply_confidence_inversion(testing_pairs, uncertainty_measure)
 
-            # Get Quantile Thresholds, fit Isotonic Regression (IR) line and estimate Error bounds. Return both and save for each fold and target.
+            # Get Quantile Thresholds, fit Isotonic Regression (IR) line and estimate Error bounds.
+            # Return both and save for each fold and target.
             validation_errors = validation_pairs[evaluation_metric].values
             validation_uncerts = validation_pairs[uncertainty_measure].values
             uncert_boundaries, estimated_errors = quantile_binning_and_est_errors(

--- a/kale/embed/video_feature_extractor.py
+++ b/kale/embed/video_feature_extractor.py
@@ -25,7 +25,8 @@ def get_video_feat_extractor(model_name, image_modality, attention, num_classes)
     Args:
         model_name (string): The name of the feature extractor. (Choices=["I3D", "R3D_18", "R2PLUS1D_18", "MC3_18"])
         image_modality (string): Image type. (Choices=["rgb", "flow", "joint"])
-        attention (string): The attention type. (Choices=["SELayerC", "SELayerT", "SELayerCoC", "SELayerMC", "SELayerCT", "SELayerTC", "SELayerMAC"])
+        attention (string): The attention type. (Choices=["SELayerC", "SELayerT", "SELayerCoC", "SELayerMC",
+        "SELayerCT", "SELayerTC", "SELayerMAC"])
         num_classes (int): The class number of specific dataset. (Default: No use)
 
     Returns:

--- a/kale/evaluate/similarity_metrics.py
+++ b/kale/evaluate/similarity_metrics.py
@@ -61,9 +61,9 @@ def evaluate_correlations(
             error, and uncertainty inversion keys for each pair.
         cmaps: A dictionary of colour maps to use for plotting the results.
         num_bins: The number of quantile bins to divide the data into.
-        confidence_invert_tuples: A list of tuples specifying whether to invert the uncertainty values for each method..
-                          First element is a string specifying the uncertainty method name and the second element is a boolean
-                          whether to invert e.g. [["E-MHA", True], ["E-CPV", False]]
+        confidence_invert_tuples: A list of tuples specifying whether to invert the uncertainty values for each method.
+                          First element is a string specifying the uncertainty method name and the second element is
+                          a boolean whether to invert e.g. [["E-MHA", True], ["E-CPV", False]]
         num_folds: The number of folds to use for cross-validation (default: 8).
         error_scaling_factor: The scale factor to transform error by (default: 1).
         combine_middle_bins: Whether to combine the middle bins into one bin (default: False).

--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -163,8 +163,8 @@ def bin_wise_bound_eval(
               - 'mean all targets': The mean accuracy over all targets and quantile bins.
               - 'mean all bins': A list of mean accuracy values for each quantile bin (all targets included).
               - 'mean all': A list of accuracy values for each quantile bin and target, weighted by # targets in each bin.
-              - 'all bins concatenated targets separated': A list of accuracy values for each quantile bin, concatenated for each
-                target separately.
+              - 'all bins concatenated targets separated': A list of accuracy values for each quantile bin, concatenated
+               for each target separately.
 
     Example:
         >>> bin_wise_bound_eval(fold_bounds_all_targets, fold_errors, fold_bins, [0,1], 'S-MHA', num_bins=5)
@@ -190,7 +190,8 @@ def bin_wise_bound_eval(
         # The error bounds are from B1 -> B5 i.e. best quantile of predictions to worst quantile of predictions
         fold_bounds = fold_bounds_all_targets[i_ti]
 
-        # For each bin, see what % of targets are between the error bounds. If bin=0 then lower bound = 0, if bin=Q then no upper bound
+        # For each bin, see what % of targets are between the error bounds.
+        # If bin=0 then lower bound = 0, if bin=Q then no upper bound
         # Keep track of #samples in each bin for weighted mean.
 
         # turn dictionary of predicted bins into [[num_bins]] array
@@ -306,11 +307,12 @@ def get_mean_errors(
     """
     Evaluate uncertainty estimation's mean error of each bin.
     For each bin, we calculate the mean localization error for each target and for all targets.
-    We calculate the mean error for each dictionary in the bin_predictions dict. For each bin, we calculate: a) the mean and
-    std over all folds and all targets b) the mean and std for each target over all folds.
+    We calculate the mean error for each dictionary in the bin_predictions dict. For each bin, we calculate: a) the mean
+    and std over all folds and all targets b) the mean and std for each target over all folds.
 
     Args:
-        bin_predictions (Dict): Dict of Pandas DataFrames where each DataFrame has errors, predicted bins for all uncertainty measures for a model.
+        bin_predictions (Dict): Dict of Pandas DataFrames where each DataFrame has errors, predicted bins for all
+        uncertainty measures for a model.
         uncertainty_pairs (List[Tuple[str, str]]): List of tuples describing the different uncertainty combinations to test.
         num_bins (int): Number of quantile bins.
         targets (List[str]): List of targets to measure uncertainty estimation.
@@ -319,7 +321,8 @@ def get_mean_errors(
         combine_middle_bins (bool, optional): Combine middle bins if True. Defaults to False.
 
     Returns:
-        Dict[str, Union[Dict[str, List[List[float]]], List[Dict[str, List[float]]]]]: Dictionary with mean error for all targets combined and targets separated.
+        Dict[str, Union[Dict[str, List[List[float]]], List[Dict[str, List[float]]]]]: Dictionary with mean error for all
+         targets combined and targets separated.
             Keys that are returned:
                 "all mean error bins nosep":  For every fold, the mean error for each bin. All targets are combined in the same list.
                 "all mean error bins targets sep":   For every fold, the mean error for each bin. Each target is in a separate list.
@@ -453,7 +456,7 @@ def evaluate_jaccard(bin_predictions, uncertainty_pairs, num_bins, targets, num_
         [Dict]: Dicts with JI for all targets combined and targets seperated.
     """
 
-    # If we are combining middle bins, we need the original number of bins to calcualate the true quantiles of the error.
+    # If combining middle bins, we need the original number of bins to calcualate the true quantiles of the error.
     # Then, we combine all the middle bins of the true quantiles, giving us 3 bins.
     # There are only 3 bins that have been predicted, so set num_bins to 3.
 

--- a/kale/interpret/model_weights.py
+++ b/kale/interpret/model_weights.py
@@ -17,7 +17,7 @@ def select_top_weight(weights, select_ratio: float = 0.05):
     Returns:
         array-like: top weights in the same shape with the input model weights
     """
-    if type(weights) != np.ndarray:
+    if not isinstance(weights, np.ndarray):
         weights = np.array(weights)
     orig_shape = weights.shape
 

--- a/kale/interpret/uncertainty_quantiles.py
+++ b/kale/interpret/uncertainty_quantiles.py
@@ -1110,7 +1110,8 @@ def generate_fig_individual_bin_comparison(data: Tuple, display_settings: dict) 
 
     Args:
         data: A tuple containing various inputs needed to generate the figures, including:
-            - uncertainty_error_pairs (List[Tuple[int, float]]): A list of tuples specifying the uncertainty thresholds and corresponding error thresholds to use for binning the data.
+            - uncertainty_error_pairs (List[Tuple[int, float]]): A list of tuples specifying the uncertainty thresholds
+            and corresponding error thresholds to use for binning the data.
             - models_to_compare (List[str]): A list of model names to compare.
             - dataset (str): The name of the dataset being used.
             - target_indices (List[int]): A list of target indices to include in the analysis.
@@ -1544,7 +1545,8 @@ def generate_fig_comparing_bins(
 
     Args:
         data (Tuple): A tuple containing various inputs needed to generate the figures. The tuple should include the following elements:
-            - uncertainty_error_pair (Tuple[float, float]): A tuple representing the mean and standard deviation of the noise uncertainty used during training and evaluation.
+            - uncertainty_error_pair (Tuple[float, float]): A tuple representing the mean and standard deviation of
+            the noise uncertainty used during training and evaluation.
             - model (str): The name of the model being evaluated.
             - dataset (str): The name of the dataset being used.
             - targets (List[int]): A list of target indices being evaluated.

--- a/kale/interpret/visualize.py
+++ b/kale/interpret/visualize.py
@@ -31,7 +31,7 @@ def plot_weights(
     Returns:
         [matplotlib.figure.Figure]: Figure to plot.
     """
-    if type(weight_img) != np.ndarray:
+    if not isinstance(weight_img, np.ndarray):
         weight_img = np.array(weight_img)
     if len(weight_img.shape) != 2:
         raise ValueError(
@@ -106,11 +106,11 @@ def plot_multi_images(
     fig = plt.figure(figsize=figsize)
     if image_titles is None:
         image_titles = np.arange(n_samples) + 1
-    elif type(image_titles) != list or len(image_titles) != n_samples:
+    elif not isinstance(image_titles, list) or len(image_titles) != n_samples:
         raise ValueError("Invalid type or length of 'image_names'!")
     if marker_cmap is None:
         marker_colors = None
-    elif type(marker_cmap) == str:
+    elif isinstance(marker_cmap, str):
         marker_colors = plt.get_cmap(marker_cmap).colors
     else:
         raise ValueError("Unsupported type %s for argument 'marker_cmap'" % type(marker_cmap))
@@ -174,7 +174,7 @@ def distplot_1d(
     if colors is None:
         colors = plt.get_cmap("Set1").colors
 
-    if type(data) != list:
+    if not isinstance(data, list):
         data = [data]
 
     if labels is None:

--- a/kale/loaddata/avmnist_datasets.py
+++ b/kale/loaddata/avmnist_datasets.py
@@ -1,4 +1,5 @@
-"""Dataset setting and data loader for AVMNIST dataset by refactoring https://github.com/pliang279/MultiBench/blob/main/datasets/avmnist/get_data.py"""
+"""Dataset setting and data loader for AVMNIST dataset
+by refactoring https://github.com/pliang279/MultiBench/blob/main/datasets/avmnist/get_data.py"""
 
 import numpy as np
 import torch
@@ -7,9 +8,14 @@ from torch.utils.data import DataLoader
 
 class AVMNISTDataset:
     """This class loads the AVMNIST data stored in a specified directory, and prepares it for training, validation, and testing.
-    This class also takes care of the pre-processing steps such as reshaping and normalizing the data based on provided arguments. This includes options to flatten the audio and image data, normalize the image and audio data, and add an additional dimension to the data, often used to represent the channel in image or audio data.
-    Furthermore, The class handles the splitting of data into training and validation sets. It provides separate data loaders for the training, validation, and testing sets, which can be used to iterate over the data during model training and evaluation.
-    This data loader class simplifies the data preparation process for multimodal learning tasks, allowing the user to focus on model architecture and hyperparameter tuning.
+    This class also takes care of the pre-processing steps such as reshaping and normalizing the data based on provided
+    arguments. This includes options to flatten the audio and image data, normalize the image and audio data, and
+    add a dimension to the data, often used to represent the channel in image or audio data.
+    Furthermore, The class handles the splitting of data into training and validation sets. It provides separate data
+    loaders for the training, validation, and testing sets, which can be used to iterate over the data during model
+    training and evaluation.
+    This data loader class simplifies the data preparation process for multimodal learning tasks, allowing the user to
+    focus on model architecture and hyperparameter tuning.
 
     Args:
         data_dir (str): Directory of data.

--- a/kale/loaddata/multi_domain.py
+++ b/kale/loaddata/multi_domain.py
@@ -324,7 +324,7 @@ class MultiDomainImageFolder(VisionDataset):
     ) -> None:
         super(MultiDomainImageFolder, self).__init__(root, transform=transform, target_transform=target_transform)
         domains, domain_to_idx = self._find_classes(self.root)
-        if type(sub_domain_set) == list:
+        if isinstance(sub_domain_set, list):
             for domain_name in sub_domain_set:
                 if domain_name not in domains:
                     raise ValueError("Domain %s not in the image directory" % domain_name)
@@ -332,7 +332,7 @@ class MultiDomainImageFolder(VisionDataset):
             domain_to_idx = {domain_name: i for i, domain_name in enumerate(sub_domain_set)}
 
         classes, class_to_idx = self._find_classes(os.path.join(self.root, domains[0]))
-        if type(sub_class_set) == list:
+        if isinstance(sub_class_set, list):
             for class_name in sub_class_set:
                 if class_name not in classes:
                     raise ValueError("Class %s not in the image directory" % class_name)

--- a/kale/pipeline/base_nn_trainer.py
+++ b/kale/pipeline/base_nn_trainer.py
@@ -15,8 +15,10 @@ The structure and workflow of BaseNNTrainer is consistent with `kale.pipeline.do
 
 This module uses `PyTorch Lightning <https://github.com/Lightning-AI/lightning>`_ to standardize the flow.
 
-This module also provides a Multimodal Neural Network Trainer (MultimodalNNTrainer) where this trainer uses separate encoders for each modality, a fusion technique to combine the modalities, and a classifier head for final prediction.
-MultimodalNNTrainer is also designed to handle training, validation, and testing steps for multimodal data using specified models, optimization algorithms, and loss functions.
+This module also provides a Multimodal Neural Network Trainer (MultimodalNNTrainer) where this trainer uses separate
+encoders for each modality, a fusion technique to combine the modalities, and a classifier head for final prediction.
+MultimodalNNTrainer is also designed to handle training, validation, and testing steps for multimodal data using
+specified models, optimization algorithms, and loss functions.
 Adapted from: https://github.com/pliang279/MultiBench/blob/main/training_structures/Supervised_Learning.py
 """
 
@@ -182,14 +184,22 @@ class CNNTransformerTrainer(BaseNNTrainer):
 
 
 class MultimodalNNTrainer(pl.LightningModule):
-    """MultimodalNNTrainer, serves as a PyTorch Lightning trainer for multimodal models. It is designed to handle training, validation, and testing steps for multimodal data using specified models, optimization algorithms, and loss functions.
-       For each training, validation, and test step, the trainer class computes the model's loss and accuracy and logs these metrics. This trainer simplifies the process of training complex multimodal models, allowing the user to focus on model architecture and hyperparameter tuning.
-       This trainer is flexible and can be used with various models, optimizers, and loss functions, enabling its use across a wide range of multimodal learning tasks.
+    """MultimodalNNTrainer, serves as a PyTorch Lightning trainer for multimodal models. It is designed to handle
+    training, validation, and testing steps for multimodal data using specified models, optimization algorithms, and loss functions.
+       For each training, validation, and test step, the trainer class computes the model's loss and accuracy and logs
+       these metrics. This trainer simplifies the process of training complex multimodal models, allowing the user to
+       focus on model architecture and hyperparameter tuning.
+       This trainer is flexible and can be used with various models, optimizers, and loss functions, enabling its use
+       across a wide range of multimodal learning tasks.
     Args:
-        encoders (List[nn.Module]): A list of PyTorch `nn.Module` encoders, with one encoder per modality. Each encoder is responsible for transforming the raw input of a single modality into a high-level representation.
-        fusion (nn.Module): A PyTorch `nn.Module` that merges the high-level representations from each modality into a single representation.
+        encoders (List[nn.Module]): A list of PyTorch `nn.Module` encoders, with one encoder per modality. Each encoder
+        is responsible for transforming the raw input of a single modality into a high-level representation.
+        fusion (nn.Module): A PyTorch `nn.Module` that merges the high-level representations from each modality into a
+        single representation.
         head (nn.Module): A PyTorch `nn.Module` that takes the fused representation and outputs a class prediction.
-        is_packed (bool, optional):  whether the input modalities are packed in one list or not (default is False, which means we expect input of [tensor(20xmodal1_size),(20xmodal2_size),(20xlabel_size)] for batch size 20 and 2 input modalities)
+        is_packed (bool, optional):  whether the input modalities are packed in one list or not (default is False, which
+        means we expect input of [tensor(20xmodal1_size),(20xmodal2_size),(20xlabel_size)] for batch size 20 and 2 input
+        modalities)
         optim (torch.optim, optional): The optimization algorithm to use. Defaults to torch.optim.SGD.
         lr (float, optional): Learning rate for the optimizer. Defaults to 0.001.
         weight_decay (float, optional): Weight decay for the optimizer. Defaults to 0.0.

--- a/kale/predict/decode.py
+++ b/kale/predict/decode.py
@@ -62,7 +62,8 @@ class MLPDecoder(nn.Module):
 class DistMultDecoder(torch.nn.Module):
     """
     Build `DistMult
-    <https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/ICLR2015_updated.pdf>`_ factorization as GripNet decoder in PoSE dataset.
+    <https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/ICLR2015_updated.pdf>`_ factorization
+    as GripNet decoder in PoSE dataset.
     Copy-paste with slight modifications from https://github.com/NYXFLOWER/GripNet.
 
     Args:

--- a/kale/prepdata/supergraph_construct.py
+++ b/kale/prepdata/supergraph_construct.py
@@ -108,7 +108,10 @@ class SuperVertex(object):
         self.range_list = torch.tensor(range_list)
 
     def __repr__(self) -> str:
-        return f"SuperVertex(\n    name={self.name}, \n    node_feat={self.node_feat.shape}, \n    edge_index={self.edge_index.shape}, \n    num_edge_type={self.num_edge_type})"
+        return (
+            f"SuperVertex(\n    name={self.name}, \n    node_feat={self.node_feat.shape}, \n    "
+            f"edge_index={self.edge_index.shape}, \n    num_edge_type={self.num_edge_type})"
+        )
 
     def add_in_supervertex(self, vertex_name: str):
         self.in_supervertex_list.append(vertex_name)
@@ -145,7 +148,10 @@ class SuperEdge(object):
         self.edge_weight = edge_weight
 
     def __repr__(self) -> str:
-        return f"SuperEdges(\n    edge_direction={self.source_supervertex}->{self.target_supervertex}, \n    edge_index={self.edge_index.shape})"
+        return (
+            f"SuperEdges(\n    edge_direction={self.source_supervertex}->{self.target_supervertex}, "
+            f"\n    edge_index={self.edge_index.shape})"
+        )
 
 
 class SuperVertexParaSetting(object):
@@ -255,4 +261,8 @@ class SuperGraph(object):
         self.supervertex_setting_dict = {sv.supervertex_name: sv for sv in supervertex_setting_list}
 
     def __repr__(self) -> str:
-        return f"SuperGraph(\n  svertex_dict={self.supervertex_dict.values()}, \n  sedge_dict={self.superedge_dict.values()}, \n  G={self.G}), \n  topological_order={self.topological_order}"
+        return (
+            f"SuperGraph(\n  svertex_dict={self.supervertex_dict.values()}, "
+            f"\n  sedge_dict={self.superedge_dict.values()}, \n  G={self.G}), "
+            f"\n  topological_order={self.topological_order}"
+        )

--- a/kale/utils/initialize_nn.py
+++ b/kale/utils/initialize_nn.py
@@ -15,7 +15,7 @@ def xavier_init(module) -> None:
     Args:
         module (torch.Tensor): The input module.
     """
-    if type(module) == nn.Linear:
+    if isinstance(module, nn.Linear):
         nn.init.xavier_normal_(module.weight)
 
 
@@ -25,5 +25,5 @@ def bias_init(module) -> None:
     Args:
         module (torch.Tensor): The input module.
     """
-    if type(module) == nn.Linear and module.bias is not None:
+    if isinstance(module, nn.Linear) and module.bias is not None:
         module.bias.data.fill_(0.0)

--- a/kale/utils/save_xlsx.py
+++ b/kale/utils/save_xlsx.py
@@ -66,8 +66,8 @@ def save_dict_xlsx(data_dict: Dict[Any, Any], save_location: str, sheet_name: st
     Save a dictionary to an Excel file using the XlsxWriter engine.
 
     Parameters:
-    data_dict (Dict[Any, Any]): The dictionary that needs to be saved to an Excel file. The keys of the dictionary represent the
-                                row index and the values represent the data in the row. If a dictionary value is a list or a
+    data_dict (Dict[Any, Any]): The dictionary that needs to be saved to an Excel file. The keys represent the row index
+                                and the values represent the data in the row. If a dictionary value is a list or a
                                 series, each element in the list/series will be a column in the row.
 
     save_location (str): The location where the Excel file will be saved. This should include the full path and the filename,

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,10 +7,10 @@ universal=1
 [flake8]
 max-line-length = 120
 exclude = build,examples
-ignore =
-    E203  # whitespace before ':'. Opposite convention enforced by black
-    E501  # line too long. Long-line code is reformated by black; remaining long lines in docstrings are OK
-    W503  # line break before binary operator. W503 is incompatible with PEP 8, don't use it
+ignore = E203, E501, W503
+# E203 - whitespace before ':'. Opposite convention enforced by black
+# E501 - line too long. Long-line code is reformated by black; remaining long lines in docstrings are OK
+# W503 - line break before binary operator. W503 is incompatible with PEP 8, don't use it
 
 [mypy]
 # Suppress all missing import errors for all libraries

--- a/tests/pipeline/test_mpca_trainer.py
+++ b/tests/pipeline/test_mpca_trainer.py
@@ -52,7 +52,7 @@ def test_mpca_trainer(classifier, params, gait):
         weights = trainer.mpca.inverse_transform(trainer.clf.coef_) - trainer.mpca.mean_
         top_weights = model_weights.select_top_weight(weights, select_ratio=0.1)
         fig = visualize.plot_weights(top_weights[0][0], background_img=x[0][0])
-        assert type(fig) == matplotlib.figure.Figure
+        assert isinstance(fig, matplotlib.figure.Figure)
 
 
 def test_invalid_init():

--- a/tests/pipeline/test_multi_domain_adapter.py
+++ b/tests/pipeline/test_multi_domain_adapter.py
@@ -105,4 +105,4 @@ def test_coirls(kernel, office_caltech_access):
             title_kwargs=title_kwargs,
             hist_kwargs=hist_kwargs,
         )
-        assert type(fig) == matplotlib.figure.Figure
+        assert isinstance(fig, matplotlib.figure.Figure)

--- a/tests/prepdata/test_image_transform.py
+++ b/tests/prepdata/test_image_transform.py
@@ -60,7 +60,7 @@ def test_reg(images, coords):
         marker_kwargs=marker_kwargs,
         title_kwargs=title_kwargs,
     )
-    assert type(fig) == matplotlib.figure.Figure
+    assert isinstance(fig, matplotlib.figure.Figure)
     with pytest.raises(Exception):
         reg_img_stack(images, coords[1:, :], coords[0])
     images_reg, max_dist = reg_img_stack(images, coords, target_coords=coords[0])
@@ -70,7 +70,7 @@ def test_reg(images, coords):
     # add one for avoiding inf relative difference
     testing.assert_allclose(max_dist + 1, np.ones(n_samples), rtol=2, atol=2)
     fig = plot_multi_images([images_reg[i][0, ...] for i in range(n_samples)], n_cols=5)
-    assert type(fig) == matplotlib.figure.Figure
+    assert isinstance(fig, matplotlib.figure.Figure)
 
 
 @pytest.mark.parametrize("scale", SCALES)


### PR DESCRIPTION
### Description
Upgrade flack8 to 6.1.0.

The main change is updating the type-checking method by replacing `type(covariates) == np.ndarray` with `isinstance(covariates, np.ndarray)`, aligning with Python's preferred practices. (Resolving Flake8 error [E721](https://www.flake8rules.com/rules/E721.html))

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
