### PR TITLE
Split the test data downloading and test cases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
           pip install torch_geometric==2.3.0
           pip install -e .[dev]
         shell: bash -l {0}
-      
+
       - name: Run tests
         id: run_tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,7 @@ jobs:
           pip install torch_geometric==2.3.0
           pip install -e .[dev]
         shell: bash -l {0}
+      
       - name: Run tests
         id: run_tests
         run: |

--- a/examples/cifar_cnntransformer/config.py
+++ b/examples/cifar_cnntransformer/config.py
@@ -13,6 +13,7 @@ _C.DATASET.ROOT = "./data"  # Root directory of dataset, "data" is in the same d
 _C.DATASET.NAME = "CIFAR10"  # Dataset name
 _C.DATASET.NUM_CLASSES = 10  # Number of classes in the dataset
 _C.DATASET.NUM_WORKERS = 0  # Number of workers for data loading
+_C.DATASET.DOWNLOAD = True  # Download the dataset if it is not found in the root directory
 
 # ---------------------------------------------------------------------------- #
 # Solver

--- a/examples/cifar_cnntransformer/config.py
+++ b/examples/cifar_cnntransformer/config.py
@@ -13,7 +13,7 @@ _C.DATASET.ROOT = "./data"  # Root directory of dataset, "data" is in the same d
 _C.DATASET.NAME = "CIFAR10"  # Dataset name
 _C.DATASET.NUM_CLASSES = 10  # Number of classes in the dataset
 _C.DATASET.NUM_WORKERS = 0  # Number of workers for data loading
-_C.DATASET.DOWNLOAD = True  # Download the dataset if it is not found in the root directory
+_C.DATASET.DOWNLOAD = True  # Manually choose whether to download the dataset. Default set to True. Set to False for functional testing only.
 
 # ---------------------------------------------------------------------------- #
 # Solver

--- a/kale/embed/feature_fusion.py
+++ b/kale/embed/feature_fusion.py
@@ -174,6 +174,7 @@ class LowRankTensorFusion(nn.Module):
             ones = Variable(torch.ones(batch_size, 1).type(modality.dtype), requires_grad=False).to(
                 torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
             )
+            modality = modality.to(torch.device("cuda:0" if torch.cuda.is_available() else "cpu"))
             if self.flatten:
                 modality_withones = torch.cat((ones, torch.flatten(modality, start_dim=1)), dim=1)
             else:

--- a/kale/loaddata/image_access.py
+++ b/kale/loaddata/image_access.py
@@ -313,11 +313,19 @@ def get_cifar(cfg):
     cifar_test_transform = get_transform("cifar", augment=False)
 
     if cfg.DATASET.NAME == "CIFAR10":
-        train_set = datasets.CIFAR10(cfg.DATASET.ROOT, train=True, download=cfg.DATASET.DOWNLOAD, transform=cifar_train_transform)
-        valid_set = datasets.CIFAR10(cfg.DATASET.ROOT, train=False, download=cfg.DATASET.DOWNLOAD, transform=cifar_test_transform)
+        train_set = datasets.CIFAR10(
+            cfg.DATASET.ROOT, train=True, download=cfg.DATASET.DOWNLOAD, transform=cifar_train_transform
+        )
+        valid_set = datasets.CIFAR10(
+            cfg.DATASET.ROOT, train=False, download=cfg.DATASET.DOWNLOAD, transform=cifar_test_transform
+        )
     elif cfg.DATASET.NAME == "CIFAR100":
-        train_set = datasets.CIFAR100(cfg.DATASET.ROOT, train=True, download=cfg.DATASET.DOWNLOAD, transform=cifar_train_transform)
-        valid_set = datasets.CIFAR100(cfg.DATASET.ROOT, train=False, download=cfg.DATASET.DOWNLOAD, transform=cifar_test_transform)
+        train_set = datasets.CIFAR100(
+            cfg.DATASET.ROOT, train=True, download=cfg.DATASET.DOWNLOAD, transform=cifar_train_transform
+        )
+        valid_set = datasets.CIFAR100(
+            cfg.DATASET.ROOT, train=False, download=cfg.DATASET.DOWNLOAD, transform=cifar_test_transform
+        )
     else:
         raise NotImplementedError
 

--- a/kale/loaddata/image_access.py
+++ b/kale/loaddata/image_access.py
@@ -313,11 +313,11 @@ def get_cifar(cfg):
     cifar_test_transform = get_transform("cifar", augment=False)
 
     if cfg.DATASET.NAME == "CIFAR10":
-        train_set = datasets.CIFAR10(cfg.DATASET.ROOT, train=True, download=True, transform=cifar_train_transform)
-        valid_set = datasets.CIFAR10(cfg.DATASET.ROOT, train=False, download=True, transform=cifar_test_transform)
+        train_set = datasets.CIFAR10(cfg.DATASET.ROOT, train=True, download=cfg.DATASET.DOWNLOAD, transform=cifar_train_transform)
+        valid_set = datasets.CIFAR10(cfg.DATASET.ROOT, train=False, download=cfg.DATASET.DOWNLOAD, transform=cifar_test_transform)
     elif cfg.DATASET.NAME == "CIFAR100":
-        train_set = datasets.CIFAR100(cfg.DATASET.ROOT, train=True, download=True, transform=cifar_train_transform)
-        valid_set = datasets.CIFAR100(cfg.DATASET.ROOT, train=False, download=True, transform=cifar_test_transform)
+        train_set = datasets.CIFAR100(cfg.DATASET.ROOT, train=True, download=cfg.DATASET.DOWNLOAD, transform=cifar_train_transform)
+        valid_set = datasets.CIFAR100(cfg.DATASET.ROOT, train=False, download=cfg.DATASET.DOWNLOAD, transform=cifar_test_transform)
     else:
         raise NotImplementedError
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,12 +14,11 @@ def download_path():
     return path
 
 
-gait_url = "https://github.com/pykale/data/raw/main/videos/gait/gait_gallery_data.mat"
-
+#gait_url = "https://github.com/pykale/data/raw/main/videos/gait/gait_gallery_data.mat"
 
 @pytest.fixture(scope="session")
 def gait(download_path):
-    download_file_by_url(gait_url, download_path, "gait.mat", "mat")
+    
     return loadmat(os.path.join(download_path, "gait.mat"))
 
 
