### PR TITLE
Update cross-validation for transductive domain adaptation

### DIFF
--- a/kale/evaluate/cross_validation.py
+++ b/kale/evaluate/cross_validation.py
@@ -46,7 +46,7 @@ def _fit_and_score(
     score_args,
     return_train_score=False,
     return_parameters=False,
-    return_n_test_samples=False,
+    return_num_test_samples=False,
     return_times=False,
     return_estimator=False,
     split_progress=None,
@@ -61,11 +61,11 @@ def _fit_and_score(
 
     Args:
         estimator (sklearn.base.BaseEstimator): A scikit-learn estimator implementing fit and predict methods.
-        x (array-like): Input data for training and evaluation [n_samples, n_features].
-        y (array-like): Target variable for supervised learning [n_samples] or [n_samples, n_targets].
+        x (array-like): Input data for training and evaluation [num_samples, num_features].
+        y (array-like): Target variable for supervised learning [num_samples] or [num_samples, num_targets].
         transformer (sklearn.base.BaseEstimator, optional): An unsupervised transformer implementing fit and transform methods applied before domain adaptation.
         domain_adapter (sklearn.base.BaseEstimator, optional): A domain adapter implementing fit and transform methods.
-        factors (array-like, optional): Factors to reduce their influence on the data for domain adaptation [n_samples, n_factors].
+        factors (array-like, optional): Factors to reduce their influence on the data for domain adaptation [num_samples, num_factors].
         scorer (callable): A scoring function to evaluate the estimator's performance.
         train (array-like): Indices of training samples.
         test (array-like): Indices of testing samples.
@@ -75,7 +75,7 @@ def _fit_and_score(
         score_args (dict, optional): Additional arguments for the scorer's score method.
         return_train_score (bool): Flag to include training scores in the results.
         return_parameters (bool): Flag to include the estimator's parameters in the results.
-        return_n_test_samples (bool): Flag to include the number of test samples in the results.
+        return_num_test_samples (bool): Flag to include the number of test samples in the results.
         return_times (bool): Flag to include fit and score times in the results.
         return_estimator (bool): Flag to include the fitted estimator in the results.
         split_progress (tuple, optional): Progression value for the current split containing `(current_split, total_splits)`.
@@ -85,7 +85,7 @@ def _fit_and_score(
         dict: A dictionary containing the results of fitting and scoring, including:
             - "train_scores" (dict, optional): Scores on training set, if `return_train_score=True`.
             - "test_scores" (dict): Scores on testing set.
-            - "n_test_samples" (int, optional): Number of test samples, if `return_n_test_samples=True`.
+            - "num_test_samples" (int, optional): Number of test samples, if `return_num_test_samples=True`.
             - "fit_time" (float, optional): Time taken to fit the estimator, if `return_times=True`.
             - "score_time" (float): Time taken to score the estimator.
             - "parameters" (dict, optional): estimator parameters, if `return_parameters=True`.
@@ -247,8 +247,8 @@ def _fit_and_score(
     result["test_scores"] = test_scores
     if return_train_score:
         result["train_scores"] = train_scores
-    if return_n_test_samples:
-        result["n_test_samples"] = _num_samples(x_test)
+    if return_num_test_samples:
+        result["num_test_samples"] = _num_samples(x_test)
     if return_times:
         result["fit_time"] = fit_time
         result["score_time"] = score_time
@@ -264,9 +264,9 @@ def leave_one_group_out(x, y, groups, estimator, use_domain_adaptation=False) ->
     Perform leave one group out cross validation for a given estimator.
 
     Args:
-        x (np.ndarray or torch.tensor): Input data [n_samples, n_features].
-        y (np.ndarray or torch.tensor): Target labels [n_samples].
-        groups (np.ndarray or torch.tensor): Group labels to be left out [n_samples].
+        x (np.ndarray or torch.tensor): Input data [num_samples, num_features].
+        y (np.ndarray or torch.tensor): Target labels [num_samples].
+        groups (np.ndarray or torch.tensor): Group labels to be left out [num_samples].
         estimator (estimator object): Machine learning estimator to be evaluated from kale or scikit-learn.
         use_domain_adaptation (bool): Whether to use domain adaptation, i.e., leveraging test data, during training.
 
@@ -325,7 +325,7 @@ def leave_one_group_out(x, y, groups, estimator, use_domain_adaptation=False) ->
             None,
         ],
         "cv": ["cv_object"],
-        "n_jobs": [Integral, None],
+        "num_jobs": [Integral, None],
         "verbose": ["verbose"],
         "params": [dict, None],
         "pre_dispatch": [Integral, str],
@@ -346,12 +346,12 @@ def cross_validate(
     factors=None,
     scoring=None,
     cv=None,
-    n_jobs=None,
+    num_jobs=None,
     verbose=0,
     parameters=None,
     fit_args=None,
     score_args=None,
-    pre_dispatch="2*n_jobs",
+    pre_dispatch="2*num_jobs",
     return_train_score=False,
     return_estimator=False,
     return_indices=False,
@@ -361,15 +361,15 @@ def cross_validate(
 
     Args:
         estimator (sklearn.base.BaseEstimator): A scikit-learn estimator implementing fit and predict methods.
-        x (array-like): Input data for training and evaluation [n_samples, n_features].
-        y (array-like): Target variable for supervised learning [n_samples] or [n_samples, n_targets].
+        x (array-like): Input data for training and evaluation [num_samples, num_features].
+        y (array-like): Target variable for supervised learning [num_samples] or [num_samples, num_targets].
         groups (array-like, optional): Group labels for the samples used while splitting the dataset into train/test sets.
         transformer (sklearn.base.BaseEstimator, optional): An unsupervised transformer implementing fit and transform methods applied before domain adaptation.
         domain_adapter (sklearn.base.BaseEstimator, optional): A domain adapter implementing fit and transform methods.
-        factors (array-like, optional): Factors to reduce their influence on the data during domain adaptation [n_samples, n_factors].
+        factors (array-like, optional): Factors to reduce their influence on the data during domain adaptation [num_samples, num_factors].
         scoring (callable, list, tuple, dict, optional): A scoring function or a list of scoring functions to evaluate the estimator's performance.
         cv (cv_object, optional): Cross-validation splitting strategy.
-        n_jobs (int, optional): Number of jobs to run in parallel.
+        num_jobs (int, optional): Number of jobs to run in parallel.
         verbose (int): Level of verbosity for logging.
         parameters (dict, optional): Parameters to configure the estimator.
         fit_args (dict, optional): Additional arguments for the estimator's fit method.
@@ -401,7 +401,7 @@ def cross_validate(
     if return_indices:
         indices = list(indices)
 
-    parallel = Parallel(n_jobs, verbose=verbose, pre_dispatch=pre_dispatch)
+    parallel = Parallel(num_jobs, verbose=verbose, pre_dispatch=pre_dispatch)
 
     results = parallel(
         delayed(_fit_and_score)(

--- a/kale/evaluate/cross_validation.py
+++ b/kale/evaluate/cross_validation.py
@@ -92,6 +92,8 @@ def _fit_and_score(
             - "estimator" (object, optional): The fitted estimator, if `return_estimator=True`.
             - "fit_error" (str, optional): Error message if fitting fails.
     """
+    # xp is a drop-in replacement for numpy to be compatible with other libraries
+    # like numpy cupy, torch, etc.
     xp, _ = get_namespace(x)
     x_device = device(x)
 

--- a/kale/evaluate/cross_validation.py
+++ b/kale/evaluate/cross_validation.py
@@ -369,12 +369,12 @@ def cross_validate(
         factors (array-like, optional): Factors to reduce their influence on the data during domain adaptation [num_samples, num_factors].
         scoring (callable, list, tuple, dict, optional): A scoring function or a list of scoring functions to evaluate the estimator's performance.
         cv (cv_object, optional): Cross-validation splitting strategy.
-        num_jobs (int, optional): Number of jobs to run in parallel.
+        num_jobs (int, optional): Number of jobs to run cross-validation in parallel using joblib.Parallel.
         verbose (int): Level of verbosity for logging.
         parameters (dict, optional): Parameters to configure the estimator.
         fit_args (dict, optional): Additional arguments for the estimator's fit method.
         score_args (dict, optional): Additional arguments for the scorer's score method.
-        pre_dispatch (int, str): Controls the number of jobs that get dispatched during parallel execution.
+        pre_dispatch (int, str): Controls the number of jobs that get dispatched during parallel execution for joblib.Parallel.
         return_train_score (bool): Whether to include training scores in the results.
         return_estimator (bool): Whether to include the fitted estimator in the results.
         return_indices (bool): Whether to include the indices of the training and testing sets in the results.

--- a/kale/evaluate/cross_validation.py
+++ b/kale/evaluate/cross_validation.py
@@ -64,7 +64,7 @@ def _fit_and_score(
         estimator (sklearn.base.BaseEstimator): A scikit-learn estimator implementing fit and predict methods.
         X (array-like): Input data for training and evaluation [n_samples, n_features].
         y (array-like): Target variable for supervised learning [n_samples] or [n_samples, n_targets].
-        transformer (sklearn.base.BaseEstimator, optional): An unsupervised transformer implementing fit and transform methods.
+        transformer (sklearn.base.BaseEstimator, optional): An unsupervised transformer implementing fit and transform methods applied before domain adaptation.
         domain_adapter (sklearn.base.BaseEstimator, optional): A domain adapter implementing fit and transform methods.
         factors (array-like, optional): Factors to reduce their influence on the data for domain adaptation [n_samples, n_factors].
         scorer (callable): A scoring function to evaluate the estimator's performance.
@@ -364,7 +364,7 @@ def cross_validate(
         X (array-like): Input data for training and evaluation [n_samples, n_features].
         y (array-like): Target variable for supervised learning [n_samples] or [n_samples, n_targets].
         groups (array-like, optional): Group labels for the samples used while splitting the dataset into train/test sets.
-        transformer (sklearn.base.BaseEstimator, optional): An unsupervised transformer implementing fit and transform methods.
+        transformer (sklearn.base.BaseEstimator, optional): An unsupervised transformer implementing fit and transform methods applied before domain adaptation.
         domain_adapter (sklearn.base.BaseEstimator, optional): A domain adapter implementing fit and transform methods.
         factors (array-like, optional): Factors to reduce their influence on the data during domain adaptation [n_samples, n_factors].
         scoring (callable, list, tuple, dict, optional): A scoring function or a list of scoring functions to evaluate the estimator's performance.

--- a/kale/evaluate/cross_validation.py
+++ b/kale/evaluate/cross_validation.py
@@ -184,7 +184,6 @@ def _fit_and_score(
 
     result = {}
     try:
-        print("test", X_test.shape)
         if y_train is None:
             estimator.fit(X_train, **fit_args)
         else:

--- a/kale/evaluate/cross_validation.py
+++ b/kale/evaluate/cross_validation.py
@@ -351,7 +351,7 @@ def cross_validate(
     parameters=None,
     fit_args=None,
     score_args=None,
-    pre_dispatch="2*num_jobs",
+    pre_dispatch="2*n_jobs",
     return_train_score=False,
     return_estimator=False,
     return_indices=False,

--- a/kale/evaluate/cross_validation.py
+++ b/kale/evaluate/cross_validation.py
@@ -24,7 +24,6 @@ from sklearn.preprocessing import OneHotEncoder
 from sklearn.utils._array_api import device, get_namespace
 from sklearn.utils._indexing import _safe_indexing
 from sklearn.utils._param_validation import HasMethods, StrOptions, validate_params
-from sklearn.utils.fixes import parse_version
 from sklearn.utils.metaestimators import _safe_split
 from sklearn.utils.multiclass import type_of_target
 from sklearn.utils.parallel import delayed, Parallel

--- a/kale/evaluate/cross_validation.py
+++ b/kale/evaluate/cross_validation.py
@@ -359,7 +359,7 @@ def cross_validate(
         X (array-like): Input data for training and evaluation [n_samples, n_features].
         y (array-like): Target variable for supervised learning [n_samples] or [n_samples, n_targets].
         groups (array-like, optional): Group labels for the samples used while splitting the dataset into train/test sets.
-        transformer (sklearn.base.BaseEstimator, optional): A transformer implementing fit and transform methods.
+        transformer (sklearn.base.BaseEstimator, optional): An unsupervised transformer implementing fit and transform methods.
         domain_adapter (sklearn.base.BaseEstimator, optional): A domain adapter implementing fit and transform methods.
         factors (array-like, optional): Factors to reduce their influence on the data during domain adaptation [n_samples, n_factors].
         scoring (callable, list, tuple, dict, optional): A scoring function or a list of scoring functions to evaluate the estimator's performance.

--- a/kale/evaluate/cross_validation.py
+++ b/kale/evaluate/cross_validation.py
@@ -8,20 +8,21 @@ from numbers import Integral, Number, Real
 from traceback import format_exc
 
 import numpy as np
-from sklearn import __version__ as sk_version
+from joblib import logger
 from sklearn.base import clone, is_classifier
 from sklearn.metrics import accuracy_score, check_scoring, get_scorer_names
 from sklearn.metrics._scorer import _MultimetricScorer
 from sklearn.model_selection import check_cv, LeaveOneGroupOut
 from sklearn.model_selection._validation import (
     _aggregate_score_dicts,
+    _insert_error_scores,
     _normalize_score_results,
     _score,
     _warn_or_raise_about_fit_failures,
 )
 from sklearn.preprocessing import OneHotEncoder
 from sklearn.utils._array_api import device, get_namespace
-from sklearn.utils._indexing import _safe_assign, _safe_indexing
+from sklearn.utils._indexing import _safe_indexing
 from sklearn.utils._param_validation import HasMethods, StrOptions, validate_params
 from sklearn.utils.fixes import parse_version
 from sklearn.utils.metaestimators import _safe_split

--- a/kale/evaluate/cross_validation.py
+++ b/kale/evaluate/cross_validation.py
@@ -1,11 +1,255 @@
 """
-Functions implementing cross-validation methods for assessing model fit.
+Functions to do cross-validation with domain adaptation and pre-domain adaptation transformation
+for assessing model fitness.
 """
 
+import time
+from numbers import Integral, Number, Real
+
 import numpy as np
-from sklearn.metrics import accuracy_score
-from sklearn.model_selection import LeaveOneGroupOut
+from sklearn import __version__ as sk_version
+from sklearn.base import clone, is_classifier
+from sklearn.metrics import accuracy_score, check_scoring, get_scorer_names
+from sklearn.model_selection import check_cv, LeaveOneGroupOut
+from sklearn.model_selection._validation import (
+    _aggregate_score_dicts,
+    _normalize_score_results,
+    _score,
+    _warn_or_raise_about_fit_failures,
+)
 from sklearn.preprocessing import OneHotEncoder
+from sklearn.utils._array_api import device, get_namespace
+from sklearn.utils._indexing import _safe_assign, _safe_indexing
+from sklearn.utils._param_validation import HasMethods, StrOptions, validate_params
+from sklearn.utils.fixes import parse_version
+from sklearn.utils.metaestimators import _safe_split
+from sklearn.utils.multiclass import type_of_target
+from sklearn.utils.parallel import delayed, Parallel
+from sklearn.utils.validation import _check_method_params, _num_samples, indexable
+
+
+def _fit_and_score(
+    estimator,
+    X,
+    y,
+    *,
+    transformer,
+    domain_adapter,
+    factors,
+    scorer,
+    train,
+    test,
+    verbose,
+    parameters,
+    fit_args,
+    score_args,
+    return_train_score=False,
+    return_parameters=False,
+    return_n_test_samples=False,
+    return_times=False,
+    return_estimator=False,
+    split_progress=None,
+    candidate_progress=None,
+    error_score=np.nan,
+):
+    """Train the estimator (optionally with a domain adapter) and evaluate its performance.
+    The implementation is a modification of the `scikit-learn`'s _fit_and_score function to accomodate
+    domain adaptation and pre-domain adaptation transformation. Do not use this function with classification
+    labels that has -1 as a label, as it will be treated as an unlabeled sample. This is a limitation of the
+    current implementation.
+
+    Args:
+        estimator (sklearn.base.BaseEstimator): A scikit-learn estimator implementing fit and predict methods.
+        X (array-like): Input data for training and evaluation [n_samples, n_features].
+        y (array-like): Target variable for supervised learning [n_samples] or [n_samples, n_targets].
+        transformer (sklearn.base.BaseEstimator, optional): An unsupervised transformer implementing fit and transform methods.
+        domain_adapter (sklearn.base.BaseEstimator, optional): A domain adapter implementing fit and transform methods.
+        factors (array-like, optional): Factors to reduce their influence on the data for domain adaptation [n_samples, n_factors].
+        scorer (callable): A scoring function to evaluate the estimator's performance.
+        train (array-like): Indices of training samples.
+        test (array-like): Indices of testing samples.
+        verbose (int): Level of verbosity for logging.
+        parameters (dict, optional): Parameters to configure the estimator.
+        fit_args (dict, optional): Additional arguments for the estimator's fit method.
+        score_args (dict, optional): Additional arguments for the scorer's score method.
+        return_train_score (bool): Flag to include training scores in the results.
+        return_parameters (bool): Flag to include the estimator's parameters in the results.
+        return_n_test_samples (bool): Flag to include the number of test samples in the results.
+        return_times (bool): Flag to include fit and score times in the results.
+        return_estimator (bool): Flag to include the fitted estimator in the results.
+        split_progress (tuple, optional): Progression value for the current split containing `(current_split, total_splits)`.
+        candidate_progress (tuple, optional): Progression value for the current candidate containing `(current_candidate, total_candidates)`.
+        error_score (float or str): Value to assign to the score if an error occurs during fitting or scoring or to raise error when set to "raise".
+    Returns:
+        dict: A dictionary containing the results of fitting and scoring, including:
+            - "train_scores" (dict, optional): Scores on training set, if `return_train_score=True`.
+            - "test_scores" (dict): Scores on testing set.
+            - "n_test_samples" (int, optional): Number of test samples, if `return_n_test_samples=True`.
+            - "fit_time" (float, optional): Time taken to fit the estimator, if `return_times=True`.
+            - "score_time" (float): Time taken to score the estimator.
+            - "parameters" (dict, optional): estimator parameters, if `return_parameters=True`.
+            - "estimator" (object, optional): The fitted estimator, if `return_estimator=True`.
+            - "fit_error" (str, optional): Error message if fitting fails.
+    """
+    xp, _ = get_namespace(X)
+    X_device = device(X)
+
+    train, test = xp.asarray(train, device=X_device), xp.asarray(test, device=X_device)
+
+    if not isinstance(error_score, Number) and error_score != "raise":
+        raise ValueError(
+            "error_score must be the string 'raise' or a numeric value. "
+            "(Hint: if using 'raise', please make sure that it has been "
+            "spelled correctly.)"
+        )
+
+    progress_msg = ""
+    if verbose > 2:
+        if split_progress is not None:
+            progress_msg = f" {split_progress[0]+1}/{split_progress[1]}"
+        if candidate_progress and verbose > 9:
+            progress_msg += f"; {candidate_progress[0]+1}/{candidate_progress[1]}"
+
+    if verbose > 1:
+        if parameters is None:
+            params_msg = ""
+        else:
+            sorted_keys = sorted(parameters)  # Ensure deterministic o/p
+            params_msg = ", ".join(f"{k}={parameters[k]}" for k in sorted_keys)
+    if verbose > 9:
+        start_msg = f"[CV{progress_msg}] START {params_msg}"
+        print(f"{start_msg}{(80 - len(start_msg)) * '.'}")
+
+    start_time = time.time()
+
+    y_type = type_of_target(y) if y is not None else "unknown"
+    X_train, y_train = _safe_split(estimator, X, y, train)
+    X_test, y_test = _safe_split(estimator, X, y, test)
+
+    # Adjust length of sample weights
+    fit_args = fit_args if fit_args is not None else {}
+    fit_args = _check_method_params(X, fit_args, train)
+    score_args = score_args if score_args is not None else {}
+    score_args_train = _check_method_params(X, score_args, train)
+    score_args_test = _check_method_params(X, score_args, test)
+
+    if transformer is not None or domain_adapter is not None:
+        X_sampled = xp.concatenate([X_train, X_test], axis=0)
+        y_sampled = xp.concatenate([y_train, y_test], axis=0)
+
+        # Mask the labels for the test set to avoid leakage
+        if any([y_type.startswith(key) for key in ["binary", "multiclass"]]):
+            y_sampled[_num_samples(X_train) - 1 :] = -1
+        else:
+            raise ValueError("Domain adaptation is only supported for 'binary' or 'multiclass' y.")
+        y_sampled = xp.asarray(y_sampled, device=X_device)
+
+    if transformer is not None:
+        if parameters is not None:
+            keys = [k for k in parameters.keys() if k.startswith("transformer__")]
+            transformer_parameters = {k.replace("transformer__", ""): parameters.pop(k) for k in keys}
+            transformer.set_params(**clone(transformer_parameters, safe=False))
+
+        # For now, only unsupervised transformers are supported
+        transformer.fit(X_sampled)
+        X_sampled = transformer.transform(X_sampled)
+
+    if domain_adapter is not None:
+        factors_sampled, factors_train, factors_test = [None] * 3
+        if factors is not None:
+            factors_train = _safe_indexing(factors, train)
+            factors_test = _safe_indexing(factors, test)
+            factors_sampled = xp.concatenate([factors_train, factors_test], axis=0)
+
+        if parameters is not None:
+            keys = [k for k in parameters.keys() if k.startswith("domain_adapter__")]
+            da_parameters = {k.replace("domain_adapter__", ""): parameters.pop(k) for k in keys}
+            domain_adapter.set_params(**clone(da_parameters, safe=False))
+
+        domain_adapter.fit(X_sampled, y_sampled, factors_sampled)
+        X_train = domain_adapter.transform(X_train, factors_train)
+        X_test = domain_adapter.transform(X_test, factors_test)
+
+    if y is not None and y_type != "continuous":
+        train_labeled = y_train != -1
+        train = _safe_indexing(train, train_labeled)
+        X_train = _safe_indexing(X_train, train_labeled)
+        y_train = _safe_indexing(y_train, train_labeled)
+        fit_args_labeled = _check_method_params(X_train, fit_args, train_labeled)
+
+    if parameters is not None:
+        estimator = estimator.set_params(**clone(parameters, safe=False))
+
+    result = {}
+    try:
+        if y_train is None:
+            estimator.fit(X_train, **fit_args)
+        else:
+            estimator.fit(X_train, y_train, **fit_args)
+
+    except Exception:
+        # Note fit time as time until error
+        fit_time = time.time() - start_time
+        score_time = 0.0
+        if error_score == "raise":
+            raise
+        elif isinstance(error_score, numbers.Number):
+            if isinstance(scorer, _MultimetricScorer):
+                test_scores = {name: error_score for name in scorer._scorers}
+                if return_train_score:
+                    train_scores = test_scores.copy()
+            else:
+                test_scores = error_score
+                if return_train_score:
+                    train_scores = error_score
+        result["fit_error"] = format_exc()
+    else:
+        result["fit_error"] = None
+
+        fit_time = time.time() - start_time
+        test_scores = _score(estimator, X_test, y_test, scorer, score_args_test, error_score)
+        score_time = time.time() - start_time - fit_time
+        if return_train_score:
+            train_scores = _score(estimator, X_train, y_train, scorer, score_args_train, error_score)
+
+    if verbose > 1:
+        total_time = score_time + fit_time
+        end_msg = f"[CV{progress_msg}] END "
+        result_msg = params_msg + (";" if params_msg else "")
+        if verbose > 2:
+            if isinstance(test_scores, dict):
+                for scorer_name in sorted(test_scores):
+                    result_msg += f" {scorer_name}: ("
+                    if return_train_score:
+                        scorer_scores = train_scores[scorer_name]
+                        result_msg += f"train={scorer_scores:.3f}, "
+                    result_msg += f"test={test_scores[scorer_name]:.3f})"
+            else:
+                result_msg += ", score="
+                if return_train_score:
+                    result_msg += f"(train={train_scores:.3f}, test={test_scores:.3f})"
+                else:
+                    result_msg += f"{test_scores:.3f}"
+        result_msg += f" total time={logger.short_format_time(total_time)}"
+
+        # Right align the result_msg
+        end_msg += "." * (80 - len(end_msg) - len(result_msg))
+        end_msg += result_msg
+        print(end_msg)
+
+    result["test_scores"] = test_scores
+    if return_train_score:
+        result["train_scores"] = train_scores
+    if return_n_test_samples:
+        result["n_test_samples"] = _num_samples(X_test)
+    if return_times:
+        result["fit_time"] = fit_time
+        result["score_time"] = score_time
+    if return_parameters:
+        result["parameters"] = parameters
+    if return_estimator:
+        result["estimator"] = estimator
+    return result
 
 
 def leave_one_group_out(x, y, groups, estimator, use_domain_adaptation=False) -> dict:
@@ -54,3 +298,155 @@ def leave_one_group_out(x, y, groups, estimator, use_domain_adaptation=False) ->
         "Num_samples": num_samples,
         "Accuracy": accuracy,
     }
+
+
+@validate_params(
+    {
+        "estimator": [HasMethods(["fit", "predict", "score"])],
+        "X": ["array-like", "sparse matrix"],
+        "y": ["array-like", None],
+        "groups": ["array-like", None],
+        "transformer": [HasMethods(["fit", "transform"]), None],
+        "domain_adapter": [HasMethods(["fit", "transform"]), None],
+        "factors": ["array-like", "sparse matrix", None],
+        "scoring": [
+            StrOptions(set(get_scorer_names())),
+            callable,
+            list,
+            tuple,
+            dict,
+            None,
+        ],
+        "cv": ["cv_object"],
+        "n_jobs": [Integral, None],
+        "verbose": ["verbose"],
+        "params": [dict, None],
+        "pre_dispatch": [Integral, str],
+        "return_train_score": ["boolean"],
+        "return_estimator": ["boolean"],
+        "return_indices": ["boolean"],
+    },
+    prefer_skip_nested_validation=False,  # estimator is not validated yet
+)
+def cross_validate(
+    estimator,
+    X,
+    y=None,
+    *,
+    groups=None,
+    transformer=None,
+    domain_adapter=None,
+    factors=None,
+    scoring=None,
+    cv=None,
+    n_jobs=None,
+    verbose=0,
+    parameters=None,
+    fit_args=None,
+    score_args=None,
+    pre_dispatch="2*n_jobs",
+    return_train_score=False,
+    return_estimator=False,
+    return_indices=False,
+    error_score=np.nan,
+):
+    """Run cross-validation and record fit and score times.
+
+    Args:
+        estimator (sklearn.base.BaseEstimator): A scikit-learn estimator implementing fit and predict methods.
+        X (array-like): Input data for training and evaluation [n_samples, n_features].
+        y (array-like): Target variable for supervised learning [n_samples] or [n_samples, n_targets].
+        groups (array-like, optional): Group labels for the samples used while splitting the dataset into train/test sets.
+        transformer (sklearn.base.BaseEstimator, optional): A transformer implementing fit and transform methods.
+        domain_adapter (sklearn.base.BaseEstimator, optional): A domain adapter implementing fit and transform methods.
+        factors (array-like, optional): Factors to reduce their influence on the data during domain adaptation [n_samples, n_factors].
+        scoring (callable, list, tuple, dict, optional): A scoring function or a list of scoring functions to evaluate the estimator's performance.
+        cv (cv_object, optional): Cross-validation splitting strategy.
+        n_jobs (int, optional): Number of jobs to run in parallel.
+        verbose (int): Level of verbosity for logging.
+        parameters (dict, optional): Parameters to configure the estimator.
+        fit_args (dict, optional): Additional arguments for the estimator's fit method.
+        score_args (dict, optional): Additional arguments for the scorer's score method.
+        pre_dispatch (int, str): Controls the number of jobs that get dispatched during parallel execution.
+        return_train_score (bool): Whether to include training scores in the results.
+        return_estimator (bool): Whether to include the fitted estimator in the results.
+        return_indices (bool): Whether to include the indices of the training and testing sets in the results.
+        error_score (float or str): Value to assign to the score if an error occurs during fitting or scoring or to raise error when set to "raise".
+    Returns:
+        dict: A dictionary containing the results of fitting and scoring, including:
+            - "train_scores" (dict, optional): Scores on training set, if `return_train_score=True`.
+            - "test_scores" (dict): Scores on testing set.
+            - "fit_time" (float, optional): Time taken to fit the estimator, if `return_times=True`.
+            - "score_time" (float): Time taken to score the estimator.
+            - "estimator" (object, optional): The fitted estimator, if `return_estimator=True`.
+            - "indices" (dict, optional): Indices of the training and testing sets, if `return_indices=True`.
+    """
+    X, y, groups, factors = indexable(X, y, groups, factors)
+    cv = check_cv(cv, y, classifier=is_classifier(estimator))
+
+    parameters = {} if parameters is None else parameters
+    fit_args = {} if fit_args is None else fit_args
+    score_args = {} if score_args is None else score_args
+
+    scorers = check_scoring(estimator, scoring, raise_exc=(error_score == "raise"))
+
+    indices = cv.split(X, y, groups)
+    if return_indices:
+        indices = list(indices)
+
+    parallel = Parallel(n_jobs, verbose=verbose, pre_dispatch=pre_dispatch)
+
+    results = parallel(
+        delayed(_fit_and_score)(
+            clone(estimator),
+            X,
+            y,
+            domain_adapter=clone(domain_adapter) if domain_adapter else None,
+            factors=factors,
+            scorer=scorers,
+            train=train,
+            test=test,
+            verbose=verbose,
+            parameters=parameters,
+            fit_args=fit_args,
+            score_args=score_args,
+            return_train_score=return_train_score,
+            return_times=True,
+            return_estimator=return_estimator,
+            error_score=error_score,
+        )
+        for train, test in indices
+    )
+
+    _warn_or_raise_about_fit_failures(results, error_score)
+
+    # For callable scoring, the return type is only know after calling. If the
+    # return type is a dictionary, the error scores can now be inserted with
+    # the correct key.
+    if callable(scoring):
+        _insert_error_scores(results, error_score)
+
+    results = _aggregate_score_dicts(results)
+
+    ret = {}
+    ret["fit_time"] = results["fit_time"]
+    ret["score_time"] = results["score_time"]
+
+    if return_estimator:
+        ret["estimator"] = results["estimator"]
+
+    if return_indices:
+        ret["indices"] = {}
+        ret["indices"]["train"], ret["indices"]["test"] = zip(*indices)
+
+    test_scores_dict = _normalize_score_results(results["test_scores"])
+    if return_train_score:
+        train_scores_dict = _normalize_score_results(results["train_scores"])
+
+    for name in test_scores_dict:
+        ret["test_%s" % name] = test_scores_dict[name]
+        if return_train_score:
+            key = "train_%s" % name
+            ret[key] = train_scores_dict[name]
+
+    return ret

--- a/kale/evaluate/cross_validation.py
+++ b/kale/evaluate/cross_validation.py
@@ -106,6 +106,10 @@ def _fit_and_score(
         )
 
     progress_msg = ""
+    if verbose > 0:
+        lgr = logger.logging.getLogger("pykale")
+        lgr.setLevel(logger.logging.INFO)
+
     if verbose > 2:
         if split_progress is not None:
             progress_msg = f" {split_progress[0]+1}/{split_progress[1]}"
@@ -120,7 +124,7 @@ def _fit_and_score(
             params_msg = ", ".join(f"{k}={parameters[k]}" for k in sorted_keys)
     if verbose > 9:
         start_msg = f"[CV{progress_msg}] START {params_msg}"
-        print(f"{start_msg}{(80 - len(start_msg)) * '.'}")
+        lgr.info(f"{start_msg}{(80 - len(start_msg)) * '.'}")
 
     start_time = time.time()
 
@@ -237,7 +241,7 @@ def _fit_and_score(
         # Right align the result_msg
         end_msg += "." * (80 - len(end_msg) - len(result_msg))
         end_msg += result_msg
-        print(end_msg)
+        lgr.info(end_msg)
 
     result["test_scores"] = test_scores
     if return_train_score:

--- a/kale/evaluate/cross_validation.py
+++ b/kale/evaluate/cross_validation.py
@@ -107,7 +107,7 @@ def _fit_and_score(
 
     progress_msg = ""
     if verbose > 0:
-        lgr = logger.logging.getLogger("pykale")
+        lgr = logger.logging.getLogger("fit_and_score")
         lgr.setLevel(logger.logging.INFO)
 
     if verbose > 2:

--- a/kale/evaluate/cross_validation.py
+++ b/kale/evaluate/cross_validation.py
@@ -328,6 +328,7 @@ def leave_one_group_out(x, y, groups, estimator, use_domain_adaptation=False) ->
         "return_train_score": ["boolean"],
         "return_estimator": ["boolean"],
         "return_indices": ["boolean"],
+        "error_score": [StrOptions({"raise"}), Real],
     },
     prefer_skip_nested_validation=False,  # estimator is not validated yet
 )

--- a/tests/embed/test_factorization.py
+++ b/tests/embed/test_factorization.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 from numpy import testing
 from scipy.io import loadmat
-from sklearn.datasets import make_blobs
 from sklearn.preprocessing import OneHotEncoder
 from tensorly.tenalg import multi_mode_dot
 

--- a/tests/embed/test_factorization.py
+++ b/tests/embed/test_factorization.py
@@ -8,7 +8,7 @@ from sklearn.preprocessing import OneHotEncoder
 from tensorly.tenalg import multi_mode_dot
 
 from kale.embed.factorization import MIDA, MPCA
-from tests.helpers.toy_dataset import make_domain_shifted_dataset
+from ..helpers.toy_dataset import make_domain_shifted_dataset
 
 N_COMPS = [1, 50, 100]
 VAR_RATIOS = [0.7, 0.95]

--- a/tests/embed/test_factorization.py
+++ b/tests/embed/test_factorization.py
@@ -9,6 +9,7 @@ from sklearn.preprocessing import OneHotEncoder
 from tensorly.tenalg import multi_mode_dot
 
 from kale.embed.factorization import MIDA, MPCA
+from tests.helpers.toy_dataset import make_domain_shifted_dataset
 
 N_COMPS = [1, 50, 100]
 VAR_RATIOS = [0.7, 0.95]
@@ -85,22 +86,20 @@ def test_mpca_against_baseline(gait, baseline_model):
 @pytest.mark.parametrize("kernel", ["linear", "rbf"])
 @pytest.mark.parametrize("augmentation", [True, False])
 def test_mida(kernel, augmentation):
-    np.random.seed(29118)
-    # Generate toy data
-    n_samples = 200
-
-    xs, ys = make_blobs(n_samples, n_features=3, centers=[[0, 0, 0], [0, 2, 1]], cluster_std=[0.3, 0.35])
-    xt, yt = make_blobs(n_samples, n_features=3, centers=[[2, -2, 2], [2, 0.2, -1]], cluster_std=[0.35, 0.4])
-    x = np.concatenate((xs, xt), axis=0)
-
-    covariates = np.zeros(n_samples * 2)
-    covariates[:n_samples] = 1
+    x, y, domains = make_domain_shifted_dataset(
+        num_domains=2,
+        num_samples_per_class=50,
+        num_features=50,
+        class_sep=1.0,
+        centroid_shift_scale=5.0,
+        random_state=0,
+    )
 
     enc = OneHotEncoder(handle_unknown="ignore")
-    covariates_mat = enc.fit_transform(covariates.reshape(-1, 1)).toarray()
+    covariates_mat = enc.fit_transform(domains.reshape(-1, 1)).toarray()
     mida = MIDA(n_components=2, kernel=kernel, augmentation=augmentation)
     x_transformed = mida.fit_transform(x, covariates=covariates_mat)
-    testing.assert_equal(x_transformed.shape, (n_samples * 2, 2))
+    testing.assert_equal(x_transformed.shape, (len(x), 2))
 
-    x_transformed = mida.fit_transform(x, ys, covariates=covariates_mat)
-    testing.assert_equal(x_transformed.shape, (n_samples * 2, 2))
+    x_transformed = mida.fit_transform(x, y, covariates=covariates_mat)
+    testing.assert_equal(x_transformed.shape, (len(x), 2))

--- a/tests/embed/test_factorization.py
+++ b/tests/embed/test_factorization.py
@@ -8,6 +8,7 @@ from sklearn.preprocessing import OneHotEncoder
 from tensorly.tenalg import multi_mode_dot
 
 from kale.embed.factorization import MIDA, MPCA
+
 from ..helpers.toy_dataset import make_domain_shifted_dataset
 
 N_COMPS = [1, 50, 100]

--- a/tests/evaluate/test_cross_validation.py
+++ b/tests/evaluate/test_cross_validation.py
@@ -1,18 +1,31 @@
 import numpy as np
 import pytest
 from sklearn.dummy import DummyClassifier
+from sklearn.linear_model import LogisticRegression
 
 from kale.evaluate import cross_validation
 from kale.pipeline.multi_domain_adapter import CoIRLS
+from sklearn.model_selection import LeaveOneGroupOut, StratifiedGroupKFold
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
+from sklearn.decomposition import PCA
+from ..helpers.toy_dataset import make_domain_shifted_dataset
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def sample_data():
     # Sample data for testing
-    x = np.array([np.random.rand(100)] * 8)
-    y = np.array([0, 0, 0, 0, 1, 1, 1, 1])
-    groups = np.array(["A", "A", "B", "B", "A", "A", "B", "B"])
-    return x, y, groups
+    X, y, groups = make_domain_shifted_dataset(
+        n_domains=2,
+        n_samples_per_class=100,
+        n_features=40,
+        class_sep=1.0,
+        centroid_shift_scale=5.0,
+        random_state=0,
+    )
+
+    # Convert labels to strings for testing
+    groups = np.where(groups == 0, "A", "B")
+    return X, y, groups
 
 
 # Checks leave-one-group-out results for above sample data
@@ -32,7 +45,7 @@ def check_leave_one_group_out_results(sample_data, estimator, domain_adaptation=
     assert results["Target"] == ["A", "B", "Average"]
 
     # Check if the number of samples is correct for each target group
-    assert results["Num_samples"] == [4, 4, 8]
+    assert results["Num_samples"] == [200, 200, 400]
 
     # Check if the accuracy scores are within the expected range
     for accuracy in results["Accuracy"]:
@@ -47,3 +60,31 @@ def test_leave_one_group_out_without_domain_adaptation(sample_data):
 def test_leave_one_group_out_with_domain_adaptation(sample_data):
     estimator = CoIRLS(kernel="linear", lambda_=1.0, alpha=1.0)
     check_leave_one_group_out_results(sample_data, estimator, domain_adaptation=True)
+
+
+@pytest.mark.parametrize("cv", [5, 10, LeaveOneGroupOut()])
+@pytest.mark.parametrize("estimator", [DummyClassifier(), LogisticRegression()])
+@pytest.mark.parametrize("transformer", [None, StandardScaler(), PCA()])
+@pytest.mark.parametrize("scoring", ["accuracy", "f1", "roc_auc", ["accuracy", "f1", "roc_auc"]])
+def test_cross_validate(sample_data, cv, estimator, transformer, scoring):
+    X, y, groups = sample_data
+
+    factors = OneHotEncoder(sparse_output=False).fit_transform(groups.reshape(-1, 1))
+
+    fit_args = None
+    if isinstance(estimator, CoIRLS):
+        fit_args = {"covariates": factors}
+
+    results = cross_validation.cross_validate(
+        estimator,
+        X,
+        y,
+        groups=groups,
+        cv=cv,
+        transformer=transformer,
+        scoring=scoring,
+        fit_args=fit_args,
+        error_score="raise",
+    )
+
+    print(results)

--- a/tests/evaluate/test_cross_validation.py
+++ b/tests/evaluate/test_cross_validation.py
@@ -72,7 +72,7 @@ def test_leave_one_group_out_with_domain_adaptation(sample_data):
 def test_cross_validate(sample_data, cv, transformer, scoring, return_indices, return_train_score, return_estimator):
     estimator = DummyClassifier()
 
-    X, y, groups = sample_data
+    x, y, groups = sample_data
 
     factors = OneHotEncoder(sparse_output=False).fit_transform(groups.reshape(-1, 1))
 
@@ -82,7 +82,7 @@ def test_cross_validate(sample_data, cv, transformer, scoring, return_indices, r
 
     results = cross_validation.cross_validate(
         estimator,
-        X,
+        x,
         y,
         groups=groups,
         cv=cv,

--- a/tests/evaluate/test_cross_validation.py
+++ b/tests/evaluate/test_cross_validation.py
@@ -82,6 +82,7 @@ def test_cross_validate(sample_data, cv, estimator, transformer, scoring):
         groups=groups,
         cv=cv,
         transformer=transformer,
+        factors=factors,
         scoring=scoring,
         fit_args=fit_args,
         error_score="raise",

--- a/tests/evaluate/test_cross_validation.py
+++ b/tests/evaluate/test_cross_validation.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-
 from sklearn.dummy import DummyClassifier
 from sklearn.model_selection import LeaveOneGroupOut
 from sklearn.preprocessing import OneHotEncoder, StandardScaler

--- a/tests/evaluate/test_cross_validation.py
+++ b/tests/evaluate/test_cross_validation.py
@@ -1,8 +1,7 @@
 import numpy as np
 import pytest
-from sklearn.decomposition import PCA
+
 from sklearn.dummy import DummyClassifier
-from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import LeaveOneGroupOut
 from sklearn.preprocessing import OneHotEncoder, StandardScaler
 

--- a/tests/evaluate/test_cross_validation.py
+++ b/tests/evaluate/test_cross_validation.py
@@ -63,16 +63,15 @@ def test_leave_one_group_out_with_domain_adaptation(sample_data):
     check_leave_one_group_out_results(sample_data, estimator, domain_adaptation=True)
 
 
-@pytest.mark.parametrize("cv", [5, 10, LeaveOneGroupOut()])
-@pytest.mark.parametrize("estimator", [DummyClassifier(), LogisticRegression()])
-@pytest.mark.parametrize("transformer", [None, StandardScaler(), PCA()])
+@pytest.mark.parametrize("cv", [3, LeaveOneGroupOut()])
+@pytest.mark.parametrize("transformer", [None, StandardScaler()])
 @pytest.mark.parametrize("scoring", ["accuracy", "f1", "roc_auc", ["accuracy", "f1", "roc_auc"]])
 @pytest.mark.parametrize("return_indices", [True, False])
 @pytest.mark.parametrize("return_train_score", [True, False])
 @pytest.mark.parametrize("return_estimator", [True, False])
-def test_cross_validate(
-    sample_data, cv, estimator, transformer, scoring, return_indices, return_train_score, return_estimator
-):
+def test_cross_validate(sample_data, cv, transformer, scoring, return_indices, return_train_score, return_estimator):
+    estimator = DummyClassifier()
+
     X, y, groups = sample_data
 
     factors = OneHotEncoder(sparse_output=False).fit_transform(groups.reshape(-1, 1))

--- a/tests/evaluate/test_cross_validation.py
+++ b/tests/evaluate/test_cross_validation.py
@@ -15,7 +15,7 @@ from ..helpers.toy_dataset import make_domain_shifted_dataset
 @pytest.fixture(scope="module")
 def sample_data():
     # Sample data for testing
-    X, y, groups = make_domain_shifted_dataset(
+    x, y, groups = make_domain_shifted_dataset(
         n_domains=2,
         n_samples_per_class=100,
         n_features=40,
@@ -26,7 +26,7 @@ def sample_data():
 
     # Convert labels to strings for testing
     groups = np.where(groups == 0, "A", "B")
-    return X, y, groups
+    return x, y, groups
 
 
 # Checks leave-one-group-out results for above sample data

--- a/tests/evaluate/test_cross_validation.py
+++ b/tests/evaluate/test_cross_validation.py
@@ -1,13 +1,14 @@
 import numpy as np
 import pytest
+from sklearn.decomposition import PCA
 from sklearn.dummy import DummyClassifier
 from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import LeaveOneGroupOut
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
 
 from kale.evaluate import cross_validation
 from kale.pipeline.multi_domain_adapter import CoIRLS
-from sklearn.model_selection import LeaveOneGroupOut, StratifiedGroupKFold
-from sklearn.preprocessing import OneHotEncoder, StandardScaler
-from sklearn.decomposition import PCA
+
 from ..helpers.toy_dataset import make_domain_shifted_dataset
 
 

--- a/tests/evaluate/test_cross_validation.py
+++ b/tests/evaluate/test_cross_validation.py
@@ -16,9 +16,9 @@ from ..helpers.toy_dataset import make_domain_shifted_dataset
 def sample_data():
     # Sample data for testing
     x, y, groups = make_domain_shifted_dataset(
-        n_domains=2,
-        n_samples_per_class=100,
-        n_features=40,
+        num_domains=2,
+        num_samples_per_class=100,
+        num_features=40,
         class_sep=1.0,
         centroid_shift_scale=5.0,
         random_state=0,

--- a/tests/helpers/toy_dataset.py
+++ b/tests/helpers/toy_dataset.py
@@ -1,0 +1,46 @@
+import numpy as np
+from sklearn.utils.validation import check_random_state
+
+
+def make_domain_shifted_dataset(
+    n_domains=3,
+    n_samples_per_class=100,
+    n_features=2,
+    class_sep=1.0,
+    centroid_shift_scale=5.0,
+    random_state=None,
+):
+    random_state = check_random_state(random_state)
+
+    # Shared linear separator
+    w = random_state.randn(n_features)
+    w = w / np.linalg.norm(w)
+
+    X_all = []
+    y_all = []
+    domain_all = []
+
+    for d in range(n_domains):
+        domain_shift = random_state.randn(n_features) * centroid_shift_scale
+
+        for label in [0, 1]:
+            class_mean = (label - 0.5) * class_sep * w + domain_shift
+            cov = np.eye(n_features)
+            X_class = random_state.multivariate_normal(class_mean, cov, n_samples_per_class)
+            y_class = np.full(n_samples_per_class, label)
+            domain_class = np.full(n_samples_per_class, d)
+
+            X_all.append(X_class)
+            y_all.append(y_class)
+            domain_all.append(domain_class)
+
+    X = np.vstack(X_all)
+    y = np.concatenate(y_all)
+    domains = np.concatenate(domain_all)
+
+    idx = random_state.permutation(len(X))
+    X = X[idx]
+    y = y[idx]
+    domains = domains[idx]
+
+    return X, y, domains

--- a/tests/helpers/toy_dataset.py
+++ b/tests/helpers/toy_dataset.py
@@ -16,7 +16,7 @@ def make_domain_shifted_dataset(
     w = random_state.randn(num_features)
     w = w / np.linalg.norm(w)
 
-    X_all = []
+    x_all = []
     y_all = []
     domain_all = []
 
@@ -26,15 +26,15 @@ def make_domain_shifted_dataset(
         for label in [0, 1]:
             class_mean = (label - 0.5) * class_sep * w + domain_shift
             cov = np.eye(num_features)
-            X_class = random_state.multivariate_normal(class_mean, cov, num_samples_per_class)
+            x_class = random_state.multivariate_normal(class_mean, cov, num_samples_per_class)
             y_class = np.full(num_samples_per_class, label)
             domain_class = np.full(num_samples_per_class, i_domain)
 
-            X_all.append(X_class)
+            x_all.append(x_class)
             y_all.append(y_class)
             domain_all.append(domain_class)
 
-    x = np.vstack(X_all)
+    x = np.vstack(x_all)
     y = np.concatenate(y_all)
     domains = np.concatenate(domain_all)
 

--- a/tests/helpers/toy_dataset.py
+++ b/tests/helpers/toy_dataset.py
@@ -20,7 +20,7 @@ def make_domain_shifted_dataset(
     y_all = []
     domain_all = []
 
-    for d in range(n_domains):
+    for i_domain in range(n_domains):
         domain_shift = random_state.randn(n_features) * centroid_shift_scale
 
         for label in [0, 1]:
@@ -28,19 +28,19 @@ def make_domain_shifted_dataset(
             cov = np.eye(n_features)
             X_class = random_state.multivariate_normal(class_mean, cov, n_samples_per_class)
             y_class = np.full(n_samples_per_class, label)
-            domain_class = np.full(n_samples_per_class, d)
+            domain_class = np.full(n_samples_per_class, i_domain)
 
             X_all.append(X_class)
             y_all.append(y_class)
             domain_all.append(domain_class)
 
-    X = np.vstack(X_all)
+    x = np.vstack(X_all)
     y = np.concatenate(y_all)
     domains = np.concatenate(domain_all)
 
-    idx = random_state.permutation(len(X))
-    X = X[idx]
+    idx = random_state.permutation(len(x))
+    x = x[idx]
     y = y[idx]
     domains = domains[idx]
 
-    return X, y, domains
+    return x, y, domains

--- a/tests/helpers/toy_dataset.py
+++ b/tests/helpers/toy_dataset.py
@@ -3,9 +3,9 @@ from sklearn.utils.validation import check_random_state
 
 
 def make_domain_shifted_dataset(
-    n_domains=3,
-    n_samples_per_class=100,
-    n_features=2,
+    num_domains=3,
+    num_samples_per_class=100,
+    num_features=2,
     class_sep=1.0,
     centroid_shift_scale=5.0,
     random_state=None,
@@ -13,22 +13,22 @@ def make_domain_shifted_dataset(
     random_state = check_random_state(random_state)
 
     # Shared linear separator
-    w = random_state.randn(n_features)
+    w = random_state.randn(num_features)
     w = w / np.linalg.norm(w)
 
     X_all = []
     y_all = []
     domain_all = []
 
-    for i_domain in range(n_domains):
-        domain_shift = random_state.randn(n_features) * centroid_shift_scale
+    for i_domain in range(num_domains):
+        domain_shift = random_state.randn(num_features) * centroid_shift_scale
 
         for label in [0, 1]:
             class_mean = (label - 0.5) * class_sep * w + domain_shift
-            cov = np.eye(n_features)
-            X_class = random_state.multivariate_normal(class_mean, cov, n_samples_per_class)
-            y_class = np.full(n_samples_per_class, label)
-            domain_class = np.full(n_samples_per_class, i_domain)
+            cov = np.eye(num_features)
+            X_class = random_state.multivariate_normal(class_mean, cov, num_samples_per_class)
+            y_class = np.full(num_samples_per_class, label)
+            domain_class = np.full(num_samples_per_class, i_domain)
 
             X_all.append(X_class)
             y_all.append(y_class)


### PR DESCRIPTION
### Description
Implements cross-validation function identical to `scikit-learn`'s API with additional functionality for domain adaptation, and pre-domain adaptation transformation.

### Note
The original `leave_one_group_out` is kept for compatibility with existing notebooks for `CoIRLS` demos.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
