### PR TITLE
Upgrade minimum sklearn version from 0.23.2 to 1.6.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     "numpy<2.0.0",  # sure
     "pandas",  # sure
     "pytorch-lightning>=2.0.0",  # in pipeline API only
-    "scikit-learn>=1.6.1",  # sure
+    "scikit-learn>=1.6.1",
     "scipy>=1.5.4",  # in factorization API only
     "tensorly>=0.5.1",  # in factorization and model_weights API only
     "torch==2.3.0",  # also change the version in the test.yaml when changing this next time, and update the pytorch version in the bindingdb_deepdta tutorial notebook

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     "numpy<2.0.0",  # sure
     "pandas",  # sure
     "pytorch-lightning>=2.0.0",  # in pipeline API only
-    "scikit-learn>=0.23.2",  # sure
+    "scikit-learn>=1.6.1",  # sure
     "scipy>=1.5.4",  # in factorization API only
     "tensorly>=0.5.1",  # in factorization and model_weights API only
     "torch==2.3.0",  # also change the version in the test.yaml when changing this next time, and update the pytorch version in the bindingdb_deepdta tutorial notebook


### PR DESCRIPTION
### Description
Updates `scikit-learn` minimum version requirement from 0.23.2 to 1.6.1 to support more recent APIs, including `validation` API to validate function arguments and data consistency for `scikit-learn` compatible estimators.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
