### PR TITLE
Cache preload data

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,20 @@ jobs:
           pip install -e .[dev]
         shell: bash -l {0}
 
+
+      - name: Cache preload data
+        id: cache_data
+        uses: actions/cache@v2
+        with:
+          key: ${{ runner.os }}-python${{ matrix.python-version }}-pip-${{ hashFiles('**/tests/test_data.py') }}
+          restore-keys: |
+            ${{ runner.os }}-python${{ matrix.python-version }}-pip-${{ hashFiles('**/tests/test_data.py') }}
+          # Using the full hash of setup.py will cause the cache to be invalidated whenever the setup.py file changes.
+          # An alternative is to use 'restore-keys: ${{ runner.os }}-python${{ matrix.python-version }}-pip-', which is
+          # suggested by GitHub (https://github.com/davronaliyev/Cache-dependencies-in-GitHub-Actions/blob/main/examples.md#python---pip).
+          # However, it will restore the saved cache rather than create a new one even when the setup.py file changes.
+
+
       - name: Run tests
         id: run_tests
         run: |


### PR DESCRIPTION
Fixes #419.

### Description
Cache all data downloaded using `tests/test_data.py` so data can be called from the cache each time running the test.

### Status
**Work in progress**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
