### PR TITLE
Add symmetric weights and connectome vizualization

### DIFF
--- a/kale/interpret/model_weights.py
+++ b/kale/interpret/model_weights.py
@@ -3,7 +3,12 @@
 #         Haiping Lu, h.lu@sheffield.ac.uk or hplu@ieee.org
 # =============================================================================
 
+from itertools import combinations
+
 import numpy as np
+import pandas as pd
+from sklearn.utils import indexable
+from sklearn.utils._param_validation import Interval, Real, validate_params
 from tensorly.base import fold, unfold
 
 
@@ -31,3 +36,98 @@ def select_top_weight(weights, select_ratio: float = 0.05):
         top_weights = fold(top_weights, mode=0, shape=orig_shape)
 
     return top_weights
+
+
+@validate_params({"rois": ["array-like"]}, prefer_skip_nested_validation=True)
+def _get_pairwise_rois(rois):
+    """
+    Generate all unique ROI pair tuples (upper triangle only).
+
+    Constructs unique combinations of region-of-interest (ROI) names to represent undirected pairwise connections.
+    Useful for mapping pairwise connectivity weights or features.
+
+    Args:
+        rois (array-like):
+            List or array of ROI names (e.g., region labels or identifiers).
+
+    Returns:
+        array-like:
+            Array of ROI pair tuples corresponding to the upper triangle pairs.
+    """
+    pairs = list(combinations(rois, 2))
+    return np.array(pairs)
+
+
+@validate_params(
+    {
+        "weights": ["array-like"],
+        "labels": ["array-like"],
+        "coords": ["array-like"],
+        "p": [Interval(Real, 0, 1, closed="neither")],
+    },
+    prefer_skip_nested_validation=True,
+)
+def get_top_symmetric_weight(weights, labels, coords, p=0.001):
+    """
+    Construct a symmetric weight matrix for the top-p% ROI pairs.
+
+    Selects the top `p` proportion of ROI pairwise weights (by absolute value),
+    builds a symmetric matrix of the selected ROI connections, and extracts
+    the labels and coordinates of the involved ROIs.
+
+    Args:
+        weights (array-like):
+            1D array of edge weights for each ROI pair.
+        labels (array-like):
+            List of ROI names or indices in the full dataset.
+        coords (array-like):
+            2D array of ROI coordinates with shape (n_rois, 3).
+        p (float, optional):
+            Proportion of top weights to retain (default: 0.001). Must be in (0, 1).
+
+    Returns:
+        tuple:
+            - sym_weights (array-like): Symmetric matrix of top-weighted ROI connections.
+            - top_roi_labels (array-like): Labels of ROIs involved in top-weighted pairs.
+            - top_roi_coords (array-like): Coordinates corresponding to `top_roi_labels`.
+
+    Note:
+        This function assumes that the input `weights` correspond to the ROI pairs
+        in the upper triangle without duplicates, and converts them into a full symmetric matrix.
+    """
+    # Get lower triangle ROI pairs
+    pairwise_rois = _get_pairwise_rois(labels)
+
+    # Ensure weights and pairwise_rois have same length
+    weights, pairwise_rois = indexable(weights, pairwise_rois)
+
+    # Select top p% weights
+    weights = pd.Series(np.copy(weights), pairwise_rois)
+    rank = weights.abs().nlargest(int(len(weights.index) * p))
+    weights = weights[rank.index]
+
+    # Raises ValueError if no weights are selected
+    if len(weights) == 0:
+        raise ValueError("No weights selected. Please use larger p.")
+
+    # Use tuple keys directly from weights.index
+    pairs = np.array(list(weights.index))
+    unique = np.unique(pairs)
+
+    # Map unique ROIs to indices
+    label_to_index = {label: idx for idx, label in enumerate(labels)}
+    indices = [label_to_index[roi] for roi in unique]
+
+    # Create top roi mappings
+    top_labels = np.array(labels)[indices]
+    top_coords = np.array(coords)[indices]
+    mappings = {roi: idx for idx, roi in enumerate(top_labels)}
+
+    # Create symmetric weight matrix
+    sym_weights = np.zeros([len(indices)] * 2)
+    for (roi1, roi2), weight in zip(pairs, weights.values):
+        i, j = mappings[roi1], mappings[roi2]
+        sym_weights[i, j] = weight
+        sym_weights[j, i] = weight
+
+    return sym_weights, top_labels, top_coords

