### PR TITLE
Refactor documentation and resolve module visibility issues

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -16,10 +16,13 @@ numpy
 
 pandas
 pillow>=6.2.0
+pwlf
+pydicom
 PyTDC
 pytorch-lightning
 rdkit
 recommonmark
+scikit-image
 scikit-learn
 sphinx-markdown-tables
 sphinx-rtd-theme

--- a/docs/source/kale.embed.rst
+++ b/docs/source/kale.embed.rst
@@ -23,7 +23,7 @@ kale.embed.factorization module
    :show-inheritance:
 
 kale.embed.feature\_fusion module
-------------------------------------
+---------------------------------
 
 .. automodule:: kale.embed.feature_fusion
    :members:
@@ -78,6 +78,15 @@ kale.embed.seq\_nn module
 -------------------------
 
 .. automodule:: kale.embed.seq_nn
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members:
+
+kale.embed.uncertainty\_fitting module
+--------------------------------------
+
+.. automodule:: kale.embed.uncertainty_fitting
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/kale.evaluate.rst
+++ b/docs/source/kale.evaluate.rst
@@ -7,7 +7,7 @@ Submodules
 ----------
 
 kale.evaluate.cross\_validation module
-----------------------------
+--------------------------------------
 
 .. automodule:: kale.evaluate.cross_validation
    :members:
@@ -22,8 +22,16 @@ kale.evaluate.metrics module
    :undoc-members:
    :show-inheritance:
 
+kale.evaluate.similarity\_metrics
+---------------------------------
+
+.. automodule:: kale.evaluate.similarity_metrics
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 kale.evaluate.uncertainty\_metrics
---------------------------------
+----------------------------------
 
 .. automodule:: kale.evaluate.uncertainty_metrics
    :members:

--- a/docs/source/kale.interpret.rst
+++ b/docs/source/kale.interpret.rst
@@ -15,8 +15,8 @@ kale.interpret.model\_weights module
    :show-inheritance:
 
 
-kale.interpret.uncertainty\_quantiles
---------------------------------
+kale.interpret.uncertainty\_quantiles module
+--------------------------------------------
 
 .. automodule:: kale.interpret.uncertainty_quantiles
    :members:

--- a/docs/source/kale.loaddata.rst
+++ b/docs/source/kale.loaddata.rst
@@ -6,6 +6,14 @@ Load Data
 Submodules
 ----------
 
+kale.loaddata.avmnist\_datasets module
+--------------------------------------
+
+.. automodule:: kale.loaddata.avmnist_datasets
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 kale.loaddata.dataset\_access module
 ------------------------------------
 
@@ -14,16 +22,8 @@ kale.loaddata.dataset\_access module
    :undoc-members:
    :show-inheritance:
 
-kale.loaddata.avmnist module
-----------------------------
-
-.. automodule:: kale.loaddata.avmnist
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-kale.loaddata.image\_access
----------------------------
+kale.loaddata.image\_access module
+----------------------------------
 
 .. automodule:: kale.loaddata.image_access
    :members:
@@ -71,7 +71,7 @@ kale.loaddata.sampler module
    :show-inheritance:
 
 kale.loaddata.tabular\_access module
-----------------------------------
+------------------------------------
 
 .. automodule:: kale.loaddata.tabular_access
    :members:

--- a/docs/source/kale.pipeline.rst
+++ b/docs/source/kale.pipeline.rst
@@ -47,7 +47,7 @@ kale.pipeline.multi\_domain\_adapter module
    :show-inheritance:
 
 kale.pipeline.multiomics\_trainer module
------------------------------------------
+----------------------------------------
 
 .. automodule:: kale.pipeline.multiomics_trainer
    :members:

--- a/docs/source/kale.prepdata.rst
+++ b/docs/source/kale.prepdata.rst
@@ -30,6 +30,14 @@ kale.prepdata.image\_transform module
    :undoc-members:
    :show-inheritance:
 
+kale.prepdata.string\_transform module
+-------------------------------------
+
+.. automodule:: kale.prepdata.string_transform
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 kale.prepdata.supergraph\_construct module
 ------------------------------------------
 

--- a/docs/source/kale.prepdata.rst
+++ b/docs/source/kale.prepdata.rst
@@ -58,14 +58,14 @@ kale.prepdata.video\_transform module
 -------------------------------------
 
 .. automodule:: kale.prepdata.video_transform
-	:members:
-	:exclude-members:
-	:show-inheritance:
+    :members:
+    :exclude-members:
+    :show-inheritance:
 
 Module contents
 ---------------
 
 .. automodule:: kale.prepdata
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/kale.prepdata.rst
+++ b/docs/source/kale.prepdata.rst
@@ -31,7 +31,7 @@ kale.prepdata.image\_transform module
    :show-inheritance:
 
 kale.prepdata.string\_transform module
--------------------------------------
+--------------------------------------
 
 .. automodule:: kale.prepdata.string_transform
    :members:

--- a/docs/source/kale.utils.rst
+++ b/docs/source/kale.utils.rst
@@ -46,6 +46,14 @@ kale.utils.print module
    :undoc-members:
    :show-inheritance:
 
+kale.utils.save\_xlsx module
+----------------------------
+
+.. automodule:: kale.utils.save_xlsx
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 kale.utils.seed module
 ----------------------
 