@@ -31,9 +30,9 @@ def office_path(download_path):
 
 
 # Landmark Global fixtures
-landmark_uncertainty_url = (
-    "https://github.com/pykale/data/raw/main/tabular/cardiac_landmark_uncertainty/Uncertainty_tuples.zip"
-)
+# landmark_uncertainty_url = (
+#     "https://github.com/pykale/data/raw/main/tabular/cardiac_landmark_uncertainty/Uncertainty_tuples.zip"
+# )
 
 
 # Downloads and unzips remote file
@@ -42,7 +41,6 @@ def landmark_uncertainty_tuples_path(download_path):
     path_ = download_path
     os.makedirs(path_, exist_ok=True)
 
-    download_file_by_url(landmark_uncertainty_url, path_, "Uncertainty_tuples.zip", "zip")
     valid_path = os.path.join(path_, "Uncertainty_tuples/U-NET/SA/uncertainty_pairs_valid_t0")
     test_path = os.path.join(path_, "Uncertainty_tuples/U-NET/SA/uncertainty_pairs_test_t0")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,9 +12,6 @@ def download_path():
     return path
 
 
-# gait_url = "https://github.com/pykale/data/raw/main/videos/gait/gait_gallery_data.mat"
-
-
 @pytest.fixture(scope="session")
 def gait(download_path):
     return loadmat(os.path.join(download_path, "gait.mat"))
@@ -25,12 +22,6 @@ def office_path(download_path):
     path_ = os.path.join(download_path, "office")
     os.makedirs(path_, exist_ok=True)
     return path_
-
-
-# Landmark Global fixtures
-# landmark_uncertainty_url = (
-#     "https://github.com/pykale/data/raw/main/tabular/cardiac_landmark_uncertainty/Uncertainty_tuples.zip"
-# )
 
 
 # Downloads and unzips remote file

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,6 @@ import os
 import pytest
 from scipy.io import loadmat
 
-from kale.utils.download import download_file_by_url
-
 
 @pytest.fixture(scope="session")
 def download_path():
@@ -14,11 +12,12 @@ def download_path():
     return path
 
 
-#gait_url = "https://github.com/pykale/data/raw/main/videos/gait/gait_gallery_data.mat"
+# gait_url = "https://github.com/pykale/data/raw/main/videos/gait/gait_gallery_data.mat"
+
 
 @pytest.fixture(scope="session")
 def gait(download_path):
-    
+
     return loadmat(os.path.join(download_path, "gait.mat"))
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,6 @@ def download_path():
 
 @pytest.fixture(scope="session")
 def gait(download_path):
-
     return loadmat(os.path.join(download_path, "gait.mat"))
 
 

--- a/tests/embed/test_factorization.py
+++ b/tests/embed/test_factorization.py
@@ -18,7 +18,6 @@ baseline_url = "https://github.com/pykale/data/raw/main/videos/gait/mpca_baselin
 
 @pytest.fixture(scope="module")
 def baseline_model(download_path):
-
     return loadmat(os.path.join(download_path, "baseline.mat"))
 
 

--- a/tests/embed/test_factorization.py
+++ b/tests/embed/test_factorization.py
@@ -10,7 +10,6 @@ from tensorly.tenalg import multi_mode_dot
 
 from kale.embed.factorization import MIDA, MPCA
 
-
 N_COMPS = [1, 50, 100]
 VAR_RATIOS = [0.7, 0.95]
 relative_tol = 0.00001
@@ -19,7 +18,7 @@ baseline_url = "https://github.com/pykale/data/raw/main/videos/gait/mpca_baselin
 
 @pytest.fixture(scope="module")
 def baseline_model(download_path):
-    
+
     return loadmat(os.path.join(download_path, "baseline.mat"))
 
 

--- a/tests/embed/test_factorization.py
+++ b/tests/embed/test_factorization.py
@@ -9,7 +9,7 @@ from sklearn.preprocessing import OneHotEncoder
 from tensorly.tenalg import multi_mode_dot
 
 from kale.embed.factorization import MIDA, MPCA
-from kale.utils.download import download_file_by_url
+
 
 N_COMPS = [1, 50, 100]
 VAR_RATIOS = [0.7, 0.95]
@@ -19,7 +19,7 @@ baseline_url = "https://github.com/pykale/data/raw/main/videos/gait/mpca_baselin
 
 @pytest.fixture(scope="module")
 def baseline_model(download_path):
-    download_file_by_url(baseline_url, download_path, "baseline.mat", "mat")
+    
     return loadmat(os.path.join(download_path, "baseline.mat"))
 
 

--- a/tests/loaddata/test_image_access.py
+++ b/tests/loaddata/test_image_access.py
@@ -11,7 +11,7 @@ from kale.loaddata.multi_domain import DomainsDatasetBase, MultiDomainAdapDatase
 @pytest.mark.parametrize("test_on_all", [True, False])
 def test_office31(office_path, test_on_all):
     office_access = ImageAccess.get_multi_domain_images(
-        "OFFICE31", office_path, download=True, return_domain_label=True
+        "OFFICE31", office_path, download=False, return_domain_label=True
     )
     testing.assert_equal(len(office_access.class_to_idx), 31)
     testing.assert_equal(len(office_access.domain_to_idx), 3)
@@ -27,7 +27,7 @@ def test_office31(office_path, test_on_all):
 
 def test_office_caltech(office_path):
     office_access = ImageAccess.get_multi_domain_images(
-        "OFFICE_CALTECH", office_path, download=True, return_domain_label=True
+        "OFFICE_CALTECH", office_path, download=False, return_domain_label=True
     )
     testing.assert_equal(len(office_access.class_to_idx), 10)
     testing.assert_equal(len(office_access.domain_to_idx), 4)
@@ -35,7 +35,7 @@ def test_office_caltech(office_path):
 
 @pytest.mark.parametrize("split_ratio", [0.9, 1])
 def test_custom_office(office_path, split_ratio):
-    kwargs = {"download": True, "split_train_test": True, "split_ratio": split_ratio}
+    kwargs = {"download": False, "split_train_test": True, "split_ratio": split_ratio}
     source = ImageAccess.get_multi_domain_images("office", office_path, sub_domain_set=["dslr"], **kwargs)
     target = ImageAccess.get_multi_domain_images("office", office_path, sub_domain_set=["webcam"], **kwargs)
     dataset = MultiDomainDatasets(source_access=source, target_access=target)