--- a/tests/interpret/test_model_weights.py
+++ b/tests/interpret/test_model_weights.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pytest
+
+from kale.interpret import model_weights
+
+
+def test_select_top_weight_vector():
+    weights = np.array([1, -3, 0.5, 4, -2])
+    selected = model_weights.select_top_weight(weights, select_ratio=0.4)
+    assert np.count_nonzero(selected) == 2
+    assert selected.shape == weights.shape
+
+
+def test_get_pairwise_rois_output():
+    rois = ["A", "B", "C"]
+    pairs = model_weights._get_pairwise_rois(rois)
+    expected = np.array([("A", "B"), ("A", "C"), ("B", "C")], dtype=object)
+    assert (pairs == expected).all()
+
+
+def test_get_top_symmetric_weight_shape_and_symmetry():
+    weights = np.array([0.9, 0.1, -0.5])
+    labels = ["A", "B", "C"]
+    coords = np.array([[0, 0, 0], [1, 1, 1], [2, 2, 2]])
+    sym_w, sym_labels, sym_coords = model_weights.get_top_symmetric_weight(weights, labels, coords, p=0.5)
+
+    assert sym_w.shape[0] == sym_w.shape[1]
+    assert np.allclose(sym_w, sym_w.T)
+    assert len(sym_labels) == len(sym_coords)
+
+
+def test_get_top_symmetric_weight_empty_if_p_zero():
+    weights = np.array([1.0, 0.5, 0.2])
+    labels = ["X", "Y", "Z"]
+    coords = np.random.rand(3, 3)
+    with pytest.raises(ValueError):
+        model_weights.get_top_symmetric_weight(weights, labels, coords, p=1e-6)

