### PR TITLE
Support Codecov, Action Cache, Action Checkout v4 & Setup-miniconda v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python using Miniconda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,4 +97,4 @@ jobs:
         shell: bash -l {0}
 
       - name: Report coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
             path: ~\AppData\Local\pip\Cache
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python using Miniconda
         uses: conda-incubator/setup-miniconda@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Cache pip dependencies
         id: cache_pip
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ matrix.path }}
           key: ${{ runner.os }}-python${{ matrix.python-version }}-pip-20240705-${{ hashFiles('**/setup.py') }}
@@ -71,7 +71,7 @@ jobs:
 
       - name: Cache downloaded test data
         id: cache_data
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: tests/test_data
           key: ${{ runner.os }}-python${{ matrix.python-version }}-data-${{ hashFiles('tests/download_test_data.py') }}


### PR DESCRIPTION
### Description
Upgrade to support Codecov v4, Action Cache v4, Action Cache v4 and Setup-miniconda v3. The new versions can provide more functions and settings, particularly Codecov. 

Monai provides an example of Codecov settings: [codecov.yml](https://github.com/Project-MONAI/MONAI/blob/main/.github/codecov.yml).

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