@@ -141,7 +141,7 @@ def testing_cfg(download_path):
     cfg.DATASET = CfgNode()
     cfg.SOLVER = CfgNode()
     cfg.DATASET.ROOT = download_path
-    # cfg.DATASET.DOWNLOAD = True
+    cfg.DATASET.DOWNLOAD = False
     cfg.SOLVER.TRAIN_BATCH_SIZE = 16
     cfg.SOLVER.TEST_BATCH_SIZE = 20
     cfg.DATASET.NUM_WORKERS = 1

--- a/tests/loaddata/test_video_access.py
+++ b/tests/loaddata/test_video_access.py
@@ -1,6 +1,3 @@
-
-import os
-
 import pytest
 import torch
 from yacs.config import CfgNode

--- a/tests/loaddata/test_video_access.py
+++ b/tests/loaddata/test_video_access.py
@@ -73,13 +73,6 @@ def test_get_source_target(source_cfg, target_cfg, valid_ratio, weight_type, dat
     cfg.DATASET.WEIGHT_TYPE = weight_type
     cfg.DATASET.SIZE_TYPE = datasize_type
 
-    # download_file_by_url(
-    #     url=url,
-    #     output_directory=str(Path(cfg.DATASET.ROOT).parent.absolute()),
-    #     output_file_name="video_test_data.zip",
-    #     file_format="zip",
-    # )
-
     # test get_source_target
     source, target, num_classes = VideoDataset.get_source_target(
         VideoDataset(source_name), VideoDataset(target_name), seed, cfg

--- a/tests/loaddata/test_video_access.py
+++ b/tests/loaddata/test_video_access.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 
 import pytest
 import torch
@@ -9,7 +8,6 @@ from kale.loaddata.dataset_access import get_class_subset
 from kale.loaddata.multi_domain import DomainsDatasetBase
 from kale.loaddata.video_access import get_image_modality, VideoDataset, VideoDatasetAccess
 from kale.loaddata.video_multi_domain import VideoMultiDomainDatasets
-from kale.utils.download import download_file_by_url
 from kale.utils.seed import set_seed
 
 SOURCES = [
@@ -42,7 +40,7 @@ url = "https://github.com/pykale/data/raw/main/videos/video_test_data.zip"
 def testing_cfg(download_path):
     cfg = CfgNode()
     cfg.DATASET = CfgNode()
-    cfg.DATASET.ROOT = root_dir + "/" + download_path + "/video_test_data/"
+    cfg.DATASET.ROOT = download_path + "/video_test_data/"
     cfg.DATASET.IMAGE_MODALITY = "joint"
     cfg.DATASET.FRAMES_PER_SEGMENT = 16
     yield cfg

--- a/tests/loaddata/test_video_access.py
+++ b/tests/loaddata/test_video_access.py
@@ -78,12 +78,12 @@ def test_get_source_target(source_cfg, target_cfg, valid_ratio, weight_type, dat
     cfg.DATASET.WEIGHT_TYPE = weight_type
     cfg.DATASET.SIZE_TYPE = datasize_type
 
-    download_file_by_url(
-        url=url,
-        output_directory=str(Path(cfg.DATASET.ROOT).parent.absolute()),
-        output_file_name="video_test_data.zip",
-        file_format="zip",
-    )
+    # download_file_by_url(
+    #     url=url,
+    #     output_directory=str(Path(cfg.DATASET.ROOT).parent.absolute()),
+    #     output_file_name="video_test_data.zip",
+    #     file_format="zip",
+    # )
 
     # test get_source_target
     source, target, num_classes = VideoDataset.get_source_target(

--- a/tests/pipeline/test_multiomics_trainer.py
+++ b/tests/pipeline/test_multiomics_trainer.py
@@ -46,7 +46,7 @@ def test_model(num_classes, url):
         num_modalities=num_modalities,
         num_classes=num_classes,
         edge_per_node=10,
-        # url=url,
+        url=url,
         random_split=False,
         train_size=0.7,
         equal_weight=False,

--- a/tests/pipeline/test_multiomics_trainer.py
+++ b/tests/pipeline/test_multiomics_trainer.py
@@ -46,7 +46,7 @@ def test_model(num_classes, url):
         num_modalities=num_modalities,
         num_classes=num_classes,
         edge_per_node=10,
-        url=url,
+        # url=url,
         random_split=False,
         train_size=0.7,
         equal_weight=False,

--- a/tests/pipeline/test_uncertainty_qbin_pipeline.py
+++ b/tests/pipeline/test_uncertainty_qbin_pipeline.py
@@ -10,8 +10,6 @@ import kale.utils.logger as logging
 from kale.embed.uncertainty_fitting import fit_and_predict
 from kale.interpret.uncertainty_quantiles import generate_fig_comparing_bins, generate_fig_individual_bin_comparison
 
-# from kale.utils.download import download_file_by_url
-
 
 @pytest.fixture(scope="module")
 def testing_cfg():
@@ -178,8 +176,6 @@ def test_qbin_pipeline(testing_cfg):
 
     # ---- setup dataset ----
     base_dir = testing_cfg["DATASET"]["BASE_DIR"]
-
-    # download data if necessary
 
     uncertainty_pairs_val = testing_cfg["DATASET"]["UE_PAIRS_VAL"]
     uncertainty_pairs_test = testing_cfg["DATASET"]["UE_PAIRS_TEST"]

--- a/tests/pipeline/test_uncertainty_qbin_pipeline.py
+++ b/tests/pipeline/test_uncertainty_qbin_pipeline.py
@@ -9,7 +9,8 @@ import seaborn as sns
 import kale.utils.logger as logging
 from kale.embed.uncertainty_fitting import fit_and_predict
 from kale.interpret.uncertainty_quantiles import generate_fig_comparing_bins, generate_fig_individual_bin_comparison
-from kale.utils.download import download_file_by_url
+
+# from kale.utils.download import download_file_by_url
 
 
 @pytest.fixture(scope="module")
@@ -179,7 +180,7 @@ def test_qbin_pipeline(testing_cfg):
     base_dir = testing_cfg["DATASET"]["BASE_DIR"]
 
     # download data if necessary
-   
+
     uncertainty_pairs_val = testing_cfg["DATASET"]["UE_PAIRS_VAL"]
     uncertainty_pairs_test = testing_cfg["DATASET"]["UE_PAIRS_TEST"]
     gt_test_error_available = testing_cfg["DATASET"]["GROUND_TRUTH_TEST_ERRORS_AVAILABLE"]

--- a/tests/pipeline/test_uncertainty_qbin_pipeline.py
+++ b/tests/pipeline/test_uncertainty_qbin_pipeline.py
@@ -179,17 +179,7 @@ def test_qbin_pipeline(testing_cfg):
     base_dir = testing_cfg["DATASET"]["BASE_DIR"]
 
     # download data if necessary
-    if testing_cfg["DATASET"]["SOURCE"] is not None:
-        logger.info("Downloading data...")
-        data_file_name = "%s.%s" % (base_dir, testing_cfg["DATASET"]["FILE_FORMAT"])
-        download_file_by_url(
-            testing_cfg["DATASET"]["SOURCE"],
-            testing_cfg["DATASET"]["ROOT"],
-            data_file_name,
-            file_format=testing_cfg["DATASET"]["FILE_FORMAT"],
-        )
-        logger.info("Data downloaded to %s!", testing_cfg["DATASET"]["ROOT"] + base_dir)
-
+   
     uncertainty_pairs_val = testing_cfg["DATASET"]["UE_PAIRS_VAL"]
     uncertainty_pairs_test = testing_cfg["DATASET"]["UE_PAIRS_TEST"]
     gt_test_error_available = testing_cfg["DATASET"]["GROUND_TRUTH_TEST_ERRORS_AVAILABLE"]

--- a/tests/pipeline/test_video_domain_adapter.py
+++ b/tests/pipeline/test_video_domain_adapter.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import pytest
 from yacs.config import CfgNode
@@ -10,9 +10,6 @@ from kale.predict.class_domain_nets import ClassNetVideo, DomainNetVideo
 from kale.utils.seed import set_seed
 from tests.helpers.boring_model import VideoBoringModel
 from tests.helpers.pipe_test_helper import ModelTestHelper
-
-# from pathlib import Path
-
 
 SOURCES = [
     "ADL;7;adl_P_11_train.pkl;adl_P_11_test.pkl",
@@ -29,14 +26,14 @@ VALID_RATIO = 0.1
 seed = 36
 set_seed(seed)
 
-root_dir = os.path.dirname(os.path.dirname(os.getcwd()))
+root_dir = str(Path.cwd().parent.parent)
 
 
 @pytest.fixture(scope="module")
 def testing_cfg(download_path):
     cfg = CfgNode()
     cfg.DATASET = CfgNode()
-    cfg.DATASET.ROOT = download_path + "/video_test_data/"
+    cfg.DATASET.ROOT = str(Path(download_path) / "video_test_data")
     cfg.DAN = CfgNode()
     cfg.DATASET.FRAMES_PER_SEGMENT = 16
     yield cfg
@@ -79,14 +76,6 @@ def test_video_domain_adapter(source_cfg, target_cfg, image_modality, da_method,
     cfg.DATASET.WEIGHT_TYPE = WEIGHT_TYPE
     cfg.DATASET.SIZE_TYPE = DATASIZE_TYPE
     cfg.DAN.USERANDOM = False
-
-    # download example data
-    # download_file_by_url(
-    #     url=url,
-    #     output_directory=str(Path(cfg.DATASET.ROOT).parent.absolute()),
-    #     output_file_name="video_test_data.zip",
-    #     file_format="zip",
-    # )
 
     # build dataset
     source, target, num_classes = VideoDataset.get_source_target(

--- a/tests/pipeline/test_video_domain_adapter.py
+++ b/tests/pipeline/test_video_domain_adapter.py
@@ -29,7 +29,6 @@ seed = 36
 set_seed(seed)
 
 root_dir = os.path.dirname(os.path.dirname(os.getcwd()))
-url = "https://github.com/pykale/data/raw/main/videos/video_test_data.zip"
 
 
 @pytest.fixture(scope="module")
@@ -37,7 +36,6 @@ def testing_cfg(download_path):
     cfg = CfgNode()
     cfg.DATASET = CfgNode()
     cfg.DAN = CfgNode()
-    cfg.DATASET.ROOT = root_dir + "/" + download_path + "/video_test_data/"
     cfg.DATASET.FRAMES_PER_SEGMENT = 16
     yield cfg
 
@@ -81,12 +79,12 @@ def test_video_domain_adapter(source_cfg, target_cfg, image_modality, da_method,
     cfg.DAN.USERANDOM = False
 
     # download example data
-    download_file_by_url(
-        url=url,
-        output_directory=str(Path(cfg.DATASET.ROOT).parent.absolute()),
-        output_file_name="video_test_data.zip",
-        file_format="zip",
-    )
+    # download_file_by_url(
+    #     url=url,
+    #     output_directory=str(Path(cfg.DATASET.ROOT).parent.absolute()),
+    #     output_file_name="video_test_data.zip",
+    #     file_format="zip",
+    # )
 
     # build dataset
     source, target, num_classes = VideoDataset.get_source_target(

--- a/tests/pipeline/test_video_domain_adapter.py
+++ b/tests/pipeline/test_video_domain_adapter.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 
 import pytest
 from yacs.config import CfgNode
@@ -8,10 +7,12 @@ from kale.loaddata.video_access import VideoDataset
 from kale.loaddata.video_multi_domain import VideoMultiDomainDatasets
 from kale.pipeline import domain_adapter, video_domain_adapter
 from kale.predict.class_domain_nets import ClassNetVideo, DomainNetVideo
-from kale.utils.download import download_file_by_url
 from kale.utils.seed import set_seed
 from tests.helpers.boring_model import VideoBoringModel
 from tests.helpers.pipe_test_helper import ModelTestHelper
+
+# from pathlib import Path
+
 
 SOURCES = [
     "ADL;7;adl_P_11_train.pkl;adl_P_11_test.pkl",
@@ -35,6 +36,7 @@ root_dir = os.path.dirname(os.path.dirname(os.getcwd()))
 def testing_cfg(download_path):
     cfg = CfgNode()
     cfg.DATASET = CfgNode()
+    cfg.DATASET.ROOT = download_path + "/video_test_data/"
     cfg.DAN = CfgNode()
     cfg.DATASET.FRAMES_PER_SEGMENT = 16
     yield cfg

--- a/tests/pipeline/test_video_domain_adapter.py
+++ b/tests/pipeline/test_video_domain_adapter.py
@@ -1,4 +1,3 @@
-
 import os
 
 import pytest
@@ -31,6 +30,7 @@ seed = 36
 set_seed(seed)
 
 root_dir = os.path.dirname(os.path.dirname(os.getcwd()))
+
 
 @pytest.fixture(scope="module")
 def testing_cfg(download_path):

--- a/tests/prepdata/test_image_transform.py
+++ b/tests/prepdata/test_image_transform.py
@@ -9,10 +9,7 @@ from kale.interpret.visualize import plot_multi_images
 from kale.loaddata.image_access import check_dicom_series_uid, dicom2arraylist, read_dicom_dir
 from kale.prepdata.image_transform import mask_img_stack, normalize_img_stack, reg_img_stack, rescale_img_stack
 
-# from kale.utils.download import download_file_by_url
-
 SCALES = [4, 8]
-# cmr_url = "https://github.com/pykale/data/raw/main/images/ShefPAH-179/SA_64x64_v2.0.zip"
 
 
 @pytest.fixture(scope="module")

--- a/tests/prepdata/test_image_transform.py
+++ b/tests/prepdata/test_image_transform.py
@@ -16,7 +16,6 @@ cmr_url = "https://github.com/pykale/data/raw/main/images/ShefPAH-179/SA_64x64_v
 
 @pytest.fixture(scope="module")
 def images(download_path):
-    download_file_by_url(cmr_url, download_path, "SA_64x64.zip", "zip")
     img_path = os.path.join(download_path, "SA_64x64_v2.0", "DICOM")
     cmr_dcm_list = read_dicom_dir(img_path, sort_instance=True, sort_patient=True, check_series_uid=True)
     dcms = []

--- a/tests/prepdata/test_image_transform.py
+++ b/tests/prepdata/test_image_transform.py
@@ -8,10 +8,11 @@ from numpy import testing
 from kale.interpret.visualize import plot_multi_images
 from kale.loaddata.image_access import check_dicom_series_uid, dicom2arraylist, read_dicom_dir
 from kale.prepdata.image_transform import mask_img_stack, normalize_img_stack, reg_img_stack, rescale_img_stack
-from kale.utils.download import download_file_by_url
+
+# from kale.utils.download import download_file_by_url
 
 SCALES = [4, 8]
-cmr_url = "https://github.com/pykale/data/raw/main/images/ShefPAH-179/SA_64x64_v2.0.zip"
+# cmr_url = "https://github.com/pykale/data/raw/main/images/ShefPAH-179/SA_64x64_v2.0.zip"
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 from tdc.multi_pred import DTI
 from torchvision import datasets
@@ -10,84 +10,67 @@ from kale.utils.download import download_file_by_url
 
 
 def download_path():
-    path = os.path.join("tests", "test_data")
-    os.makedirs(path, exist_ok=True)
-    return path
+    path = Path("tests") / "test_data"
+    path.mkdir(parents=True, exist_ok=True)
+    return str(path)
 
 
-download_path = download_path()
+path_test_data = download_path()
 
 
 # tests/conftest.py
 # gait gallery data
-gait_url = "https://github.com/pykale/data/raw/main/videos/gait/gait_gallery_data.mat"
+url = "https://github.com/pykale/data/raw/main/videos/gait/gait_gallery_data.mat"
+download_file_by_url(url, path_test_data, "gait.mat", "mat")
 # Landmark Global fixtures
-landmark_uncertainty_url = (
-    "https://github.com/pykale/data/raw/main/tabular/cardiac_landmark_uncertainty/Uncertainty_tuples.zip"
-)
-
-download_file_by_url(gait_url, download_path, "gait.mat", "mat")
-download_file_by_url(landmark_uncertainty_url, download_path, "Uncertainty_tuples.zip", "zip")
+url = "https://github.com/pykale/data/raw/main/tabular/cardiac_landmark_uncertainty/Uncertainty_tuples.zip"
+download_file_by_url(url, path_test_data, "Uncertainty_tuples.zip", "zip")
 
 
 # MPCA
 # tests/embed/test_factorization.py
-baseline_url = "https://github.com/pykale/data/raw/main/videos/gait/mpca_baseline.mat"
-download_file_by_url(baseline_url, download_path, "baseline.mat", "mat")
+url = "https://github.com/pykale/data/raw/main/videos/gait/mpca_baseline.mat"
+download_file_by_url(url, path_test_data, "baseline.mat", "mat")
 
 
 # tests/loaddata/test_video_access.py
 # tests/pipeline/test_video_domain_adapter.py
 # Downloading Test Video Data
 url = "https://github.com/pykale/data/raw/main/videos/video_test_data.zip"
-root_dir = os.path.dirname(os.path.dirname(os.getcwd()))
-
-# dataset_root =  download_path + "/video_test_data/"
-download_file_by_url(url=url, output_directory=download_path, output_file_name="video_test_data.zip", file_format="zip")
+download_file_by_url(
+    url=url, output_directory=path_test_data, output_file_name="video_test_data.zip", file_format="zip"
+)
 
 
 # tests/pipeline/test_multiomics_trainer.py
 # Downloading Binary Class and Multi Class Multiomics Dataset
-binary_class_data_url = "https://github.com/pykale/data/raw/main/multiomics/ROSMAP.zip"
-multi_class_data_url = "https://github.com/pykale/data/raw/main/multiomics/TCGA_BRCA.zip"
-
-dataset_root = str(download_path) + "/multiomics/trainer/binary_class/"
+url = "https://github.com/pykale/data/raw/main/multiomics/ROSMAP.zip"
+dataset_root = str(Path(path_test_data) / "multiomics/trainer/binary_class/")
 download_file_by_url(
-    url=binary_class_data_url,
+    url=url,
     output_directory=dataset_root,
     output_file_name="binary_class.zip",
     file_format="zip",
 )
-
-dataset_root = str(download_path) + "/multiomics/trainer/multi_class/"
-download_file_by_url(
-    url=multi_class_data_url, output_directory=dataset_root, output_file_name="multi_class.zip", file_format="zip"
-)
+url = "https://github.com/pykale/data/raw/main/multiomics/TCGA_BRCA.zip"
+dataset_root = str(Path(path_test_data) / "multiomics/trainer/multi_class/")
+download_file_by_url(url=url, output_directory=dataset_root, output_file_name="multi_class.zip", file_format="zip")
 
 # tests/prepdata/test_image_transform.py
 # Downloading CMR Dataset
-cmr_url = "https://github.com/pykale/data/raw/main/images/ShefPAH-179/SA_64x64_v2.0.zip"
-download_file_by_url(cmr_url, download_path, "SA_64x64.zip", "zip")
+url = "https://github.com/pykale/data/raw/main/images/ShefPAH-179/SA_64x64_v2.0.zip"
+download_file_by_url(url, path_test_data, "SA_64x64.zip", "zip")
+
+office_path = str(Path(path_test_data) / "office")
 
 
-# tests/prepdata/test_image_access.py
-# Downloading various datasets including MNIST, MNISTM, USPS, SVHN, CIFAR10, and CIFAR100
-def office_path(download_path):
-    path_ = os.path.join(download_path, "office")
-    os.makedirs(path_, exist_ok=True)
-    return path_
-
-
-office_path = office_path(download_path)
-
-
-datasets.MNIST(download_path, train=True, transform=get_transform("mnistm"), download=True)
-MNISTM(download_path, train=True, transform=get_transform("mnistm"), download=True)
-USPS(download_path, train=True, transform=get_transform("mnistm"), download=True)
-datasets.SVHN(download_path, split="train", transform=get_transform("mnistm"), download=True)
-datasets.SVHN(download_path, split="test", transform=get_transform("mnistm"), download=True)
-datasets.CIFAR10(download_path, train=True, download=True, transform=get_transform("cifar", augment=True))
-datasets.CIFAR100(download_path, train=True, download=True, transform=get_transform("cifar", augment=True))
+datasets.MNIST(path_test_data, train=True, transform=get_transform("mnistm"), download=True)
+MNISTM(path_test_data, train=True, transform=get_transform("mnistm"), download=True)
+USPS(path_test_data, train=True, transform=get_transform("mnistm"), download=True)
+datasets.SVHN(path_test_data, split="train", transform=get_transform("mnistm"), download=True)
+datasets.SVHN(path_test_data, split="test", transform=get_transform("mnistm"), download=True)
+datasets.CIFAR10(path_test_data, train=True, download=True, transform=get_transform("cifar", augment=True))
+datasets.CIFAR100(path_test_data, train=True, download=True, transform=get_transform("cifar", augment=True))
 
 
 OFFICE_DOMAINS = ["amazon", "caltech", "dslr", "webcam"]
@@ -102,4 +85,4 @@ for domain_ in OFFICE_DOMAINS:
 SOURCES = ["BindingDB_Kd", "BindingDB_Ki"]
 
 for source_name in SOURCES:
-    test_dataset = DTI(name=source_name, path=download_path)
+    test_dataset = DTI(name=source_name, path=path_test_data)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,117 @@
+import os
+
+import pytest
+from scipy.io import loadmat
+from pathlib import Path
+from yacs.config import CfgNode
+from kale.loaddata.mnistm import MNISTM
+from kale.loaddata.usps import USPS
+from kale.prepdata.image_transform import get_transform
+
+from kale.utils.download import download_file_by_url
+from kale.loaddata.image_access import DigitDataset, DigitDatasetAccess, get_cifar, ImageAccess
+from torchvision import datasets, transforms
+
+# # @pytest.fixture(scope="session")
+def download_path():
+    path = os.path.join("tests", "test_data")
+    os.makedirs(path, exist_ok=True)
+    return path
+
+download_path = download_path()
+
+
+#tests/conftest.py
+gait_url = "https://github.com/pykale/data/raw/main/videos/gait/gait_gallery_data.mat"
+landmark_uncertainty_url = (
+    "https://github.com/pykale/data/raw/main/tabular/cardiac_landmark_uncertainty/Uncertainty_tuples.zip"
+)
+
+download_file_by_url(gait_url, download_path, "gait.mat", "mat")
+download_file_by_url(landmark_uncertainty_url, download_path, "Uncertainty_tuples.zip", "zip")
+
+
+
+#tests/embed/test_factorization.py
+baseline_url = "https://github.com/pykale/data/raw/main/videos/gait/mpca_baseline.mat"
+download_file_by_url(baseline_url, download_path, "baseline.mat", "mat")
+
+
+
+
+
+
+
+
+#tests/loaddata/test_video_access.py
+#tests/pipeline/test_video_domain_adapter.py
+url = "https://github.com/pykale/data/raw/main/videos/video_test_data.zip"
+root_dir = os.path.dirname(os.path.dirname(os.getcwd()))
+
+# dataset_root =  download_path + "/video_test_data/"
+download_file_by_url(
+        url=url,
+        output_directory=download_path,
+        output_file_name="video_test_data.zip",
+        file_format="zip",
+    )
+
+
+
+#tests/pipeline/test_multiomics_trainer.py
+binary_class_data_url = "https://github.com/pykale/data/raw/main/multiomics/ROSMAP.zip"
+multi_class_data_url = "https://github.com/pykale/data/raw/main/multiomics/TCGA_BRCA.zip"
+
+dataset_root = download_path + "/multiomics/trainer/binary_class/"
+download_file_by_url(
+        url=binary_class_data_url,
+        output_directory=dataset_root,
+        output_file_name="binary_class.zip",
+        file_format="zip",
+    )
+
+dataset_root = download_path + "/multiomics/trainer/multi_class/"
+download_file_by_url(
+        url=multi_class_data_url,
+        output_directory=dataset_root,
+        output_file_name="multi_class.zip",
+        file_format="zip",
+    )
+
+
+#tests/prepdata/test_image_transform.py
+cmr_url = "https://github.com/pykale/data/raw/main/images/ShefPAH-179/SA_64x64_v2.0.zip"
+download_file_by_url(cmr_url, download_path, "SA_64x64.zip", "zip")
+
+
+#tests/prepdata/test_image_access.py
+def office_path(download_path):
+    path_ = os.path.join(download_path, "office")
+    os.makedirs(path_, exist_ok=True)
+    return path_
+
+office_path = office_path(download_path)
+
+
+datasets.MNIST(download_path, train=True, transform=get_transform("mnistm"), download=True)
+MNISTM(download_path, train=True, transform=get_transform("mnistm"), download=True)
+USPS(download_path, train=True, transform=get_transform("mnistm"), download=True)
+datasets.SVHN(download_path, split="train", transform=get_transform("mnistm"), download=True)
+datasets.SVHN(download_path, split="test", transform=get_transform("mnistm"), download=True)
+datasets.CIFAR10(download_path, train=True, download=True, transform=get_transform("cifar", augment=True))
+datasets.CIFAR100(download_path, train=True, download=True, transform=get_transform("cifar", augment=True))
+
+
+OFFICE_DOMAINS = ["amazon", "caltech", "dslr", "webcam"]
+url = "https://github.com/pykale/data/raw/main/images/office"
+for domain_ in OFFICE_DOMAINS:
+    filename = "%s.zip" % domain_
+    data_url = "%s/%s" % (url, filename)
+    download_file_by_url(data_url, office_path, filename, "zip")
+
+
+#tests/utils/test_download.py
+PARAM = [
+    "https://github.com/pykale/data/raw/main/videos/video_test_data/ADL/annotations/labels_train_test/adl_P_11_train.pkl;a.pkl;pkl",
+    "https://github.com/pykale/data/raw/main/videos/video_test_data.zip;video_test_data.zip;zip",
+]

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -53,7 +53,10 @@ multi_class_data_url = "https://github.com/pykale/data/raw/main/multiomics/TCGA_
 
 dataset_root = str(download_path) + "/multiomics/trainer/binary_class/"
 download_file_by_url(
-    url=binary_class_data_url, output_directory=dataset_root, output_file_name="binary_class.zip", file_format="zip",
+    url=binary_class_data_url,
+    output_directory=dataset_root,
+    output_file_name="binary_class.zip",
+    file_format="zip",
 )
 
 dataset_root = str(download_path) + "/multiomics/trainer/multi_class/"

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -18,32 +18,29 @@ def download_path():
 path_test_data = download_path()
 
 
-# tests/conftest.py
-# gait gallery data
+# Downloading gait gallery data for tests/conftest.py test
 url = "https://github.com/pykale/data/raw/main/videos/gait/gait_gallery_data.mat"
 download_file_by_url(url, path_test_data, "gait.mat", "mat")
-# Landmark Global fixtures
+# Downloading Landmark Global fixtures data for tests/conftest.py test
 url = "https://github.com/pykale/data/raw/main/tabular/cardiac_landmark_uncertainty/Uncertainty_tuples.zip"
 download_file_by_url(url, path_test_data, "Uncertainty_tuples.zip", "zip")
 
 
-# MPCA
-# tests/embed/test_factorization.py
+# 
+# Downloading MPCA data for tests/embed/test_factorization.py test
 url = "https://github.com/pykale/data/raw/main/videos/gait/mpca_baseline.mat"
 download_file_by_url(url, path_test_data, "baseline.mat", "mat")
 
 
-# tests/loaddata/test_video_access.py
-# tests/pipeline/test_video_domain_adapter.py
-# Downloading Test Video Data
+# Downloading Test Video Data for tests/loaddata/test_video_access.py and tests/pipeline/test_video_domain_adapter.py test
 url = "https://github.com/pykale/data/raw/main/videos/video_test_data.zip"
 download_file_by_url(
     url=url, output_directory=path_test_data, output_file_name="video_test_data.zip", file_format="zip"
 )
 
 
-# tests/pipeline/test_multiomics_trainer.py
-# Downloading Binary Class and Multi Class Multiomics Dataset
+
+# Downloading Binary Class and Multi Class Multiomics Dataset for tests/pipeline/test_multiomics_trainer.py test
 url = "https://github.com/pykale/data/raw/main/multiomics/ROSMAP.zip"
 dataset_root = str(Path(path_test_data) / "multiomics/trainer/binary_class/")
 download_file_by_url(
@@ -56,14 +53,12 @@ url = "https://github.com/pykale/data/raw/main/multiomics/TCGA_BRCA.zip"
 dataset_root = str(Path(path_test_data) / "multiomics/trainer/multi_class/")
 download_file_by_url(url=url, output_directory=dataset_root, output_file_name="multi_class.zip", file_format="zip")
 
-# tests/prepdata/test_image_transform.py
-# Downloading CMR Dataset
+# Downloading CMR Dataset for tests/prepdata/test_image_transform.py test
 url = "https://github.com/pykale/data/raw/main/images/ShefPAH-179/SA_64x64_v2.0.zip"
 download_file_by_url(url, path_test_data, "SA_64x64.zip", "zip")
 
-office_path = str(Path(path_test_data) / "office")
 
-
+# Downloading MNISTM, USPS, SVHN, CIFAR10, CIFAR100 for tests/loaddata/test_image_access.py test
 datasets.MNIST(path_test_data, train=True, transform=get_transform("mnistm"), download=True)
 MNISTM(path_test_data, train=True, transform=get_transform("mnistm"), download=True)
 USPS(path_test_data, train=True, transform=get_transform("mnistm"), download=True)
@@ -73,6 +68,8 @@ datasets.CIFAR10(path_test_data, train=True, download=True, transform=get_transf
 datasets.CIFAR100(path_test_data, train=True, download=True, transform=get_transform("cifar", augment=True))
 
 
+# Downloading Office-31 Dataset for tests/loaddata/test_image_access.py test
+office_path = str(Path(path_test_data) / "office")
 OFFICE_DOMAINS = ["amazon", "caltech", "dslr", "webcam"]
 url = "https://github.com/pykale/data/raw/main/images/office"
 for domain_ in OFFICE_DOMAINS:
@@ -81,8 +78,7 @@ for domain_ in OFFICE_DOMAINS:
     download_file_by_url(data_url, office_path, filename, "zip")
 
 
-# Downloading Drug-Target Interaction (DTI) Datasets
+# Downloading Drug-Target Interaction (DTI) Datasets for tests/loaddata/test_tdc_datasets.py test
 SOURCES = ["BindingDB_Kd", "BindingDB_Ki"]
-
 for source_name in SOURCES:
     test_dataset = DTI(name=source_name, path=path_test_data)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -26,7 +26,7 @@ url = "https://github.com/pykale/data/raw/main/tabular/cardiac_landmark_uncertai
 download_file_by_url(url, path_test_data, "Uncertainty_tuples.zip", "zip")
 
 
-# 
+#
 # Downloading MPCA data for tests/embed/test_factorization.py test
 url = "https://github.com/pykale/data/raw/main/videos/gait/mpca_baseline.mat"
 download_file_by_url(url, path_test_data, "baseline.mat", "mat")
@@ -37,7 +37,6 @@ url = "https://github.com/pykale/data/raw/main/videos/video_test_data.zip"
 download_file_by_url(
     url=url, output_directory=path_test_data, output_file_name="video_test_data.zip", file_format="zip"
 )
-
 
 
 # Downloading Binary Class and Multi Class Multiomics Dataset for tests/pipeline/test_multiomics_trainer.py test

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,28 +1,27 @@
 import os
 
-import pytest
-from scipy.io import loadmat
-from pathlib import Path
-from yacs.config import CfgNode
+from tdc.multi_pred import DTI
+from torchvision import datasets
+
 from kale.loaddata.mnistm import MNISTM
 from kale.loaddata.usps import USPS
 from kale.prepdata.image_transform import get_transform
-
 from kale.utils.download import download_file_by_url
-from kale.loaddata.image_access import DigitDataset, DigitDatasetAccess, get_cifar, ImageAccess
-from torchvision import datasets, transforms
 
-# # @pytest.fixture(scope="session")
+
 def download_path():
     path = os.path.join("tests", "test_data")
     os.makedirs(path, exist_ok=True)
     return path
 
+
 download_path = download_path()
 
 
-#tests/conftest.py
+# tests/conftest.py
+# gait gallery data
 gait_url = "https://github.com/pykale/data/raw/main/videos/gait/gait_gallery_data.mat"
+# Landmark Global fixtures
 landmark_uncertainty_url = (
     "https://github.com/pykale/data/raw/main/tabular/cardiac_landmark_uncertainty/Uncertainty_tuples.zip"
 )
@@ -31,64 +30,50 @@ download_file_by_url(gait_url, download_path, "gait.mat", "mat")
 download_file_by_url(landmark_uncertainty_url, download_path, "Uncertainty_tuples.zip", "zip")
 
 
-
-#tests/embed/test_factorization.py
+# MPCA
+# tests/embed/test_factorization.py
 baseline_url = "https://github.com/pykale/data/raw/main/videos/gait/mpca_baseline.mat"
 download_file_by_url(baseline_url, download_path, "baseline.mat", "mat")
 
 
-
-
-
-
-
-
-#tests/loaddata/test_video_access.py
-#tests/pipeline/test_video_domain_adapter.py
+# tests/loaddata/test_video_access.py
+# tests/pipeline/test_video_domain_adapter.py
+# Downloading Test Video Data
 url = "https://github.com/pykale/data/raw/main/videos/video_test_data.zip"
 root_dir = os.path.dirname(os.path.dirname(os.getcwd()))
 
 # dataset_root =  download_path + "/video_test_data/"
-download_file_by_url(
-        url=url,
-        output_directory=download_path,
-        output_file_name="video_test_data.zip",
-        file_format="zip",
-    )
+download_file_by_url(url=url, output_directory=download_path, output_file_name="video_test_data.zip", file_format="zip")
 
 
-
-#tests/pipeline/test_multiomics_trainer.py
+# tests/pipeline/test_multiomics_trainer.py
+# Downloading Binary Class and Multi Class Multiomics Dataset
 binary_class_data_url = "https://github.com/pykale/data/raw/main/multiomics/ROSMAP.zip"
 multi_class_data_url = "https://github.com/pykale/data/raw/main/multiomics/TCGA_BRCA.zip"
 
-dataset_root = download_path + "/multiomics/trainer/binary_class/"
+dataset_root = str(download_path) + "/multiomics/trainer/binary_class/"
 download_file_by_url(
-        url=binary_class_data_url,
-        output_directory=dataset_root,
-        output_file_name="binary_class.zip",
-        file_format="zip",
-    )
+    url=binary_class_data_url, output_directory=dataset_root, output_file_name="binary_class.zip", file_format="zip",
+)
 
-dataset_root = download_path + "/multiomics/trainer/multi_class/"
+dataset_root = str(download_path) + "/multiomics/trainer/multi_class/"
 download_file_by_url(
-        url=multi_class_data_url,
-        output_directory=dataset_root,
-        output_file_name="multi_class.zip",
-        file_format="zip",
-    )
+    url=multi_class_data_url, output_directory=dataset_root, output_file_name="multi_class.zip", file_format="zip"
+)
 
-
-#tests/prepdata/test_image_transform.py
+# tests/prepdata/test_image_transform.py
+# Downloading CMR Dataset
 cmr_url = "https://github.com/pykale/data/raw/main/images/ShefPAH-179/SA_64x64_v2.0.zip"
 download_file_by_url(cmr_url, download_path, "SA_64x64.zip", "zip")
 
 
-#tests/prepdata/test_image_access.py
+# tests/prepdata/test_image_access.py
+# Downloading various datasets including MNIST, MNISTM, USPS, SVHN, CIFAR10, and CIFAR100
 def office_path(download_path):
     path_ = os.path.join(download_path, "office")
     os.makedirs(path_, exist_ok=True)
     return path_
+
 
 office_path = office_path(download_path)
 
@@ -110,8 +95,8 @@ for domain_ in OFFICE_DOMAINS:
     download_file_by_url(data_url, office_path, filename, "zip")
 
 
-#tests/utils/test_download.py
-PARAM = [
-    "https://github.com/pykale/data/raw/main/videos/video_test_data/ADL/annotations/labels_train_test/adl_P_11_train.pkl;a.pkl;pkl",
-    "https://github.com/pykale/data/raw/main/videos/video_test_data.zip;video_test_data.zip;zip",
-]
+# Downloading Drug-Target Interaction (DTI) Datasets
+SOURCES = ["BindingDB_Kd", "BindingDB_Ki"]
+
+for source_name in SOURCES:
+    test_dataset = DTI(name=source_name, path=download_path)


### PR DESCRIPTION
Fixes #419.

### Description
Split the code for downloading into `tests/test_data.py`. All downloaded data will be stored in the `test/test_data` directory. Some files will still be generated in the `test_data` folder while running `pytest`, as a result of data preprocessing.

Use `cfg.DATASET.DOWNLOAD` to control the download process in the `get_cifar` function located in `kale/loaddata/image_access.py`.

### Status
**Ready**



### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
