### PR TITLE
452 scheduled test failed dec 9th 2024

### DIFF
--- a/tests/pipeline/test_multi_domain_adapter.py
+++ b/tests/pipeline/test_multi_domain_adapter.py
@@ -78,7 +78,8 @@ def test_coirls(kernel, office_caltech_access):
     x, y, z = next(iter(dataloader))
     tgt_idx = torch.where(z == 0)
     src_idx = torch.where(z != 0)
-    
+
+    # avoid saving computational graph to save memory
     with torch.no_grad():
         x_feat = feature_network(x)
         z_one_hot = one_hot(z)
@@ -88,6 +89,11 @@ def test_coirls(kernel, office_caltech_access):
     y_train = y[src_idx]
     z_train = torch.cat((z_one_hot[src_idx], z_one_hot[tgt_idx]))
 
+    # casting to numpy is an ad-hoc fix at the moment
+    # to fix device allocation issue with torch.Tensor
+    # where the device is set to cpu for both model and data
+    # but will remain to raise error when using sklearn
+    # functions
     x_train = x_train.numpy()
     y_train = y_train.numpy()
     z_train = z_train.numpy()

--- a/tests/pipeline/test_multi_domain_adapter.py
+++ b/tests/pipeline/test_multi_domain_adapter.py
@@ -78,17 +78,26 @@ def test_coirls(kernel, office_caltech_access):
     x, y, z = next(iter(dataloader))
     tgt_idx = torch.where(z == 0)
     src_idx = torch.where(z != 0)
-
-    x_feat = feature_network(x)
-    z_one_hot = one_hot(z)
-    clf = CoIRLS(kernel=kernel, alpha=1.0)
+    
+    with torch.no_grad():
+        x_feat = feature_network(x)
+        z_one_hot = one_hot(z)
+        clf = CoIRLS(kernel=kernel, alpha=1.0)
 
     x_train = torch.cat((x_feat[src_idx], x_feat[tgt_idx]))
     y_train = y[src_idx]
     z_train = torch.cat((z_one_hot[src_idx], z_one_hot[tgt_idx]))
+
+    x_train = x_train.numpy()
+    y_train = y_train.numpy()
+    z_train = z_train.numpy()
+
+    x_feat_tgt = x_feat[tgt_idx].numpy()
+    y_tgt = y[tgt_idx].numpy()
+
     clf.fit(x_train, y_train, z_train)
-    y_pred = clf.predict(x_feat[tgt_idx])
-    acc = accuracy_score(y[tgt_idx], y_pred)
+    y_pred = clf.predict(x_feat_tgt)
+    acc = accuracy_score(y_tgt, y_pred)
 
     assert 0 <= acc <= 1
 


### PR DESCRIPTION
Fixes #452.

### Description
- Ad-hoc fixes regarding device allocation between PyTorch's tensors and NumPy's arrays (`test_multi_domain_adapter.py`).
- Update to handle different types of values between original and outputted csv (`test_uncertainty_qbin_pipeline.py`).
- `test_pipeline` function in `test_multiomics_trainer.py` hasn't been resolved due to requiring to access the `Trainer.test` method to inspect the issues.
- The device allocation error could be due `scikit-learn`'s `ArrayAPI` issues/changes when handling `torch.Tensor`.

### Status
**Work in progress**


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
