### PR TITLE
Use a softer matching strategy for caching downloaded pip dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,13 +45,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ matrix.path }}
-          key: ${{ runner.os }}-python${{ matrix.python-version }}-pip-${{ hashFiles('**/setup.py') }}
+          key: ${{ runner.os }}-python${{ matrix.python-version }}-pip-20231130-${{ hashFiles('**/setup.py') }}
           restore-keys: |
-            ${{ runner.os }}-python${{ matrix.python-version }}-pip-${{ hashFiles('**/setup.py') }}
-          # Using the full hash of setup.py will cause the cache to be invalidated whenever the setup.py file changes.
-          # An alternative is to use 'restore-keys: ${{ runner.os }}-python${{ matrix.python-version }}-pip-', which is
-          # suggested by GitHub (https://github.com/davronaliyev/Cache-dependencies-in-GitHub-Actions/blob/main/examples.md#python---pip).
-          # However, it will restore the saved cache rather than create a new one even when the setup.py file changes.
+            ${{ runner.os }}-python${{ matrix.python-version }}-pip-20231130-
+          # We have used a softer matching strategy for the full hash of setup.py, as recommended by GitHub.
+          # See: https://github.com/davronaliyev/Cache-dependencies-in-GitHub-Actions/blob/main/examples.md#python---pip
+          # This restores the cache first and then downloads any changed packages to avoid updating the cache with
+          # every change to the setup.py file, thus reducing the storage requirements of GitHub Action.
+          # We set a date tag to the cache key to show the updated date of the cache. We can update this date tag to
+          # generate new cache after every major changes in setup.py.
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Improve #427 

### Description
I have adopted a softer matching strategy for the full hash of setup.py, as recommended by GitHub (See [here](https://github.com/davronaliyev/Cache-dependencies-in-GitHub-Actions/blob/main/examples.md#python---pip)).

This prioritizes restoring the cache first and then downloading any changed packages to avoid updating the cache with every change to `setup.py`, thus reducing the storage requirements of GitHub Actions. This can be faster and more efficient, especially when dependencies don't change frequently, as it allows for reusing caches even with minor modifications.

I set a date tag to the cache key to show the updated date of the cache, so I can update the cache by changing this tag after some major changes in `setup.py`.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