--- a/kale/evaluate/similarity_metrics.py
+++ b/kale/evaluate/similarity_metrics.py
@@ -17,13 +17,12 @@ from kale.prepdata.tabular_transform import apply_confidence_inversion
 def jaccard_similarity(list1: list, list2: list) -> float:
     """
     Calculates the Jaccard Index (JI) between two lists.
+
     Args:
         list1 (list): List of elements in set A.
         list2 (list): List of elements in set B.
     Returns:
-        float: JI between list1 and list2.
-    Raises:
-        None.
+        float: The Jaccard Index between list1 and list2.
     Example:
         >>> jaccard_similarity([1,2,3], [2,3,4])
         0.5

--- a/kale/interpret/uncertainty_quantiles.py
+++ b/kale/interpret/uncertainty_quantiles.py
@@ -1,5 +1,6 @@
 """
 Authors: Lawrence Schobs, lawrenceschobs@gmail.com
+
 Module from the implementation of L. A. Schobs, A. J. Swift and H. Lu, "Uncertainty Estimation for Heatmap-Based Landmark Localization,"
 in IEEE Transactions on Medical Imaging, vol. 42, no. 4, pp. 1021-1034, April 2023, doi: 10.1109/TMI.2022.3222730.
 
@@ -10,7 +11,7 @@ Functions related to interpreting the uncertainty quantiles from the quantile bi
    D) Plot cumularive error plots: plot_cumulative
    E) Big caller functions for analysis loop for QBinning:  generate_fig_individual_bin_comparison, generate_fig_comparing_bins
 
-   """
+"""
 import logging
 import math
 import os

--- a/kale/prepdata/supergraph_construct.py
+++ b/kale/prepdata/supergraph_construct.py
@@ -4,8 +4,8 @@
 # =============================================================================
 
 """
-The supergraph structure from the `"GripNet: Graph Information Propagation on Supergraph for Heterogeneous Graphs"
-    <https://doi.org/10.1016/j.patcog.2022.108973>`_ (PatternRecognit 2022) paper.
+The supergraph structure from the ``GripNet: Graph Information Propagation on Supergraph for Heterogeneous Graphs''
+    <https://doi.org/10.1016/j.patcog.2022.108973> _ (PatternRecognit 2022) paper.
 """
 
 import logging

--- a/kale/prepdata/supergraph_construct.py
+++ b/kale/prepdata/supergraph_construct.py
@@ -4,8 +4,8 @@
 # =============================================================================
 
 """
-The supergraph structure from the ``GripNet: Graph Information Propagation on Supergraph for Heterogeneous Graphs''
-    <https://doi.org/10.1016/j.patcog.2022.108973> _ (PatternRecognit 2022) paper.
+The supergraph structure from the Pattern Recognition 2022 paper "GripNet: Graph Information Propagation on Supergraph
+for Heterogeneous Graphs" <https://doi.org/10.1016/j.patcog.2022.108973>.
 """
 
 import logging

--- a/kale/utils/save_xlsx.py
+++ b/kale/utils/save_xlsx.py
@@ -17,6 +17,7 @@ def generate_summary_df(
     """
     Generates pandas dataframe with summary statistics.
     Designed for use in Quantile Binning (/pykale/examples/landmark_uncertainty/main.py).
+
     Args:
         results_dictionary (dict): A dictionary containing results for each quantile bin and uncertainty method.
             The keys are strings indicating the name of each uncertainty method.
@@ -65,18 +66,18 @@ def save_dict_xlsx(data_dict: Dict[Any, Any], save_location: str, sheet_name: st
     """
     Save a dictionary to an Excel file using the XlsxWriter engine.
 
-    Parameters:
-    data_dict (Dict[Any, Any]): The dictionary that needs to be saved to an Excel file. The keys represent the row index
-                                and the values represent the data in the row. If a dictionary value is a list or a
-                                series, each element in the list/series will be a column in the row.
+    Args:
+        data_dict (Dict[Any, Any]): The dictionary that needs to be saved to an Excel file. The keys represent the row
+                                    index and the values represent the data in the row. If a dictionary value is a list
+                                    or a series, each element in the list/series will be a column in the row.
 
-    save_location (str): The location where the Excel file will be saved. This should include the full path and the filename,
-                         for example, "/path/to/save/data.xlsx". Overwrites the file if it already exists.
+        save_location (str): The location where the Excel file will be saved. This should include the full path and the
+                            filename, for example, "/path/to/save/data.xlsx". Overwrites the file if it already exists.
 
-    sheet_name (str): The name of the sheet where the dictionary will be saved in the Excel file.
+        sheet_name (str): The name of the sheet where the dictionary will be saved in the Excel file.
 
     Returns:
-    None: This function does not return anything. It saves the dictionary as an Excel file at the specified location.
+        None: This function does not return anything. It saves the dictionary as an Excel file at the specified location.
     """
     pd_df = pd.DataFrame.from_dict(data_dict, orient="index")
 


### PR DESCRIPTION
Fixes #425.

### Description
Some documentations are not visible currently, due to the incorrect module name and non-alphabetically-sorted arrangement.

### Status
**Ready**

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [x] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