--- a/tests/interpret/test_visualize.py
+++ b/tests/interpret/test_visualize.py
@@ -90,7 +90,7 @@ def test_visualize_connectome(monkeypatch):
     monkeypatch.setattr(
         visualize,
         "get_top_symmetric_weight",
-        lambda weights, labels, coords, p: (np.ones(n_rois * (n_rois) // 2), labels, coords),
+        lambda weights, labels, coords, p: (np.ones([n_rois] * 2), labels, coords),
     )
 
     proj = visualize.visualize_connectome(weights, labels, coords, p=0.5)

--- a/tests/interpret/test_visualize.py
+++ b/tests/interpret/test_visualize.py
@@ -1,0 +1,138 @@
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+from kale.interpret import visualize
+
+matplotlib.use("Agg")  # Use non-interactive backend for tests
+
+
+def test_plot_weights():
+    # Create a small 2D array with positive and negative weights
+    weights = np.zeros((5, 5))
+    weights[1, 2] = 1.5  # positive
+    weights[3, 4] = -2.0  # negative
+    fig = visualize.plot_weights(weights)
+    ax = fig.axes[0]
+    # Extract plotted data for markers
+    lines = ax.get_lines()
+    # There should be two marker sets plotted (one for pos, one for neg)
+    assert len(lines) == 2
+    # Check that the positive marker is at (2, 1)
+    pos_line = lines[0]
+    xdata, ydata = pos_line.get_xdata(), pos_line.get_ydata()
+    assert (2 in xdata) and (1 in ydata)
+    # Check that the negative marker is at (4, 3)
+    neg_line = lines[1]
+    xdata2, ydata2 = neg_line.get_xdata(), neg_line.get_ydata()
+    assert (4 in xdata2) and (3 in ydata2)
+    plt.close(fig)
+
+
+def test_plot_multi_images():
+    # Create two simple images
+    images = np.zeros((2, 10, 10))
+    images[0, 5, 5] = 1
+    images[1, 2, 2] = 1
+    # Marker locations: 2 markers per image
+    marker_locs = np.array([[5, 5, 1, 1], [2, 2, 8, 8]])
+    marker_titles = ["A", "B"]
+    image_titles = ["Img1", "Img2"]
+    fig = visualize.plot_multi_images(
+        images,
+        n_cols=2,
+        marker_locs=marker_locs,
+        image_titles=image_titles,
+        marker_titles=marker_titles,
+        marker_cmap=None,
+        marker_kwargs={"s": 50},
+    )
+    # Check titles are set
+    for ax, title in zip(fig.axes, image_titles):
+        assert title in ax.get_title()
+    plt.close(fig)
+
+
+def test_distplot_1d():
+    data1 = np.random.randn(100)
+    data2 = np.random.randn(100) + 2
+    labels = ["Group 1", "Group 2"]
+    fig = visualize.distplot_1d([data1, data2], labels=labels, xlabel="Value", ylabel="Frequency", title="Dist")
+    # Check that the legend contains the labels
+    legend = fig.axes[0].get_legend()
+    assert legend is not None
+    legend_labels = [t.get_text() for t in legend.get_texts()]
+    for label in labels:
+        assert label in legend_labels
+    plt.close(fig)
+
+
+def test_visualize_connectome(monkeypatch):
+    # Provide dummy symmetric connectome data
+    n_rois = 4
+    # 1D weights for upper triangle (excluding diagonal)
+    weights = np.array([0.9, 0.1, 0.2, 0.8, 0.3, 0.7])
+    labels = np.array(["A", "B", "C", "D"])
+    coords = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0]])
+
+    # Patch plot_connectome and get_top_symmetric_weight to avoid heavy nilearn plotting
+    class DummyProj:
+        def __init__(self):
+            self.axes = {
+                "main": type("DummyAx", (), {"ax": type("DummyAx2", (), {"legend": lambda self, **kwargs: None})()})()
+            }
+
+        def add_markers(self, coords, marker_color, marker_size, label):
+            pass
+
+    monkeypatch.setattr(visualize, "plot_connectome", lambda *args, **kwargs: DummyProj())
+    monkeypatch.setattr(
+        visualize,
+        "get_top_symmetric_weight",
+        lambda weights, labels, coords, p: (np.ones(n_rois * (n_rois) // 2), labels, coords),
+    )
+
+    proj = visualize.visualize_connectome(weights, labels, coords, p=0.5)
+    assert hasattr(proj, "add_markers")
+
+
+def test_plot_weights_background_mask():
+    weights = np.ones((5, 5))
+    background = np.ones((5, 5))
+    background[2, 2] = 0  # mask center
+    weights[2, 2] = 5
+    fig = visualize.plot_weights(weights, background_img=background)
+    assert isinstance(fig, plt.Figure)
+    plt.close(fig)
+
+
+def test_plot_weights_invalid_shape():
+    with pytest.raises(ValueError):
+        visualize.plot_weights(np.ones((5, 5, 5)))
+
+
+def test_plot_multi_images_auto_rows():
+    images = np.random.rand(3, 5, 5)
+    marker_locs = np.array([[1, 1, 2, 2], [3, 3, 4, 4], [0, 0, 1, 1]])
+    fig = visualize.plot_multi_images(images, n_cols=2, marker_locs=marker_locs, marker_titles=["X", "Y"])
+    assert isinstance(fig, plt.Figure)
+    plt.close(fig)
+
+
+def test_distplot_1d_single_group():
+    data = np.random.randn(100)
+    fig = visualize.distplot_1d(data, labels=["Only"], xlabel="X", ylabel="Y", title="Title")
+    assert isinstance(fig, plt.Figure)
+    plt.close(fig)
+
+
+def test_distplot_1d_invalid_label_length():
+    with pytest.raises(IndexError):
+        visualize.distplot_1d([np.random.randn(100), np.random.randn(100)], labels=["Only one"])
+
+
+def test_plot_multi_images_invalid_image_titles():
+    with pytest.raises(ValueError):
+        images = np.random.rand(2, 5, 5)
+        visualize.plot_multi_images(images, image_titles=["One only"])


### PR DESCRIPTION
### Description
Adds functions to handle connectome visualization:
- `_get_pairwise_rois`: Generate a pairwise ROI mapping for each specified label.
- `get_top_p_symmetric_weight`: Produce top-p% weights converted to symmetric matrix with associated ROI labels and coordinates.
- `visualize_connectome`: Visualize the top-p weighted ROI connections as a connectome plot. An extension from `nilearn.plotting.plot_connectome` to add markers and ROI legends.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
