### PR TITLE
Pin torch to 2.3.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,11 +60,11 @@ jobs:
           pip install rdkit
           pip install pyparsing==3.0.9
           pip install torch==2.3.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
-          pip install torchvision==0.15.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
-          pip install torch_scatter==2.1.1 -f https://data.pyg.org/whl/torch-2.0.0+cpu.html
-          pip install torch_sparse==0.6.18 -f https://data.pyg.org/whl/torch-2.0.0+cpu.html
-          pip install torch_cluster==1.6.3 -f https://data.pyg.org/whl/torch-2.0.0+cpu.html
-          pip install torch_spline_conv==1.2.2 -f https://data.pyg.org/whl/torch-2.0.0+cpu.html
+          pip install torchvision==0.18.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+          pip install torch_scatter==2.1.2 -f https://data.pyg.org/whl/torch-2.3.0+cpu.html
+          pip install torch_sparse==0.6.18 -f https://data.pyg.org/whl/torch-2.3.0+cpu.html
+          pip install torch_cluster==1.6.3 -f https://data.pyg.org/whl/torch-2.3.0+cpu.html
+          pip install torch_spline_conv==1.2.2 -f https://data.pyg.org/whl/torch-2.3.0+cpu.html
           pip install torch_geometric==2.3.0
           pip install -e .[dev]
         shell: bash -l {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           pip install rdkit
           pip install pyparsing==3.0.9
-          pip install torch==2.0.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+          pip install torch==2.3.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
           pip install torchvision==0.15.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
           pip install torch_scatter==2.1.1 -f https://data.pyg.org/whl/torch-2.0.0+cpu.html
           pip install torch_sparse==0.6.18 -f https://data.pyg.org/whl/torch-2.0.0+cpu.html

--- a/examples/bindingdb_deepdta/tutorial.ipynb
+++ b/examples/bindingdb_deepdta/tutorial.ipynb
@@ -333,19 +333,5 @@
       ],
       "cell_type": "markdown"
     },
-    {
-      "metadata": {},
-      "source": "",
-      "cell_type": "code",
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "metadata": {},
-      "source": "",
-      "cell_type": "code",
-      "outputs": [],
-      "execution_count": null
-    }
   ]
 }

--- a/examples/bindingdb_deepdta/tutorial.ipynb
+++ b/examples/bindingdb_deepdta/tutorial.ipynb
@@ -73,9 +73,9 @@
         "os.environ['TORCH'] = torch.__version__\n",
         "print(torch.__version__)\n",
         "\n",
-        "!pip install torch==2.3.0+cpu -f https://download.pytorch.org/whl/torch_stable.html\n",
-        "!pip install -q torch-scatter==2.1.2 -f https://pytorch-geometric.com/whl/torch-2.3.0+cpu.html\n",
-        "!pip install -q torch-sparse==0.6.18 -f https://pytorch-geometric.com/whl/torch-2.3.0+cpu.html\n",
+        "!pip install -q torch==2.3.0+cpu -f https://download.pytorch.org/whl/torch_stable.html\n",
+        "!pip install -q torch_scatter==2.1.2 -f https://data.pyg.org/whl/torch-2.3.0+cpu.html\n",
+        "!pip install -q torch_sparse==0.6.18 -f https://data.pyg.org/whl/torch-2.3.0+cpu.html\n",
         "!pip install -q torch-geometric==2.3.0\n",
         "!pip install tensorboard"
       ],
@@ -85,7 +85,9 @@
     },
     {
       "metadata": {},
-      "source": "This imports required modules.",
+      "source": [
+        "This imports required modules."
+      ],
       "cell_type": "markdown"
     },
     {
@@ -179,7 +181,9 @@
     },
     {
       "metadata": {},
-      "source": "cfg.DATASET.PATH",
+      "source": [
+        "cfg.DATASET.PATH"
+      ],
       "cell_type": "code",
       "outputs": [],
       "execution_count": null
@@ -206,7 +210,9 @@
     },
     {
       "metadata": {},
-      "source": "model = get_model(cfg)",
+      "source": [
+        "model = get_model(cfg)"
+      ],
       "cell_type": "code",
       "outputs": [],
       "execution_count": null
@@ -222,7 +228,9 @@
     },
     {
       "metadata": {},
-      "source": "tb_logger = TensorBoardLogger(\"outputs\", name=cfg.DATASET.NAME)",
+      "source": [
+        "tb_logger = TensorBoardLogger(\"outputs\", name=cfg.DATASET.NAME)"
+      ],
       "cell_type": "code",
       "outputs": [],
       "execution_count": null
@@ -261,7 +269,9 @@
     },
     {
       "metadata": {},
-      "source": "%time trainer.fit(model, train_dataloaders=train_loader, val_dataloaders=valid_loader)",
+      "source": [
+        "%time trainer.fit(model, train_dataloaders=train_loader, val_dataloaders=valid_loader)"
+      ],
       "cell_type": "code",
       "outputs": [],
       "execution_count": null
@@ -277,7 +287,9 @@
     },
     {
       "metadata": {},
-      "source": "trainer.test(dataloaders=test_loader)",
+      "source": [
+        "trainer.test(dataloaders=test_loader)"
+      ],
       "cell_type": "code",
       "outputs": [],
       "execution_count": null
@@ -332,6 +344,6 @@
         "Estimated Total Size (MB): 440.21"
       ],
       "cell_type": "markdown"
-    },
+    }
   ]
 }

