### PR TITLE
Update the default checkpoint (ckpt) resume and test file name to None

### DIFF
--- a/examples/cifar_cnntransformer/main.py
+++ b/examples/cifar_cnntransformer/main.py
@@ -84,7 +84,7 @@ def main():
     )
 
     # ---- start training ----
-    # trainer.fit(model, train_loader, valid_loader, ckpt_path=args.ckpt_resume)
+    trainer.fit(model, train_loader, valid_loader, ckpt_path=args.ckpt_resume)
 
     # ---- start testing ----
     trainer.test(model, valid_loader, ckpt_path=args.ckpt_test)

--- a/examples/cifar_cnntransformer/main.py
+++ b/examples/cifar_cnntransformer/main.py
@@ -29,8 +29,8 @@ def arg_parse():
         help="gpu id(s) to use. int(0) for cpu. list[x,y] for xth, yth GPU."
         "str(x) for the first x GPUs. str(-1)/int(-1) for all available GPUs",
     )
-    parser.add_argument("--ckpt_resume", default="", help="path to train checkpoint file", type=str)
-    parser.add_argument("--ckpt_test", default="best", help="path to test checkpoint file", type=str)
+    parser.add_argument("--ckpt_resume", default=None, help="path to train checkpoint file", type=str)
+    parser.add_argument("--ckpt_test", default=None, help="path to test checkpoint file", type=str)
     args = parser.parse_args()
     return args
 
@@ -84,7 +84,7 @@ def main():
     )
 
     # ---- start training ----
-    trainer.fit(model, train_loader, valid_loader, ckpt_path=args.ckpt_resume)
+    # trainer.fit(model, train_loader, valid_loader, ckpt_path=args.ckpt_resume)
 
     # ---- start testing ----
     trainer.test(model, valid_loader, ckpt_path=args.ckpt_test)


### PR DESCRIPTION
### Description
Fixed a bug related to loading trained `ckpt_resume` and `ckpt_test` in `cifar_cnntransformer`.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