--- a/examples/bindingdb_deepdta/tutorial.ipynb
+++ b/examples/bindingdb_deepdta/tutorial.ipynb
@@ -73,8 +73,9 @@
         "os.environ['TORCH'] = torch.__version__\n",
         "print(torch.__version__)\n",
         "\n",
-        "!pip install -q torch-scatter==2.1.1 -f https://pytorch-geometric.com/whl/torch-2.0.1+cpu.html\n",
-        "!pip install -q torch-sparse==0.6.17 -f https://pytorch-geometric.com/whl/torch-2.0.1+cpu.html\n",
+        "!pip install torch==2.3.0+cpu -f https://download.pytorch.org/whl/torch_stable.html\n",
+        "!pip install -q torch-scatter==2.1.2 -f https://pytorch-geometric.com/whl/torch-2.3.0+cpu.html\n",
+        "!pip install -q torch-sparse==0.6.18 -f https://pytorch-geometric.com/whl/torch-2.3.0+cpu.html\n",
         "!pip install -q torch-geometric==2.3.0\n",
         "!pip install tensorboard"
       ],
@@ -84,9 +85,7 @@
     },
     {
       "metadata": {},
-      "source": [
-        "This imports required modules."
-      ],
+      "source": "This imports required modules.",
       "cell_type": "markdown"
     },
     {
@@ -180,9 +179,7 @@
     },
     {
       "metadata": {},
-      "source": [
-        "cfg.DATASET.PATH"
-      ],
+      "source": "cfg.DATASET.PATH",
       "cell_type": "code",
       "outputs": [],
       "execution_count": null
@@ -209,9 +206,7 @@
     },
     {
       "metadata": {},
-      "source": [
-        "model = get_model(cfg)"
-      ],
+      "source": "model = get_model(cfg)",
       "cell_type": "code",
       "outputs": [],
       "execution_count": null
@@ -227,9 +222,7 @@
     },
     {
       "metadata": {},
-      "source": [
-        "tb_logger = TensorBoardLogger(\"outputs\", name=cfg.DATASET.NAME)"
-      ],
+      "source": "tb_logger = TensorBoardLogger(\"outputs\", name=cfg.DATASET.NAME)",
       "cell_type": "code",
       "outputs": [],
       "execution_count": null
@@ -268,9 +261,7 @@
     },
     {
       "metadata": {},
-      "source": [
-        "%time trainer.fit(model, train_dataloaders=train_loader, val_dataloaders=valid_loader)"
-      ],
+      "source": "%time trainer.fit(model, train_dataloaders=train_loader, val_dataloaders=valid_loader)",
       "cell_type": "code",
       "outputs": [],
       "execution_count": null
@@ -286,9 +277,7 @@
     },
     {
       "metadata": {},
-      "source": [
-        "trainer.test(dataloaders=test_loader)"
-      ],
+      "source": "trainer.test(dataloaders=test_loader)",
       "cell_type": "code",
       "outputs": [],
       "execution_count": null
@@ -343,6 +332,20 @@
         "Estimated Total Size (MB): 440.21"
       ],
       "cell_type": "markdown"
+    },
+    {
+      "metadata": {},
+      "source": "",
+      "cell_type": "code",
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "metadata": {},
+      "source": "",
+      "cell_type": "code",
+      "outputs": [],
+      "execution_count": null
     }
   ]
 }

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ install_requires = [
     "scikit-learn>=0.23.2",  # sure
     "scipy>=1.5.4",  # in factorization API only
     "tensorly>=0.5.1",  # in factorization and model_weights API only
-    "torch==2.3.0", # also change the version in the test.yaml when changing this next time, and update the pytorch version in the bindingdb_deepdta tutorial notebook
+    "torch==2.3.0",  # also change the version in the test.yaml when changing this next time, and update the pytorch version in the bindingdb_deepdta tutorial notebook
     "torchvision>=0.12.0",  # in download, sampler (NON-ideal), and vision API only
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ install_requires = [
     "scikit-learn>=0.23.2",  # sure
     "scipy>=1.5.4",  # in factorization API only
     "tensorly>=0.5.1",  # in factorization and model_weights API only
-    "torch==2.0.0",  # also change the version in the test.yaml when changing this next time
+    "torch==2.3.0",  # also change the version in the test.yaml when changing this next time
     "torchvision>=0.12.0",  # in download, sampler (NON-ideal), and vision API only
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ install_requires = [
     "scikit-learn>=0.23.2",  # sure
     "scipy>=1.5.4",  # in factorization API only
     "tensorly>=0.5.1",  # in factorization and model_weights API only
-    "torch==2.3.0",  # also change the version in the test.yaml when changing this next time
+    "torch==2.3.0", # also change the version in the test.yaml when changing this next time, and update the pytorch version in the bindingdb_deepdta tutorial notebook
     "torchvision>=0.12.0",  # in download, sampler (NON-ideal), and vision API only
 ]
 


### PR DESCRIPTION
Resolve failures in pytest related to the version of PyTorch used.

### Description
Modified libraries including: 
- torch==2.3.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
- torch_scatter==2.1.2 -f https://data.pyg.org/whl/torch-2.3.0+cpu.html
- torch_sparse==0.6.18 -f https://data.pyg.org/whl/torch-2.3.0+cpu.html
- torch_cluster==1.6.3 -f https://data.pyg.org/whl/torch-2.3.0+cpu.html
- torch_spline_conv==1.2.2 -f https://data.pyg.org/whl/torch-2.3.0+cpu.html

### Status
**Work in progress**


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
