### PR TITLE
Add multimodal tri-stream pre-training and fine-tuning for image and signal modalities

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -34,4 +34,5 @@ torch-geometric
 torchsummary>=1.5.0
 torchvision
 urllib3<2.0
+wfdb
 yacs>=0.1.7

--- a/docs/source/kale.embed.rst
+++ b/docs/source/kale.embed.rst
@@ -57,6 +57,14 @@ kale.embed.image\_cnn module
    :undoc-members:
    :show-inheritance:
 
+kale.embed.signal\_cnn module
+----------------------------
+
+.. automodule:: kale.embed.signal_cnn
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 kale.embed.mogonet module
 -------------------------
 
@@ -65,6 +73,13 @@ kale.embed.mogonet module
     :undoc-members:
     :show-inheritance:
 
+kale.embed.multimodal_\_encoder module
+-------------------------
+
+.. automodule:: kale.embed.multimodal_encoder
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 kale.embed.positional\_encoding module
 --------------------------------------

--- a/docs/source/kale.embed.rst
+++ b/docs/source/kale.embed.rst
@@ -81,7 +81,7 @@ kale.embed.mogonet module
     :undoc-members:
     :show-inheritance:
 
-kale.embed.multimodal_\_encoder module
+kale.embed.multimodal\_encoder module
 -------------------------
 
 .. automodule:: kale.embed.multimodal_encoder

--- a/docs/source/kale.loaddata.rst
+++ b/docs/source/kale.loaddata.rst
@@ -78,6 +78,16 @@ kale.loaddata.tabular\_access module
    :undoc-members:
    :show-inheritance:
 
+
+kale.loaddata.signal\_image\_access module
+------------------------------------
+
+.. automodule:: kale.loaddata.signal_image_access
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
 kale.loaddata.tdc\_datasets module
 ----------------------------------
 

--- a/docs/source/kale.loaddata.rst
+++ b/docs/source/kale.loaddata.rst
@@ -87,6 +87,14 @@ kale.loaddata.tabular\_access module
    :show-inheritance:
 
 
+kale.loaddata.signal\_access module
+------------------------------------
+
+.. automodule:: kale.loaddata.signal_access
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 kale.loaddata.signal\_image\_access module
 ------------------------------------
 

--- a/docs/source/kale.pipeline.rst
+++ b/docs/source/kale.pipeline.rst
@@ -38,6 +38,14 @@ kale.pipeline.mpca\_trainer module
    :undoc-members:
    :show-inheritance:
 
+kale.pipeline.multimodal\_trainer module
+----------------------------------
+
+.. automodule:: kale.pipeline.multimodal_trainer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 kale.pipeline.multi\_domain\_adapter module
 -------------------------------------------
 

--- a/docs/source/kale.prepdata.rst
+++ b/docs/source/kale.prepdata.rst
@@ -38,6 +38,14 @@ kale.prepdata.string\_transform module
    :undoc-members:
    :show-inheritance:
 
+kale.prepdata.signal\_transform module
+--------------------------------------
+
+.. automodule:: kale.prepdata.signal_transform
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 kale.prepdata.supergraph\_construct module
 ------------------------------------------
 

--- a/kale/embed/factorization.py
+++ b/kale/embed/factorization.py
@@ -873,7 +873,7 @@ class MIDA(BaseKernelDomainAdapter):
 
     Args:
         num_components (int, optional): Number of components to keep. If None, all components are kept.
-        mu (float, optional): L2 kernel regularization coefficient. Default is 1.0.
+        mean (float, optional): L2 kernel regularization coefficient. Default is 1.0.
         eta (float, optional): Class-dependency regularization coefficient. Default is 1.0.
         ignore_y (bool, optional): Whether to ignore the target variable `y` during fitting. Default is False.
         augment (str, optional): Whether to augment the input data with factors. Can be "pre" (prepend factors),
@@ -919,14 +919,14 @@ class MIDA(BaseKernelDomainAdapter):
 
     _parameter_constraints: dict = {
         **BaseKernelDomainAdapter._parameter_constraints,
-        "mu": [Interval(Real, 0, None, closed="neither")],
+        "mean": [Interval(Real, 0, None, closed="neither")],
         "eta": [Interval(Real, 0, None, closed="neither")],
     }
 
     def __init__(
         self,
         num_components=None,
-        mu=1.0,
+        mean=1.0,
         eta=1.0,
         ignore_y=False,
         augment=None,
@@ -948,7 +948,7 @@ class MIDA(BaseKernelDomainAdapter):
         num_jobs=None,
     ):
         # L2 kernel regularization parameter
-        self.mu = mu
+        self.mean = mean
         # Class dependency regularization parameter
         self.eta = eta
 

--- a/kale/embed/factorization.py
+++ b/kale/embed/factorization.py
@@ -873,7 +873,7 @@ class MIDA(BaseKernelDomainAdapter):
 
     Args:
         num_components (int, optional): Number of components to keep. If None, all components are kept.
-        mean (float, optional): L2 kernel regularization coefficient. Default is 1.0.
+        mu (float, optional): L2 kernel regularization coefficient. Default is 1.0.
         eta (float, optional): Class-dependency regularization coefficient. Default is 1.0.
         ignore_y (bool, optional): Whether to ignore the target variable `y` during fitting. Default is False.
         augment (str, optional): Whether to augment the input data with factors. Can be "pre" (prepend factors),
@@ -919,14 +919,14 @@ class MIDA(BaseKernelDomainAdapter):
 
     _parameter_constraints: dict = {
         **BaseKernelDomainAdapter._parameter_constraints,
-        "mean": [Interval(Real, 0, None, closed="neither")],
+        "mu": [Interval(Real, 0, None, closed="neither")],
         "eta": [Interval(Real, 0, None, closed="neither")],
     }
 
     def __init__(
         self,
         num_components=None,
-        mean=1.0,
+        mu=1.0,
         eta=1.0,
         ignore_y=False,
         augment=None,
@@ -948,7 +948,7 @@ class MIDA(BaseKernelDomainAdapter):
         num_jobs=None,
     ):
         # L2 kernel regularization parameter
-        self.mean = mean
+        self.mu = mu
         # Class dependency regularization parameter
         self.eta = eta
 

--- a/kale/embed/feature_fusion.py
+++ b/kale/embed/feature_fusion.py
@@ -240,10 +240,11 @@ class ProductOfExperts(nn.Module):
         poe = ProductOfExperts()
         combined_mu, combined_logvar = poe(mu_experts, logvar_experts)
     """
+
     def forward(self, mu, logvar, eps=1e-8):
         var = torch.exp(logvar) + eps
-        T = 1. / (var + eps)
+        T = 1.0 / (var + eps)
         pd_mu = torch.sum(mu * T, dim=0) / torch.sum(T, dim=0)
-        pd_var = 1. / torch.sum(T, dim=0)
+        pd_var = 1.0 / torch.sum(T, dim=0)
         pd_logvar = torch.log(pd_var + eps)
         return pd_mu, pd_logvar

--- a/kale/embed/feature_fusion.py
+++ b/kale/embed/feature_fusion.py
@@ -1,4 +1,4 @@
-"""This module implements fiur different multimodal fusion methods:
+"""This module implements four different multimodal fusion methods:
 1. Concat
 2. BimodalInteractionFusion
 3. LowRankTensorFusion
@@ -220,7 +220,7 @@ class ProductOfExperts(nn.Module):
     by computing their product in closed form. This is commonly used in multimodal variational autoencoders (VAE)
     and probabilistic models to fuse information from different modalities or sources, yielding a consensus latent distribution.
 
-    For each expert, the inputs are mean (`mu`) and log-variance (`logvar`) tensors, and the output is the mean and log-variance
+    For each expert, the inputs are mean (`mean`) and log-variance (`log_var`) tensors, and the output is the mean and log-variance
     of the combined product Gaussian. This formulation enables principled uncertainty fusion and robust inference
     in the presence of missing or noisy modalities.
 
@@ -229,20 +229,20 @@ class ProductOfExperts(nn.Module):
         combined_mu, combined_log_var = poe(mu_experts, log_var_experts)
     """
 
-    def forward(self, mu, logvar, eps=1e-8):
+    def forward(self, mean, log_var, eps=1e-8):
         """
         Args:
-            mu (Tensor): Mean values from all experts, shape (num_experts, batch_size, latent_dim)
-            logvar (Tensor): Log-variance values from all experts, shape (num_experts, batch_size, latent_dim)
+            mean (Tensor): Mean values from all experts, shape (num_experts, batch_size, latent_dim)
+            log_var (Tensor): Log-variance values from all experts, shape (num_experts, batch_size, latent_dim)
             eps (float, optional): Small value for numerical stability. Default is 1e-8.
 
         Returns:
             prod_mean (Tensor): Mean of the combined product Gaussian, shape (batch_size, latent_dim)
             prod_log_var (Tensor): Log-variance of the combined product Gaussian, shape (batch_size, latent_dim)
         """
-        var = torch.exp(logvar) + eps
+        var = torch.exp(log_var) + eps
         precision = 1.0 / (var + eps)
-        prod_mean = torch.sum(mu * precision, dim=0) / torch.sum(precision, dim=0)
+        prod_mean = torch.sum(mean * precision, dim=0) / torch.sum(precision, dim=0)
         prod_var = 1.0 / torch.sum(precision, dim=0)
         prod_log_var = torch.log(prod_var + eps)
         return prod_mean, prod_log_var

--- a/kale/embed/feature_fusion.py
+++ b/kale/embed/feature_fusion.py
@@ -246,4 +246,3 @@ class ProductOfExperts(nn.Module):
         prod_var = 1.0 / torch.sum(precision, dim=0)
         prod_log_var = torch.log(prod_var + eps)
         return prod_mean, prod_log_var
-

--- a/kale/embed/image_cnn.py
+++ b/kale/embed/image_cnn.py
@@ -2,7 +2,6 @@
 ImageNet). The code is based on https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/models/modules.py,
  which is for domain adaptation.
 """
-import torch
 import torch.nn as nn
 from torch.nn import functional as F
 from torchvision import models
@@ -15,10 +14,10 @@ class Flatten(nn.Module):
     the batch size.
 
     Examples:
-        >>> x = torch.randn(8, 3, 224, 224)
-        >>> x = Flatten()(x)
-        >>> print(x.shape)
-        >>> (8, 150528)
+        x = torch.randn(8, 3, 224, 224)
+        x = Flatten()(x)
+        print(x.shape)
+        (8, 150528)
     """
 
     def __init__(self):
@@ -34,10 +33,10 @@ class Identity(nn.Module):
     It returns the input tensor as the output.
 
     Examples:
-        >>> x = torch.randn(8, 3, 224, 224)
-        >>> x = Identity()(x)
-        >>> print(x.shape)
-        >>> (8, 3, 224, 224)
+        x = torch.randn(8, 3, 224, 224)
+        x = Identity()(x)
+        print(x.shape)
+        (8, 3, 224, 224)
     """
 
     def __init__(self):
@@ -57,7 +56,7 @@ class SmallCNNFeature(nn.Module):
         kernel_size (int): the size of the convolution kernel (default=5).
 
     Examples::
-        >>> feature_network = SmallCNNFeature(num_channels)
+        feature_network = SmallCNNFeature(num_channels)
     """
 
     def __init__(self, num_channels=3, kernel_size=5):
@@ -388,7 +387,6 @@ class LeNet(nn.Module):
             return output.squeeze()
         return output
 
-import torch.nn as nn
 
 class ImageVAEEncoder(nn.Module):
     """
@@ -414,6 +412,7 @@ class ImageVAEEncoder(nn.Module):
         encoder = ImageVAEEncoder(input_channels=1, latent_dim=128)
         mu, logvar = encoder(images)
     """
+
     def __init__(self, input_channels=1, latent_dim=256):
         super().__init__()
         self.conv1 = nn.Conv2d(input_channels, 16, kernel_size=3, stride=2, padding=1)
@@ -432,5 +431,3 @@ class ImageVAEEncoder(nn.Module):
         mu = self.fc_mu(x)
         logvar = self.fc_logvar(x)
         return mu, logvar
-
-

--- a/kale/embed/image_cnn.py
+++ b/kale/embed/image_cnn.py
@@ -33,9 +33,9 @@ class Identity(nn.Module):
     It returns the input tensor as the output.
 
     Examples:
-        x = torch.randn(8, 3, 224, 224)
-        x = Identity()(x)
-        print(x.shape)
+        >>> x = torch.randn(8, 3, 224, 224)
+        >>> x = Identity()(x)
+        >>> print(x.shape)
         (8, 3, 224, 224)
     """
 
@@ -56,7 +56,7 @@ class SmallCNNFeature(nn.Module):
         kernel_size (int): the size of the convolution kernel (default=5).
 
     Examples::
-        feature_network = SmallCNNFeature(num_channels)
+        >>> feature_network = SmallCNNFeature(num_channels)
     """
 
     def __init__(self, num_channels=3, kernel_size=5):
@@ -388,9 +388,9 @@ class LeNet(nn.Module):
         return output
 
 
-class ImageVaeEncoder(nn.Module):
+class ImageVAEEncoder(nn.Module):
     """
-    ImageVaeEncoder encodes 2D image data into a latent representation for use in a Variational Autoencoder (VAE).
+    ImageVAEEncoder encodes 2D image data into a latent representation for use in a Variational Autoencoder (VAE).
 
     Note:
         This implementation assumes the input images are 224 x 224 pixels.
@@ -409,12 +409,12 @@ class ImageVaeEncoder(nn.Module):
         x (Tensor): Input image tensor of shape (batch_size, input_channels, 224, 224).
 
     Forward Output:
-        mu (Tensor): Mean vector of the latent Gaussian distribution, shape (batch_size, latent_dim).
+        mean (Tensor): Mean vector of the latent Gaussian distribution, shape (batch_size, latent_dim).
         log_var (Tensor): Log-variance vector of the latent Gaussian, shape (batch_size, latent_dim).
 
     Example:
-        encoder = ImageVaeEncoder(input_channels=1, latent_dim=128)
-        mu, log_var = encoder(images)
+        encoder = ImageVAEEncoder(input_channels=1, latent_dim=128)
+        mean, log_var = encoder(images)
     """
 
     def __init__(self, input_channels=1, latent_dim=256):
@@ -436,13 +436,13 @@ class ImageVaeEncoder(nn.Module):
             x (Tensor): Input image tensor, shape (batch_size, input_channels, 224, 224)
 
         Returns:
-            mu (Tensor): Latent mean, shape (batch_size, latent_dim)
-            logvar (Tensor): Latent log-variance, shape (batch_size, latent_dim)
+            mean (Tensor): Latent mean, shape (batch_size, latent_dim)
+            log_var (Tensor): Latent log-variance, shape (batch_size, latent_dim)
         """
         x = self.relu(self.conv1(x))
         x = self.relu(self.conv2(x))
         x = self.relu(self.conv3(x))
         x = self.flatten(x)
-        mu = self.fc_mu(x)
+        mean = self.fc_mu(x)
         log_var = self.fc_log_var(x)
-        return mu, log_var
+        return mean, log_var

--- a/kale/embed/image_cnn.py
+++ b/kale/embed/image_cnn.py
@@ -2,7 +2,7 @@
 ImageNet). The code is based on https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/models/modules.py,
  which is for domain adaptation.
 """
-
+import torch
 import torch.nn as nn
 from torch.nn import functional as F
 from torchvision import models
@@ -387,3 +387,50 @@ class LeNet(nn.Module):
         if self.squeeze_output:
             return output.squeeze()
         return output
+
+import torch.nn as nn
+
+class ImageVAEEncoder(nn.Module):
+    """
+    ImageVAEEncoder encodes 2D image data into a latent representation for use in a Variational Autoencoder (VAE).
+
+    This encoder consists of a stack of convolutional layers followed by fully connected layers to produce the
+    mean and log-variance of the latent Gaussian distribution. It is suitable for compressing image modalities
+    (such as chest X-rays) into a lower-dimensional latent space, facilitating downstream tasks like reconstruction,
+    multimodal learning, or generative modelling.
+
+    Args:
+        input_channels (int, optional): Number of input channels in the image (e.g., 1 for grayscale, 3 for RGB). Default is 1.
+        latent_dim (int, optional): Dimensionality of the latent space representation. Default is 256.
+
+    Forward Input:
+        x (Tensor): Input image tensor of shape (batch_size, input_channels, H, W).
+
+    Forward Output:
+        mu (Tensor): Mean vector of the latent Gaussian distribution, shape (batch_size, latent_dim).
+        logvar (Tensor): Log-variance vector of the latent Gaussian, shape (batch_size, latent_dim).
+
+    Example:
+        encoder = ImageVAEEncoder(input_channels=1, latent_dim=128)
+        mu, logvar = encoder(images)
+    """
+    def __init__(self, input_channels=1, latent_dim=256):
+        super().__init__()
+        self.conv1 = nn.Conv2d(input_channels, 16, kernel_size=3, stride=2, padding=1)
+        self.conv2 = nn.Conv2d(16, 32, kernel_size=3, stride=2, padding=1)
+        self.conv3 = nn.Conv2d(32, 64, kernel_size=3, stride=2, padding=1)
+        self.flatten = nn.Flatten()
+        self.fc_mu = nn.Linear(64 * 28 * 28, latent_dim)
+        self.fc_logvar = nn.Linear(64 * 28 * 28, latent_dim)
+        self.relu = nn.ReLU()
+
+    def forward(self, x):
+        x = self.relu(self.conv1(x))
+        x = self.relu(self.conv2(x))
+        x = self.relu(self.conv3(x))
+        x = self.flatten(x)
+        mu = self.fc_mu(x)
+        logvar = self.fc_logvar(x)
+        return mu, logvar
+
+

--- a/kale/embed/image_cnn.py
+++ b/kale/embed/image_cnn.py
@@ -387,6 +387,7 @@ class LeNet(nn.Module):
             return output.squeeze()
         return output
 
+
 class ImageVaeEncoder(nn.Module):
     """
     ImageVaeEncoder encodes 2D image data into a latent representation for use in a Variational Autoencoder (VAE).

--- a/kale/embed/multimodal_encoder.py
+++ b/kale/embed/multimodal_encoder.py
@@ -10,11 +10,12 @@ Contains multimodal encoder models, such as BimodalVAE, for joint representation
 
 import torch
 import torch.nn as nn
+
+from kale.embed.feature_fusion import ProductOfExperts
 from kale.embed.image_cnn import ImageVAEEncoder
 from kale.embed.signal_cnn import SignalVAEEncoder
-from kale.predict.decode import ImageVAEDecoder
-from kale.predict.decode import SignalVAEDecoder
-from kale.embed.feature_fusion import ProductOfExperts
+from kale.predict.decode import ImageVAEDecoder, SignalVAEDecoder
+
 
 class BimodalVAE(nn.Module):
     """
@@ -134,4 +135,3 @@ class BimodalVAE(nn.Module):
             logvar = torch.cat((logvar, signal_logvar.unsqueeze(0)), dim=0)
         mu, logvar = self.experts(mu, logvar)
         return mu, logvar
-

--- a/kale/embed/multimodal_encoder.py
+++ b/kale/embed/multimodal_encoder.py
@@ -1,0 +1,137 @@
+# =============================================================================
+# Author: Mohammod Suvon, m.suvon@sheffield.ac.uk
+# =============================================================================
+
+"""
+multimodal_encoder.py
+
+Contains multimodal encoder models, such as BimodalVAE, for joint representation learning.
+"""
+
+import torch
+import torch.nn as nn
+from kale.embed.image_cnn import ImageVAEEncoder
+from kale.embed.signal_cnn import SignalVAEEncoder
+from kale.predict.decode import ImageVAEDecoder
+from kale.predict.decode import SignalVAEDecoder
+from kale.embed.feature_fusion import ProductOfExperts
+
+class BimodalVAE(nn.Module):
+    """
+    BimodalVAE performs joint variational autoencoding for two input modalities (such as images and 1D signals).
+
+    The architecture comprises separate encoders and decoders for each modality (e.g., an image encoder/decoder and a signal encoder/decoder),
+    and uses a Product of Experts (PoE) mechanism to fuse the latent distributions from each modality as well as a universal prior expert.
+    During inference, the model supports missing modalities by marginalizing over available experts.
+
+    This flexible design allows for robust unsupervised representation learning, missing data imputation, and multimodal generation tasks
+    in diverse domains including medical imaging, sensor fusion, and more.
+
+    Args:
+        image_input_channels (int, optional): Number of input channels in the image modality (e.g., 1 for grayscale). Default is 1.
+        signal_input_dim (int, optional): Length of the 1D input signal. Default is 60000.
+        latent_dim (int, optional): Dimensionality of the shared latent space. Default is 256.
+
+    Forward Inputs:
+        image (Tensor, optional): Image tensor of shape (batch_size, image_input_channels, H, W)
+        signal (Tensor, optional): 1D signal tensor of shape (batch_size, 1, signal_input_dim)
+
+    Forward Outputs:
+        image_recon (Tensor): Reconstructed image tensor (batch_size, image_input_channels, H, W)
+        signal_recon (Tensor): Reconstructed signal tensor (batch_size, 1, signal_input_dim)
+        mu (Tensor): Mean vector of the fused latent distribution (batch_size, latent_dim)
+        logvar (Tensor): Log-variance vector of the fused latent distribution (batch_size, latent_dim)
+
+    Example:
+        model = MultimodalVAE(image_input_channels=1, signal_input_dim=60000, latent_dim=128)
+        image_recon, signal_recon, mu, logvar = model(image=image_data, signal=signal_data)
+    """
+
+    def __init__(self, image_input_channels=1, signal_input_dim=60000, latent_dim=256):
+        super().__init__()
+        self.image_encoder = ImageVAEEncoder(image_input_channels, latent_dim)
+        self.signal_encoder = SignalVAEEncoder(signal_input_dim, latent_dim)
+        self.image_decoder = ImageVAEDecoder(latent_dim, image_input_channels)
+        self.signal_decoder = SignalVAEDecoder(latent_dim, signal_input_dim)
+        self.experts = ProductOfExperts()
+        self.n_latents = latent_dim
+
+    @staticmethod
+    def prior_expert(size, use_cuda=False):
+        """
+        Creates a universal prior expert as a spherical Gaussian N(0, 1) with specified size.
+
+        Args:
+            size (tuple): Desired shape, typically (1, batch_size, latent_dim).
+            use_cuda (bool): Whether to move tensors to CUDA.
+
+        Returns:
+            mu (Tensor): Zero-mean tensor.
+            logvar (Tensor): Zero log-variance tensor.
+        """
+        mu = torch.zeros(size)
+        logvar = torch.zeros(size)
+        if use_cuda:
+            mu = mu.cuda()
+            logvar = logvar.cuda()
+        return mu, logvar
+
+    def reparametrize(self, mu, logvar):
+        """
+        Applies the reparameterization trick to sample from a Gaussian distribution parameterized by mu and logvar.
+
+        This allows backpropagation through stochastic nodes by expressing the random variable as a deterministic
+        function of mu, logvar, and noise. During training, returns a random sample from N(mu, sigma^2).
+        During evaluation, returns mu (the mean).
+
+        Args:
+            mu (Tensor): Mean of the Gaussian, shape (batch_size, latent_dim).
+            logvar (Tensor): Log-variance of the Gaussian, shape (batch_size, latent_dim).
+
+        Returns:
+            z (Tensor): Sampled latent vector, shape (batch_size, latent_dim).
+        """
+        if self.training:
+            std = torch.exp(0.5 * logvar)
+            eps = torch.randn_like(std)
+            return mu + eps * std
+        else:
+            return mu
+
+    def forward(self, image=None, signal=None):
+        mu, logvar = self.infer(image, signal)
+        z = self.reparametrize(mu, logvar)
+        image_recon = self.image_decoder(z)
+        signal_recon = self.signal_decoder(z)
+        return image_recon, signal_recon, mu, logvar
+
+    def infer(self, image=None, signal=None):
+        """
+        Computes the parameters of the fused latent distribution using the available modalities and the universal prior expert.
+
+        Encodes the input image and/or signal into their respective latent Gaussians, concatenates them (along with the prior expert),
+        and applies the Product of Experts to produce a single joint posterior for the latent variables.
+        This function supports missing modalities by only using the provided inputs.
+
+        Args:
+            image (Tensor, optional): Image tensor, shape (batch_size, channels, H, W).
+            signal (Tensor, optional): 1D signal tensor, shape (batch_size, 1, signal_length).
+
+        Returns:
+            mu (Tensor): Mean vector of the fused latent distribution, shape (batch_size, latent_dim).
+            logvar (Tensor): Log-variance vector of the fused latent distribution, shape (batch_size, latent_dim).
+        """
+        batch_size = image.size(0) if image is not None else signal.size(0)
+        use_cuda = next(self.parameters()).is_cuda
+        mu, logvar = self.prior_expert((1, batch_size, self.n_latents), use_cuda=use_cuda)
+        if image is not None:
+            img_mu, img_logvar = self.image_encoder(image)
+            mu = torch.cat((mu, img_mu.unsqueeze(0)), dim=0)
+            logvar = torch.cat((logvar, img_logvar.unsqueeze(0)), dim=0)
+        if signal is not None:
+            signal_mu, signal_logvar = self.signal_encoder(signal)
+            mu = torch.cat((mu, signal_mu.unsqueeze(0)), dim=0)
+            logvar = torch.cat((logvar, signal_logvar.unsqueeze(0)), dim=0)
+        mu, logvar = self.experts(mu, logvar)
+        return mu, logvar
+

--- a/kale/embed/multimodal_encoder.py
+++ b/kale/embed/multimodal_encoder.py
@@ -12,14 +12,14 @@ import torch
 import torch.nn as nn
 
 from kale.embed.feature_fusion import ProductOfExperts
-from kale.embed.image_cnn import ImageVAEEncoder
-from kale.embed.signal_cnn import SignalVAEEncoder
-from kale.predict.decode import ImageVAEDecoder, SignalVAEDecoder
+from kale.embed.image_cnn import ImageVaeEncoder
+from kale.embed.signal_cnn import SignalVaeEncoder
+from kale.predict.decode import ImageVaeDecoder, SignalVaeDecoder
 
 
-class BimodalVAE(nn.Module):
+class SignalImageVAE(nn.Module):
     """
-    BimodalVAE performs joint variational autoencoding for two input modalities (such as images and 1D signals).
+    SignalImageVAE performs joint variational autoencoding for two input modality image and signal).
 
     The architecture comprises separate encoders and decoders for each modality (e.g., an image encoder/decoder and a signal encoder/decoder),
     and uses a Product of Experts (PoE) mechanism to fuse the latent distributions from each modality as well as a universal prior expert.
@@ -44,16 +44,16 @@ class BimodalVAE(nn.Module):
         logvar (Tensor): Log-variance vector of the fused latent distribution (batch_size, latent_dim)
 
     Example:
-        model = MultimodalVAE(image_input_channels=1, signal_input_dim=60000, latent_dim=128)
+        model = SignalImageVAE(image_input_channels=1, signal_input_dim=60000, latent_dim=128)
         image_recon, signal_recon, mu, logvar = model(image=image_data, signal=signal_data)
     """
 
     def __init__(self, image_input_channels=1, signal_input_dim=60000, latent_dim=256):
         super().__init__()
-        self.image_encoder = ImageVAEEncoder(image_input_channels, latent_dim)
-        self.signal_encoder = SignalVAEEncoder(signal_input_dim, latent_dim)
-        self.image_decoder = ImageVAEDecoder(latent_dim, image_input_channels)
-        self.signal_decoder = SignalVAEDecoder(latent_dim, signal_input_dim)
+        self.image_encoder = ImageVaeEncoder(image_input_channels, latent_dim)
+        self.signal_encoder = SignalVaeEncoder(signal_input_dim, latent_dim)
+        self.image_decoder = ImageVaeDecoder(latent_dim, image_input_channels)
+        self.signal_decoder = SignalVaeDecoder(latent_dim, signal_input_dim)
         self.experts = ProductOfExperts()
         self.n_latents = latent_dim
 

--- a/kale/embed/signal_cnn.py
+++ b/kale/embed/signal_cnn.py
@@ -8,9 +8,9 @@ This module provides CNN-based encoders for transforming 1D signals into latent 
 import torch.nn as nn
 
 
-class SignalVaeEncoder(nn.Module):
+class SignalVAEEncoder(nn.Module):
     """
-    SignalVaeEncoder encodes 1D signals into a latent representation suitable for variational autoencoders (VAE).
+    SignalVAEEncoder encodes 1D signals into a latent representation suitable for variational autoencoders (VAE).
 
     This encoder uses a series of 1D convolutional layers to extract hierarchical temporal features from generic 1D signals,
     followed by fully connected layers that output the mean and log-variance vectors for the latent Gaussian distribution.
@@ -24,12 +24,12 @@ class SignalVaeEncoder(nn.Module):
         x (Tensor): Input signal tensor of shape (batch_size, 1, input_dim).
 
     Forward Output:
-        mu (Tensor): Mean vector of the latent Gaussian distribution, shape (batch_size, latent_dim).
-        logvar (Tensor): Log-variance vector of the latent Gaussian, shape (batch_size, latent_dim).
+        mean (Tensor): Mean vector of the latent Gaussian distribution, shape (batch_size, latent_dim).
+        log_var (Tensor): Log-variance vector of the latent Gaussian, shape (batch_size, latent_dim).
 
     Example:
-        encoder = SignalVaeEncoder(input_dim=60000, latent_dim=128)
-        mu, logvar = encoder(signals)
+        encoder = SignalVAEEncoder(input_dim=60000, latent_dim=128)
+        mean, log_var = encoder(signals)
     """
 
     def __init__(self, input_dim=60000, latent_dim=256):
@@ -39,7 +39,7 @@ class SignalVaeEncoder(nn.Module):
         self.conv3 = nn.Conv1d(32, 64, kernel_size=3, stride=2, padding=1)
         self.flatten = nn.Flatten()
         self.fc_mu = nn.Linear(64 * (input_dim // 8), latent_dim)
-        self.fc_logvar = nn.Linear(64 * (input_dim // 8), latent_dim)
+        self.fc_log_var = nn.Linear(64 * (input_dim // 8), latent_dim)
         self.relu = nn.ReLU()
 
     def forward(self, x):
@@ -47,6 +47,6 @@ class SignalVaeEncoder(nn.Module):
         x = self.relu(self.conv2(x))
         x = self.relu(self.conv3(x))
         x = self.flatten(x)
-        mu = self.fc_mu(x)
-        logvar = self.fc_logvar(x)
-        return mu, logvar
+        mean = self.fc_mu(x)
+        log_var = self.fc_log_var(x)
+        return mean, log_var

--- a/kale/embed/signal_cnn.py
+++ b/kale/embed/signal_cnn.py
@@ -7,6 +7,7 @@ This module provides CNN-based encoders for transforming 1D signals into latent 
 
 import torch.nn as nn
 
+
 class SignalVAEEncoder(nn.Module):
     """
     SignalVAEEncoder encodes 1D signals into a latent representation suitable for variational autoencoders (VAE).
@@ -30,6 +31,7 @@ class SignalVAEEncoder(nn.Module):
         encoder = SignalVAEEncoder(input_dim=60000, latent_dim=128)
         mu, logvar = encoder(signals)
     """
+
     def __init__(self, input_dim=60000, latent_dim=256):
         super().__init__()
         self.conv1 = nn.Conv1d(1, 16, kernel_size=3, stride=2, padding=1)

--- a/kale/embed/signal_cnn.py
+++ b/kale/embed/signal_cnn.py
@@ -1,0 +1,50 @@
+# =============================================================================
+# Author: Mohammod Suvon, m.suvon@sheffield.ac.uk
+# =============================================================================
+"""
+This module provides CNN-based encoders for transforming 1D signals into latent representations, primarily for use in variational autoencoders (VAE) and related deep learning applications.
+"""
+
+import torch.nn as nn
+
+class SignalVAEEncoder(nn.Module):
+    """
+    SignalVAEEncoder encodes 1D signals into a latent representation suitable for variational autoencoders (VAE).
+
+    This encoder uses a series of 1D convolutional layers to extract hierarchical temporal features from generic 1D signals,
+    followed by fully connected layers that output the mean and log-variance vectors for the latent Gaussian distribution.
+    This structure is commonly used for unsupervised or multimodal learning on time-series or sequential data.
+
+    Args:
+        input_dim (int, optional): Length of the input 1D signal (number of time points). Default is 60000.
+        latent_dim (int, optional): Dimensionality of the latent space representation. Default is 256.
+
+    Forward Input:
+        x (Tensor): Input signal tensor of shape (batch_size, 1, input_dim).
+
+    Forward Output:
+        mu (Tensor): Mean vector of the latent Gaussian distribution, shape (batch_size, latent_dim).
+        logvar (Tensor): Log-variance vector of the latent Gaussian, shape (batch_size, latent_dim).
+
+    Example:
+        encoder = SignalVAEEncoder(input_dim=60000, latent_dim=128)
+        mu, logvar = encoder(signals)
+    """
+    def __init__(self, input_dim=60000, latent_dim=256):
+        super().__init__()
+        self.conv1 = nn.Conv1d(1, 16, kernel_size=3, stride=2, padding=1)
+        self.conv2 = nn.Conv1d(16, 32, kernel_size=3, stride=2, padding=1)
+        self.conv3 = nn.Conv1d(32, 64, kernel_size=3, stride=2, padding=1)
+        self.flatten = nn.Flatten()
+        self.fc_mu = nn.Linear(64 * (input_dim // 8), latent_dim)
+        self.fc_logvar = nn.Linear(64 * (input_dim // 8), latent_dim)
+        self.relu = nn.ReLU()
+
+    def forward(self, x):
+        x = self.relu(self.conv1(x))
+        x = self.relu(self.conv2(x))
+        x = self.relu(self.conv3(x))
+        x = self.flatten(x)
+        mu = self.fc_mu(x)
+        logvar = self.fc_logvar(x)
+        return mu, logvar

--- a/kale/embed/signal_cnn.py
+++ b/kale/embed/signal_cnn.py
@@ -8,9 +8,9 @@ This module provides CNN-based encoders for transforming 1D signals into latent 
 import torch.nn as nn
 
 
-class SignalVAEEncoder(nn.Module):
+class SignalVaeEncoder(nn.Module):
     """
-    SignalVAEEncoder encodes 1D signals into a latent representation suitable for variational autoencoders (VAE).
+    SignalVaeEncoder encodes 1D signals into a latent representation suitable for variational autoencoders (VAE).
 
     This encoder uses a series of 1D convolutional layers to extract hierarchical temporal features from generic 1D signals,
     followed by fully connected layers that output the mean and log-variance vectors for the latent Gaussian distribution.
@@ -28,7 +28,7 @@ class SignalVAEEncoder(nn.Module):
         logvar (Tensor): Log-variance vector of the latent Gaussian, shape (batch_size, latent_dim).
 
     Example:
-        encoder = SignalVAEEncoder(input_dim=60000, latent_dim=128)
+        encoder = SignalVaeEncoder(input_dim=60000, latent_dim=128)
         mu, logvar = encoder(signals)
     """
 

--- a/kale/evaluate/metrics.py
+++ b/kale/evaluate/metrics.py
@@ -326,8 +326,8 @@ class protonet_loss:
         device (torch.device): The device in computation. Default: torch.device("cuda")
 
     Examples:
-        loss_fn = protonet_loss(num_classes=5, num_query_samples=15, device=torch.device("cuda"))
-        loss, acc = loss_fn(feature_support, feature_query)
+        >>> loss_fn = protonet_loss(num_classes=5, num_query_samples=15, device=torch.device("cuda"))
+        >>> loss, acc = loss_fn(feature_support, feature_query)
 
     Reference:
         Snell, J., Swersky, K. and Zemel, R., 2017. Prototypical networks for few-shot learning. Advances in Neural Information Processing Systems, 30.
@@ -467,8 +467,8 @@ def signal_image_elbo_loss(
     target_image,
     recon_signal,
     target_signal,
-    mu,
-    logvar,
+    mean,
+    log_var,
     lambda_image=1.0,
     lambda_signal=1.0,
     annealing_factor=1.0,
@@ -487,8 +487,8 @@ def signal_image_elbo_loss(
         signal_mse = F.mse_loss(recon_signal, target_signal, reduction="sum") * lambda_signal
 
     recon_loss = (image_mse + signal_mse) * scale_factor
-    logvar = torch.clamp(logvar, min=-10, max=10)
-    kl_div = -0.5 * torch.sum(1 + logvar - mu.pow(2) - logvar.exp() + eps, dim=1)
+    log_var = torch.clamp(log_var, min=-10, max=10)
+    kl_div = -0.5 * torch.sum(1 + log_var - mean.pow(2) - log_var.exp() + eps, dim=1)
     kl_div = kl_div.sum()
     loss = recon_loss + annealing_factor * kl_div
     return loss

--- a/kale/evaluate/metrics.py
+++ b/kale/evaluate/metrics.py
@@ -446,13 +446,18 @@ def calculate_distance(
 
     raise Exception("This metric is not still implemented")
 
+
 def elbo_loss(
-        recon_modality1, modality1,
-        recon_modality2, modality2,
-        mu, logvar,
-        lambda_modality1=1.0, lambda_modality2=1.0,
-        annealing_factor=1.0,
-        scale_factor=1e-4
+    recon_modality1,
+    modality1,
+    recon_modality2,
+    modality2,
+    mu,
+    logvar,
+    lambda_modality1=1.0,
+    lambda_modality2=1.0,
+    annealing_factor=1.0,
+    scale_factor=1e-4,
 ):
     """
     Computes the Evidence Lower Bound (ELBO) loss for a multimodal variational autoencoder (VAE) with two modalities.
@@ -482,12 +487,11 @@ def elbo_loss(
     modality1_mse, modality2_mse = 0.0, 0.0
     eps = 1e-8
     if recon_modality1 is not None and modality1 is not None:
-        modality1_mse = F.mse_loss(recon_modality1, modality1, reduction='sum')
+        modality1_mse = F.mse_loss(recon_modality1, modality1, reduction="sum")
     if recon_modality2 is not None and modality2 is not None:
-        modality2_mse = F.mse_loss(recon_modality2, modality2, reduction='sum')
+        modality2_mse = F.mse_loss(recon_modality2, modality2, reduction="sum")
     recon_loss = (lambda_modality1 * modality1_mse + lambda_modality2 * modality2_mse) * scale_factor
     logvar = torch.clamp(logvar, min=-10, max=10)
     kl_div = -0.5 * torch.sum(1 + logvar - mu.pow(2) - logvar.exp() + eps, dim=1)
     kl_div = kl_div.sum()
-    return (recon_loss + annealing_factor * kl_div)
-
+    return recon_loss + annealing_factor * kl_div

--- a/kale/evaluate/metrics.py
+++ b/kale/evaluate/metrics.py
@@ -60,11 +60,11 @@ def topk_accuracy(output, target, topk=(1,)):
         The shape of tensor is batch_size, i.e. the number of predictions.
 
     Examples:
-        output = torch.tensor(([0.3, 0.2, 0.1], [0.3, 0.2, 0.1]))
-        target = torch.tensor((0, 1))
-        top1, top2 = topk_accuracy(output, target, topk=(1, 2)) # get the boolean value
-        top1_value = top1.double().mean() # get the top 1 accuracy score
-        top2_value = top2.double().mean() # get the top 2 accuracy score
+        >>> output = torch.tensor(([0.3, 0.2, 0.1], [0.3, 0.2, 0.1]))
+        >>> target = torch.tensor((0, 1))
+        >>> top1, top2 = topk_accuracy(output, target, topk=(1, 2)) # get the boolean value
+        >>> top1_value = top1.double().mean() # get the top 1 accuracy score
+        >>> top2_value = top2.double().mean() # get the top 2 accuracy score
     """
 
     maxk = max(topk)
@@ -97,15 +97,15 @@ def multitask_topk_accuracy(output, target, topk=(1,)):
         The shape of tensor is batch_size, i.e. the number of predictions.
 
         Examples:
-            first_output = torch.tensor(([0.3, 0.2, 0.1], [0.3, 0.2, 0.1]))
-            first_target = torch.tensor((0, 2))
-            second_output = torch.tensor(([0.2, 0.1], [0.2, 0.1]))
-            second_target = torch.tensor((0, 1))
-            output = (first_output, second_output)
-            target = (first_target, second_target)
-            top1, top2 = multitask_topk_accuracy(output, target, topk=(1, 2)) # get the boolean value
-            top1_value = top1.double().mean() # get the top 1 accuracy score
-            top2_value = top2.double().mean() # get the top 2 accuracy score
+            >>> first_output = torch.tensor(([0.3, 0.2, 0.1], [0.3, 0.2, 0.1]))
+            >>> first_target = torch.tensor((0, 2))
+            >>> second_output = torch.tensor(([0.2, 0.1], [0.2, 0.1]))
+            >>> second_target = torch.tensor((0, 1))
+            >>> output = (first_output, second_output)
+            >>> target = (first_target, second_target)
+            >>> top1, top2 = multitask_topk_accuracy(output, target, topk=(1, 2)) # get the boolean value
+            >>> top1_value = top1.double().mean() # get the top 1 accuracy score
+            >>> top2_value = top2.double().mean() # get the top 2 accuracy score
     """
 
     maxk = max(topk)
@@ -447,7 +447,7 @@ def calculate_distance(
     raise Exception("This metric is not still implemented")
 
 
-def elbo_loss(
+def multimodal_elbo_loss(
     recon_modality1,
     modality1,
     recon_modality2,

--- a/kale/loaddata/signal_access.py
+++ b/kale/loaddata/signal_access.py
@@ -9,7 +9,7 @@ from tqdm import tqdm
 from kale.prepdata.signal_transform import interpolate_signal, normalize_signal, prepare_ecg_tensor
 
 
-def load_ecg_from_dir(base_path, csv_file):
+def load_ecg_from_folder(base_path, csv_file):
     """
     Loads and preprocesses a batch of ECG signals from a CSV file listing file paths.
 

--- a/kale/loaddata/signal_access.py
+++ b/kale/loaddata/signal_access.py
@@ -1,0 +1,45 @@
+import logging
+import os
+
+import pandas as pd
+import torch
+import wfdb
+from tqdm import tqdm
+
+from kale.prepdata.signal_transform import interpolate_signal, normalize_signal, prepare_ecg_tensor
+
+
+def load_ecg_from_dir(base_path, csv_file):
+    """
+    Loads and preprocesses a batch of ECG signals from a CSV file listing file paths.
+
+    Args:
+        base_path (str): Root directory containing ECG files.
+        csv_file (str): CSV file listing files in column 'path'.
+
+    Returns:
+        Tensor: Batch of preprocessed ECG signals, shape (N, 1, total_samples).
+    Example:
+        ecg_tensor = load_ecg_from_csv("/data/ecg/", "ecg_files.csv")
+    """
+    cases = pd.read_csv(os.path.join(base_path, csv_file))
+    full_paths = cases["path"].apply(lambda x: os.path.join(base_path, x))
+    all_ecg = []
+
+    for f in tqdm(full_paths, desc="Loading ECG data"):
+        wave_array, meta = wfdb.rdsamp(f)
+        wave_array = interpolate_signal(wave_array)
+        num_channels = meta["n_sig"]
+        num_samples_per_channel = wave_array.size // num_channels
+
+        if wave_array.size % num_channels == 0:
+            wave_array = wave_array.reshape(num_samples_per_channel, num_channels)
+            wave_array = normalize_signal(wave_array)
+            ecg_tensor = prepare_ecg_tensor(wave_array)
+            all_ecg.append(ecg_tensor)
+        else:
+            logging.warning(f"Unexpected data size in {f}. Skipping file.")
+    if all_ecg:
+        return torch.cat(all_ecg, dim=0)
+    else:
+        return torch.empty(0)

--- a/kale/loaddata/signal_image_access.py
+++ b/kale/loaddata/signal_image_access.py
@@ -4,6 +4,7 @@
 
 from torch.utils.data import Dataset
 
+
 class SignalImageDataset(Dataset):
     """
     SignalImageDataset prepares paired signal (e.g., ECG) and image (e.g., CXR) features for multimodal deep learning tasks.
@@ -25,6 +26,7 @@ class SignalImageDataset(Dataset):
     Returns:
         Tuple: (signal_features, image_features) for the requested sample index.
     """
+
     def __init__(self, signal_features, image_features):
         self.signal_features = signal_features
         self.image_features = image_features
@@ -34,4 +36,3 @@ class SignalImageDataset(Dataset):
 
     def __getitem__(self, idx):
         return self.signal_features[idx], self.image_features[idx]
-

--- a/kale/loaddata/signal_image_access.py
+++ b/kale/loaddata/signal_image_access.py
@@ -3,7 +3,7 @@
 # =============================================================================
 
 from torch.utils.data import Dataset
-
+import numpy as np
 
 class SignalImageDataset(Dataset):
     """
@@ -36,3 +36,41 @@ class SignalImageDataset(Dataset):
 
     def __getitem__(self, idx):
         return self.signal_features[idx], self.image_features[idx]
+
+
+    @classmethod
+    def prepare_data_loaders(cls, signal_features, image_features, train_ratio=0.8, random_seed=None):
+        """
+        Splits the dataset into training and validation subsets.
+
+        Args:
+            signal_features (Tensor or ndarray): Tensor containing the signal features.
+            image_features (Tensor or ndarray): Tensor containing the image features.
+            train_ratio (float, optional): Ratio of the training set (e.g., 0.8 for 80% train, 20% val). Default is 0.8.
+            random_seed (int, optional): Seed for reproducibility.
+
+        Returns:
+            train_dataset (SignalImageDataset): Training subset.
+            val_dataset (SignalImageDataset): Validation subset.
+        """
+        assert len(signal_features) == len(image_features), "Mismatch in number of samples."
+
+        num_samples = len(signal_features)
+        indices = np.arange(num_samples)
+        if random_seed is not None:
+            np.random.seed(random_seed)
+        np.random.shuffle(indices)
+
+        train_size = int(train_ratio * num_samples)
+        train_indices = indices[:train_size]
+        val_indices = indices[train_size:]
+
+        train_signal = signal_features[train_indices]
+        train_image = image_features[train_indices]
+        val_signal = signal_features[val_indices]
+        val_image = image_features[val_indices]
+
+        return (
+            cls(train_signal, train_image),
+            cls(val_signal, val_image)
+        )

--- a/kale/loaddata/signal_image_access.py
+++ b/kale/loaddata/signal_image_access.py
@@ -1,0 +1,37 @@
+# =============================================================================
+# Author: Mohammod Suvon, m.suvon@sheffield.ac.uk
+# =============================================================================
+
+from torch.utils.data import Dataset
+
+class SignalImageDataset(Dataset):
+    """
+    SignalImageDataset prepares paired signal (e.g., ECG) and image (e.g., CXR) features for multimodal deep learning tasks.
+
+    This class simplifies data preparation by accepting two tensors: one for signal features and one for image features.
+    Each sample returned by the dataset consists of a pair of (signal_features, image_features) at the same index,
+    making it suitable for tasks where both modalities are required as input (such as multimodal classification,
+    reconstruction, or representation learning).
+
+    Args:
+        signal_features (Tensor or ndarray): Tensor containing the signal features for all samples.
+        image_features (Tensor or ndarray): Tensor containing the image features for all samples.
+
+    Usage:
+        dataset = SignalImageDataset(signal_features, image_features)
+        signal, image = dataset[0]
+        # Can be used with DataLoader for batching in model training.
+
+    Returns:
+        Tuple: (signal_features, image_features) for the requested sample index.
+    """
+    def __init__(self, signal_features, image_features):
+        self.signal_features = signal_features
+        self.image_features = image_features
+
+    def __len__(self):
+        return len(self.signal_features)
+
+    def __getitem__(self, idx):
+        return self.signal_features[idx], self.image_features[idx]
+

--- a/kale/loaddata/signal_image_access.py
+++ b/kale/loaddata/signal_image_access.py
@@ -2,8 +2,9 @@
 # Author: Mohammod Suvon, m.suvon@sheffield.ac.uk
 # =============================================================================
 
-from torch.utils.data import Dataset
 import numpy as np
+from torch.utils.data import Dataset
+
 
 class SignalImageDataset(Dataset):
     """
@@ -37,7 +38,6 @@ class SignalImageDataset(Dataset):
     def __getitem__(self, idx):
         return self.signal_features[idx], self.image_features[idx]
 
-
     @classmethod
     def prepare_data_loaders(cls, signal_features, image_features, train_ratio=0.8, random_seed=None):
         """
@@ -70,7 +70,4 @@ class SignalImageDataset(Dataset):
         val_signal = signal_features[val_indices]
         val_image = image_features[val_indices]
 
-        return (
-            cls(train_signal, train_image),
-            cls(val_signal, val_image)
-        )
+        return (cls(train_signal, train_image), cls(val_signal, val_image))

--- a/kale/pipeline/multimodal_trainer.py
+++ b/kale/pipeline/multimodal_trainer.py
@@ -1,0 +1,153 @@
+# =============================================================================
+# Author: Mohammod Suvon, m.suvon@sheffield.ac.uk
+# =============================================================================
+"""
+multimodal_trainer.py
+
+Contains all trainer classes for multimodal training, including MultimodalTriStreamVAETrainer for joint optimization and validation of tri-stream MVAE pre-training with image and signal modalities.
+"""
+import torch
+import pytorch_lightning as pl
+from kale.evaluate.metrics import elbo_loss
+
+
+class MultimodalTriStreamVAETrainer(pl.LightningModule):
+    """
+    PyTorch Lightning trainer for tri-stream multimodal variational autoencoders (MVAE) with image and 1D signal modalities.
+
+    This class manages the training and validation steps for a MVAE, supporting separate and joint reconstruction
+    loss computation for each modality and the fused latent distribution. It is agnostic to input domains and supports
+    both training and validation via PyTorch Lightning’s workflow.
+
+    Args:
+        model (nn.Module): The multimodal VAE model to be trained.
+        train_dataset (Dataset): PyTorch dataset providing training samples (image, signal) pairs.
+        val_dataset (Dataset): PyTorch dataset for validation (optional; can be None).
+        batch_size (int, optional): Batch size for training/validation. Default is 32.
+        num_workers (int, optional): Number of DataLoader worker processes. Default is 4.
+        lambda_image (float, optional): Weight for the image reconstruction loss. Default is 1.0.
+        lambda_signal (float, optional): Weight for the signal reconstruction loss. Default is 10.0.
+        lr (float, optional): Learning rate for Adam optimizer. Default is 1e-3.
+        annealing_epochs (int, optional): Number of epochs for KL annealing. Default is 50.
+        scale_factor (float, optional): Overall scaling factor for reconstruction loss. Default is 1e-4.
+    """
+
+    def __init__(
+            self,
+            model,
+            train_dataset,
+            val_dataset,
+            batch_size=32,
+            num_workers=4,
+            lambda_image=1.0,
+            lambda_signal=10.0,
+            lr=1e-3,
+            annealing_epochs=50,
+            scale_factor=1e-4,
+    ):
+        super().__init__()
+        self.model = model
+        self.train_dataset = train_dataset
+        self.val_dataset = val_dataset
+        self.batch_size = batch_size
+        self.num_workers = num_workers
+        self.lambda_image = lambda_image
+        self.lambda_signal = lambda_signal
+        self.lr = lr
+        self.annealing_epochs = annealing_epochs
+        self.scale_factor = scale_factor
+        self.save_hyperparameters(ignore=['model', 'train_dataset', 'val_dataset'])
+
+    def forward(self, image=None, signal=None):
+        """
+        Forward pass through the multimodal VAE model.
+
+        Args:
+            image (Tensor, optional): Batch of image modality inputs.
+            signal (Tensor, optional): Batch of signal modality inputs.
+
+        Returns:
+            Tuple: Model outputs (image reconstruction, signal reconstruction, mu, logvar).
+        """
+        return self.model(image, signal)
+
+    def training_step(self, batch, batch_idx):
+        """
+        Performs a single training step with reconstruction and KL losses for all input combinations.
+
+        Args:
+            batch (tuple): Tuple of (signal, image) tensors.
+            batch_idx (int): Batch index.
+
+        Returns:
+            Tensor: Training loss for the current batch.
+        """
+        signal, image = batch
+        signal = signal.to(self.device)
+        image = image.to(self.device)
+        epoch = self.current_epoch
+        annealing_factor = min(epoch / self.annealing_epochs, 1.0)
+        recon_image_joint, recon_signal_joint, mu_joint, logvar_joint = self.model(image, signal)
+        recon_image_only, _, mu_image, logvar_image = self.model(image=image)
+        _, recon_signal_only, mu_signal, logvar_signal = self.model(signal=signal)
+        batch_size = signal.size(0)
+        joint_loss = elbo_loss(
+            recon_image_joint, image, recon_signal_joint, signal, mu_joint, logvar_joint,
+            self.lambda_image, self.lambda_signal, annealing_factor, self.scale_factor
+        )
+        image_loss = elbo_loss(
+            recon_image_only, image, None, None, mu_image, logvar_image,
+            self.lambda_image, self.lambda_signal, annealing_factor, self.scale_factor
+        )
+        signal_loss = elbo_loss(
+            None, None, recon_signal_only, signal, mu_signal, logvar_signal,
+            self.lambda_image, self.lambda_signal, annealing_factor, self.scale_factor
+        )
+        train_loss = (joint_loss + image_loss + signal_loss) / batch_size
+        self.log("train_loss", train_loss, prog_bar=True, on_step=True, on_epoch=True)
+        return train_loss
+
+    def validation_step(self, batch, batch_idx):
+        """
+        Performs a single validation step, mirroring the training loss calculations.
+
+        Args:
+            batch (tuple): Tuple of (signal, image) tensors.
+            batch_idx (int): Batch index.
+
+        Returns:
+            Tensor: Validation loss for the current batch.
+        """
+        signal, image = batch
+        signal = signal.to(self.device)
+        image = image.to(self.device)
+        epoch = self.current_epoch
+        annealing_factor = min(epoch / self.annealing_epochs, 1.0)
+        recon_image_joint, recon_signal_joint, mu_joint, logvar_joint = self.model(image, signal)
+        recon_image_only, _, mu_image, logvar_image = self.model(image=image)
+        _, recon_signal_only, mu_signal, logvar_signal = self.model(signal=signal)
+        batch_size = signal.size(0)
+        joint_loss = elbo_loss(
+            recon_image_joint, image, recon_signal_joint, signal, mu_joint, logvar_joint,
+            self.lambda_image, self.lambda_signal, annealing_factor, self.scale_factor
+        )
+        image_loss = elbo_loss(
+            recon_image_only, image, None, None, mu_image, logvar_image,
+            self.lambda_image, self.lambda_signal, annealing_factor, self.scale_factor
+        )
+        signal_loss = elbo_loss(
+            None, None, recon_signal_only, signal, mu_signal, logvar_signal,
+            self.lambda_image, self.lambda_signal, annealing_factor, self.scale_factor
+        )
+        val_loss = (joint_loss + image_loss + signal_loss) / batch_size
+        self.log("val_loss", val_loss, prog_bar=True, on_epoch=True)
+        return val_loss
+
+    def configure_optimizers(self):
+        """
+        Configures the optimizer (Adam) for model training.
+
+        Returns:
+            torch.optim.Optimizer: The optimizer instance.
+        """
+        return torch.optim.Adam(self.model.parameters(), lr=self.lr)

--- a/kale/pipeline/multimodal_trainer.py
+++ b/kale/pipeline/multimodal_trainer.py
@@ -244,7 +244,6 @@ class SignalImageTriStreamVAETrainer(pl.LightningModule):
         return torch.optim.Adam(self.model.parameters(), lr=self.lr)
 
 
-
 class SignalImageFineTuningTrainer(pl.LightningModule):
     """
     SignalImageFineTuningTrainer trains and validates a supervised classifier built on top of frozen encoders from a pre-trained multimodal model.
@@ -328,6 +327,7 @@ class SignalImageFineTuningTrainer(pl.LightningModule):
         self.val_accuracy.reset()
         self.val_auc.reset()
         self.val_mcc.reset()
+
     def configure_optimizers(self):
         """
         Configures the Adam optimizer for training the classifier.

--- a/kale/pipeline/multimodal_trainer.py
+++ b/kale/pipeline/multimodal_trainer.py
@@ -10,6 +10,7 @@ import pytorch_lightning as pl
 import torch
 import torch.nn.functional as F
 import torchmetrics
+from torch.utils.data import DataLoader
 
 from kale.evaluate.metrics import signal_image_elbo_loss
 from kale.predict.decode import SignalImageFineTuningClassifier
@@ -242,6 +243,33 @@ class SignalImageTriStreamVAETrainer(pl.LightningModule):
             torch.optim.Optimizer: The optimizer instance.
         """
         return torch.optim.Adam(self.model.parameters(), lr=self.lr)
+
+    def train_dataloader(self):
+        """
+        Returns a DataLoader for the training set.
+        """
+        return DataLoader(
+            self.train_dataset,
+            batch_size=self.batch_size,
+            shuffle=True,
+            num_workers=self.num_workers,
+            pin_memory=True,
+        )
+
+    def val_dataloader(self):
+        """
+        Returns a DataLoader for the validation set.
+        """
+        if self.val_dataset is not None:
+            return DataLoader(
+                self.val_dataset,
+                batch_size=self.batch_size,
+                shuffle=False,
+                num_workers=self.num_workers,
+                pin_memory=True,
+            )
+        else:
+            return None
 
 
 class SignalImageFineTuningTrainer(pl.LightningModule):

--- a/kale/pipeline/multimodal_trainer.py
+++ b/kale/pipeline/multimodal_trainer.py
@@ -11,7 +11,7 @@ import torch
 import torch.nn.functional as F
 import torchmetrics
 
-from kale.evaluate.metrics import multimodal_elbo_loss
+from kale.evaluate.metrics import signal_image_elbo_loss
 from kale.predict.decode import SignalImageFineTuningClassifier
 
 
@@ -141,7 +141,7 @@ class SignalImageTriStreamVAETrainer(pl.LightningModule):
         total_loss = 0.0
         for mode in ["joint", "image_only", "signal_only"]:
             args = loss_args[mode]
-            total_loss += multimodal_elbo_loss(
+            total_loss += signal_image_elbo_loss(
                 args["recon_image"],
                 args["target_image"],
                 args["recon_signal"],
@@ -220,7 +220,7 @@ class SignalImageTriStreamVAETrainer(pl.LightningModule):
         total_loss = 0.0
         for mode in ["joint", "image_only", "signal_only"]:
             args = loss_args[mode]
-            total_loss += multimodal_elbo_loss(
+            total_loss += signal_image_elbo_loss(
                 args["recon_image"],
                 args["target_image"],
                 args["recon_signal"],

--- a/kale/predict/decode.py
+++ b/kale/predict/decode.py
@@ -338,7 +338,6 @@ class SignalVaeDecoder(nn.Module):
         signal_recon = decoder(latent_vector)
     """
 
-
     def __init__(self, latent_dim=256, output_dim=60000):
         super().__init__()
         self.fc = nn.Linear(latent_dim, 64 * (output_dim // 8))

--- a/kale/prepdata/signal_transform.py
+++ b/kale/prepdata/signal_transform.py
@@ -1,0 +1,48 @@
+import numpy as np
+import pandas as pd
+import torch
+
+
+def normalize_signal(signal):
+    """
+    Normalizes a multi-channel ECG signal by removing mean and scaling to unit variance per channel.
+
+    Args:
+        signal (ndarray): Array of shape (samples, channels)
+
+    Returns:
+        ndarray: Normalized signal, same shape as input.
+    """
+    mean = np.mean(signal, axis=0)
+    std = np.std(signal, axis=0)
+    std_safe = np.where(std == 0, 1e-10, std)
+    normalized_signal = (signal - mean) / std_safe
+    return normalized_signal
+
+
+def interpolate_signal(signal):
+    """
+    Linearly interpolates missing or NaN values in the ECG signal.
+
+    Args:
+        signal (ndarray): Array of shape (samples, channels)
+
+    Returns:
+        ndarray: Interpolated signal, same shape as input.
+    """
+    signal_df = pd.DataFrame(signal)
+    signal_df.interpolate(method="linear", axis=0, inplace=True, limit_direction="both")
+    return signal_df.to_numpy()
+
+
+def prepare_ecg_tensor(signal):
+    """
+    Converts preprocessed ECG numpy array to a torch tensor of shape (1, -1).
+
+    Args:
+        signal (ndarray): Preprocessed and normalized ECG array (samples, channels).
+
+    Returns:
+        Tensor: Flattened ECG tensor, shape (1, total_samples).
+    """
+    return torch.tensor(signal.reshape(1, -1), dtype=torch.float32)

--- a/kale/prepdata/signal_transform.py
+++ b/kale/prepdata/signal_transform.py
@@ -37,12 +37,17 @@ def interpolate_signal(signal):
 
 def prepare_ecg_tensor(signal):
     """
-    Converts preprocessed ECG numpy array to a torch tensor of shape (1, -1).
+    Converts a preprocessed ECG signal (NumPy array or PyTorch tensor) to a torch tensor of shape (1, -1).
 
     Args:
-        signal (ndarray): Preprocessed and normalized ECG array (samples, channels).
+        signal (ndarray or Tensor): Preprocessed and normalized ECG array (samples, channels).
 
     Returns:
         Tensor: Flattened ECG tensor, shape (1, total_samples).
     """
-    return torch.tensor(signal.reshape(1, -1), dtype=torch.float32)
+    if isinstance(signal, np.ndarray):
+        return torch.tensor(signal.reshape(1, -1), dtype=torch.float32)
+    elif isinstance(signal, torch.Tensor):
+        return signal.reshape(1, -1).to(dtype=torch.float32)
+    else:
+        raise TypeError("Input must be a NumPy ndarray or a PyTorch tensor")

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ example_requires = [
     "torchsummary>=1.5.0",
     "yacs>=0.1.7",
     "pwlf",
+    "wfdb",
     "xlsxwriter",
     "prettytable",
     "comet_ml",

--- a/tests/embed/test_feature_fusion.py
+++ b/tests/embed/test_feature_fusion.py
@@ -38,28 +38,28 @@ def test_low_rank_tensor_fusion():
 
 
 def test_product_of_experts_forward():
-    # Prepare dummy expert means and logvars for 3 experts, 5 batch, 8 latent dims
+    # Prepare dummy expert means and log_vars for 3 experts, 5 batch, 8 latent dims
     num_experts = 3
     batch_size = 5
     latent_dim = 8
-    mu = torch.randn(num_experts, batch_size, latent_dim)
-    logvar = torch.randn(num_experts, batch_size, latent_dim)
+    mean = torch.randn(num_experts, batch_size, latent_dim)
+    log_var = torch.randn(num_experts, batch_size, latent_dim)
 
     poe = ProductOfExperts()
-    pd_mu, pd_logvar = poe(mu, logvar)
+    pd_mu, pd_log_var = poe(mean, log_var)
 
     # Check shapes
     assert pd_mu.shape == (batch_size, latent_dim)
-    assert pd_logvar.shape == (batch_size, latent_dim)
+    assert pd_log_var.shape == (batch_size, latent_dim)
     assert isinstance(pd_mu, torch.Tensor)
-    assert isinstance(pd_logvar, torch.Tensor)
+    assert isinstance(pd_log_var, torch.Tensor)
 
 
 def test_product_of_experts_numerical_stability():
-    # All experts have large negative logvar (very low variance)
-    mu = torch.zeros(2, 1, 4)
-    logvar = torch.full((2, 1, 4), -20.0)
+    # All experts have large negative log_var (very low variance)
+    mean = torch.zeros(2, 1, 4)
+    log_var = torch.full((2, 1, 4), -20.0)
     poe = ProductOfExperts()
-    pd_mu, pd_logvar = poe(mu, logvar, eps=1e-10)  # Use custom eps for coverage
+    pd_mu, pd_log_var = poe(mean, log_var, eps=1e-10)  # Use custom eps for coverage
     assert torch.isfinite(pd_mu).all()
-    assert torch.isfinite(pd_logvar).all()
+    assert torch.isfinite(pd_log_var).all()

--- a/tests/embed/test_image_cnn.py
+++ b/tests/embed/test_image_cnn.py
@@ -4,7 +4,7 @@ import torch
 from kale.embed.image_cnn import (
     Flatten,
     Identity,
-    ImageVAEEncoder,
+    ImageVaeEncoder,
     LeNet,
     ResNet18Feature,
     ResNet34Feature,
@@ -88,7 +88,7 @@ def test_image_vae_encoder_forward():
     x = torch.randn(batch_size, input_channels, height, width)
 
     # Initialize encoder
-    encoder = ImageVAEEncoder(input_channels=input_channels, latent_dim=32)
+    encoder = ImageVaeEncoder(input_channels=input_channels, latent_dim=32)
 
     # Forward pass
     mu, logvar = encoder(x)

--- a/tests/embed/test_image_cnn.py
+++ b/tests/embed/test_image_cnn.py
@@ -4,7 +4,7 @@ import torch
 from kale.embed.image_cnn import (
     Flatten,
     Identity,
-    ImageVaeEncoder,
+    ImageVAEEncoder,
     LeNet,
     ResNet18Feature,
     ResNet34Feature,
@@ -88,14 +88,14 @@ def test_image_vae_encoder_forward():
     x = torch.randn(batch_size, input_channels, height, width)
 
     # Initialize encoder
-    encoder = ImageVaeEncoder(input_channels=input_channels, latent_dim=32)
+    encoder = ImageVAEEncoder(input_channels=input_channels, latent_dim=32)
 
     # Forward pass
-    mu, logvar = encoder(x)
+    mean, log_var = encoder(x)
 
     # Check output shapes
-    assert mu.shape == (batch_size, 32)
-    assert logvar.shape == (batch_size, 32)
+    assert mean.shape == (batch_size, 32)
+    assert log_var.shape == (batch_size, 32)
     # Check types
-    assert isinstance(mu, torch.Tensor)
-    assert isinstance(logvar, torch.Tensor)
+    assert isinstance(mean, torch.Tensor)
+    assert isinstance(log_var, torch.Tensor)

--- a/tests/embed/test_image_cnn.py
+++ b/tests/embed/test_image_cnn.py
@@ -4,6 +4,7 @@ import torch
 from kale.embed.image_cnn import (
     Flatten,
     Identity,
+    ImageVAEEncoder,
     LeNet,
     ResNet18Feature,
     ResNet34Feature,
@@ -75,3 +76,26 @@ def test_identity_output_shapes():
     x = torch.randn(16, 3, 32, 32)
     output = identity(x)
     assert output.shape == (16, 3, 32, 32), "Unexpected output shape"
+
+
+def test_image_vae_encoder_forward():
+    # Test configuration
+    batch_size = 2
+    input_channels = 1
+    height, width = 224, 224  # After 3 layers with stride=2, output is 28x28
+
+    # Create dummy image input (batch of grayscale images)
+    x = torch.randn(batch_size, input_channels, height, width)
+
+    # Initialize encoder
+    encoder = ImageVAEEncoder(input_channels=input_channels, latent_dim=32)
+
+    # Forward pass
+    mu, logvar = encoder(x)
+
+    # Check output shapes
+    assert mu.shape == (batch_size, 32)
+    assert logvar.shape == (batch_size, 32)
+    # Check types
+    assert isinstance(mu, torch.Tensor)
+    assert isinstance(logvar, torch.Tensor)

--- a/tests/embed/test_multimodal_encoder.py
+++ b/tests/embed/test_multimodal_encoder.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import torch
 
-from kale.embed.multimodal_encoder import BimodalVAE
+from kale.embed.multimodal_encoder import SignalImageVAE
 
 
 def test_bimodal_vae_full_coverage():
@@ -16,7 +16,7 @@ def test_bimodal_vae_full_coverage():
     image = torch.randn(batch_size, image_channels, image_size, image_size)
     signal = torch.randn(batch_size, 1, signal_length)
 
-    model = BimodalVAE(image_input_channels=image_channels, signal_input_dim=signal_length, latent_dim=latent_dim)
+    model = SignalImageVAE(image_input_channels=image_channels, signal_input_dim=signal_length, latent_dim=latent_dim)
 
     # --- Test prior_expert (cpu branch) ---
     mu, logvar = model.prior_expert((1, batch_size, latent_dim), use_cuda=False)

--- a/tests/embed/test_multimodal_encoder.py
+++ b/tests/embed/test_multimodal_encoder.py
@@ -1,0 +1,51 @@
+import torch
+
+from kale.embed.multimodal_encoder import BimodalVAE
+
+
+def test_bimodal_vae_full_coverage():
+    # Small test config for speed and memory
+    batch_size = 2
+    image_channels = 1
+    image_size = 224  # So output after 3x stride=2 is 28x28
+    signal_length = 64  # Smaller than 60000 for test speed
+    latent_dim = 4
+
+    # Dummy image and signal data
+    image = torch.randn(batch_size, image_channels, image_size, image_size)
+    signal = torch.randn(batch_size, 1, signal_length)
+
+    model = BimodalVAE(image_input_channels=image_channels, signal_input_dim=signal_length, latent_dim=latent_dim)
+
+    # --- Test prior_expert (cpu and cuda branch if possible) ---
+    mu, logvar = model.prior_expert((1, batch_size, latent_dim), use_cuda=False)
+    assert mu.shape == (1, batch_size, latent_dim)
+    assert torch.allclose(logvar, torch.zeros_like(logvar))
+    if torch.cuda.is_available():
+        mu_cuda, logvar_cuda = model.prior_expert((1, batch_size, latent_dim), use_cuda=True)
+        assert mu_cuda.is_cuda
+        assert logvar_cuda.is_cuda
+
+    # --- Test reparametrize, both training and eval mode ---
+    dummy_mu = torch.zeros(batch_size, latent_dim)
+    dummy_logvar = torch.zeros(batch_size, latent_dim)
+    model.train()
+    z_train = model.reparametrize(dummy_mu, dummy_logvar)
+    assert z_train.shape == (batch_size, latent_dim)
+    model.eval()
+    z_eval = model.reparametrize(dummy_mu, dummy_logvar)
+    assert torch.allclose(z_eval, dummy_mu)
+
+    # --- Test forward (with both modalities) ---
+    model.train()
+    img_recon, sig_recon, mu, logvar = model(image=image, signal=signal)
+    assert img_recon.shape[0] == batch_size
+    assert sig_recon.shape[0] == batch_size
+    assert mu.shape == (batch_size, latent_dim)
+    assert logvar.shape == (batch_size, latent_dim)
+
+    # --- Test infer with only one modality at a time ---
+    mu_img, logvar_img = model.infer(image=image)
+    assert mu_img.shape == (batch_size, latent_dim)
+    mu_sig, logvar_sig = model.infer(signal=signal)
+    assert mu_sig.shape == (batch_size, latent_dim)

--- a/tests/embed/test_signal_cnn.py
+++ b/tests/embed/test_signal_cnn.py
@@ -1,0 +1,25 @@
+import torch
+
+from kale.embed.signal_cnn import SignalVAEEncoder
+
+
+def test_signal_vae_encoder_forward():
+    # Test configuration
+    batch_size = 3
+    input_dim = 60000
+    latent_dim = 16
+
+    # Create dummy 1D signal input (batch_size, channels, input_dim)
+    x = torch.randn(batch_size, 1, input_dim)
+
+    # Initialize encoder
+    encoder = SignalVAEEncoder(input_dim=input_dim, latent_dim=latent_dim)
+
+    # Forward pass
+    mu, logvar = encoder(x)
+
+    # Check output shapes
+    assert mu.shape == (batch_size, latent_dim)
+    assert logvar.shape == (batch_size, latent_dim)
+    assert isinstance(mu, torch.Tensor)
+    assert isinstance(logvar, torch.Tensor)

--- a/tests/embed/test_signal_cnn.py
+++ b/tests/embed/test_signal_cnn.py
@@ -1,6 +1,6 @@
 import torch
 
-from kale.embed.signal_cnn import SignalVaeEncoder
+from kale.embed.signal_cnn import SignalVAEEncoder
 
 
 def test_signal_vae_encoder_forward():
@@ -13,13 +13,13 @@ def test_signal_vae_encoder_forward():
     x = torch.randn(batch_size, 1, input_dim)
 
     # Initialize encoder
-    encoder = SignalVaeEncoder(input_dim=input_dim, latent_dim=latent_dim)
+    encoder = SignalVAEEncoder(input_dim=input_dim, latent_dim=latent_dim)
 
     # Forward pass
-    mu, logvar = encoder(x)
+    mean, log_var = encoder(x)
 
     # Check output shapes
-    assert mu.shape == (batch_size, latent_dim)
-    assert logvar.shape == (batch_size, latent_dim)
-    assert isinstance(mu, torch.Tensor)
-    assert isinstance(logvar, torch.Tensor)
+    assert mean.shape == (batch_size, latent_dim)
+    assert log_var.shape == (batch_size, latent_dim)
+    assert isinstance(mean, torch.Tensor)
+    assert isinstance(log_var, torch.Tensor)

--- a/tests/embed/test_signal_cnn.py
+++ b/tests/embed/test_signal_cnn.py
@@ -1,6 +1,6 @@
 import torch
 
-from kale.embed.signal_cnn import SignalVAEEncoder
+from kale.embed.signal_cnn import SignalVaeEncoder
 
 
 def test_signal_vae_encoder_forward():
@@ -13,7 +13,7 @@ def test_signal_vae_encoder_forward():
     x = torch.randn(batch_size, 1, input_dim)
 
     # Initialize encoder
-    encoder = SignalVAEEncoder(input_dim=input_dim, latent_dim=latent_dim)
+    encoder = SignalVaeEncoder(input_dim=input_dim, latent_dim=latent_dim)
 
     # Forward pass
     mu, logvar = encoder(x)

--- a/tests/evaluate/test_metrics.py
+++ b/tests/evaluate/test_metrics.py
@@ -141,16 +141,16 @@ def test_signal_image_elbo_loss_branches(use_image, use_signal):
     recon_signal = torch.randn(signal_shape) if use_signal else None
     target_signal = torch.randn(signal_shape) if use_signal else None
 
-    mu = torch.zeros(batch_size, latent_dim)
-    logvar = torch.zeros(batch_size, latent_dim)
+    mean = torch.zeros(batch_size, latent_dim)
+    log_var = torch.zeros(batch_size, latent_dim)
 
     loss = signal_image_elbo_loss(
         recon_image,
         target_image,
         recon_signal,
         target_signal,
-        mu,
-        logvar,
+        mean,
+        log_var,
         lambda_image=2.0,
         lambda_signal=3.0,
         annealing_factor=0.7,
@@ -171,8 +171,8 @@ def test_signal_image_elbo_loss_values():
     target_image = torch.ones(batch_size, 2)
     recon_signal = torch.zeros(batch_size, 2)
     target_signal = torch.ones(batch_size, 2)
-    mu = torch.zeros(batch_size, latent_dim)
-    logvar = torch.zeros(batch_size, latent_dim)
+    mean = torch.zeros(batch_size, latent_dim)
+    log_var = torch.zeros(batch_size, latent_dim)
 
     # MSE = mean((0-1)^2) = 1 per element, 4 elements per modality
     # Reduction='sum' = 4.0
@@ -183,8 +183,8 @@ def test_signal_image_elbo_loss_values():
         target_image,
         recon_signal,
         target_signal,
-        mu,
-        logvar,
+        mean,
+        log_var,
         lambda_image=1.0,
         lambda_signal=1.0,
         annealing_factor=1.0,

--- a/tests/evaluate/test_metrics.py
+++ b/tests/evaluate/test_metrics.py
@@ -6,7 +6,7 @@ import torch
 from kale.evaluate.metrics import (
     calculate_distance,
     DistanceMetric,
-    elbo_loss,
+    multimodal_elbo_loss,
     multitask_topk_accuracy,
     protonet_loss,
     topk_accuracy,
@@ -144,7 +144,7 @@ def test_elbo_loss_branches(use_modality1, use_modality2):
     mu = torch.zeros(batch_size, latent_dim)
     logvar = torch.zeros(batch_size, latent_dim)
 
-    loss = elbo_loss(
+    loss = multimodal_elbo_loss(
         recon_modality1,
         modality1,
         recon_modality2,
@@ -180,7 +180,7 @@ def test_elbo_loss_values():
     # Reduction='sum' = 4.0
     expected_recon = (1.0 * 4 + 1.0 * 4) * 1e-4  # scale_factor
 
-    loss = elbo_loss(
+    loss = multimodal_elbo_loss(
         recon_modality1,
         modality1,
         recon_modality2,

--- a/tests/loaddata/test_image_access.py
+++ b/tests/loaddata/test_image_access.py
@@ -1,10 +1,11 @@
+import pandas as pd
 import pytest
 import torch
 from numpy import testing
 from yacs.config import CfgNode
 
 from kale.loaddata.dataset_access import get_class_subset
-from kale.loaddata.image_access import DigitDataset, DigitDatasetAccess, get_cifar, ImageAccess
+from kale.loaddata.image_access import DigitDataset, DigitDatasetAccess, get_cifar, ImageAccess, load_images_from_dir
 from kale.loaddata.multi_domain import DomainsDatasetBase, MultiDomainAdapDataset, MultiDomainDatasets
 
 
@@ -164,3 +165,38 @@ def test_get_cifar(dataset, testing_cfg):
     train_loader, valid_loader = get_cifar(cfg)
     assert isinstance(train_loader, torch.utils.data.DataLoader)
     assert isinstance(valid_loader, torch.utils.data.DataLoader)
+
+
+# Example dummy prepare_image_tensor for the test
+def prepare_image_tensor(image_path, resize_dim=(224, 224), channels=1):
+    if channels == 1:
+        return torch.ones(1, resize_dim[0], resize_dim[1])
+    else:
+        return torch.ones(3, resize_dim[0], resize_dim[1])
+
+
+@pytest.mark.parametrize("channels", [1, 3])
+def test_load_images_from_dir(tmp_path, channels, monkeypatch):
+    root = tmp_path
+    num_images = 5
+    resize_dim = (32, 32)
+    file_names = [f"img_{i}.png" for i in range(num_images)]
+
+    for fname in file_names:
+        img_path = root / fname
+        with open(img_path, "wb") as f:
+            f.write(b"")
+
+    # Write a CSV file listing the images
+    csv_path = root / "images.csv"
+    df = pd.DataFrame({"file_path": file_names})
+    df.to_csv(csv_path, index=False)
+
+    def dummy_prepare_image_tensor(image_path, resize_dim=(32, 32), channels=1):
+        return torch.ones(channels, *resize_dim)
+
+    monkeypatch.setattr("kale.loaddata.image_access.prepare_image_tensor", dummy_prepare_image_tensor)
+
+    batch = load_images_from_dir(root, "images.csv", resize_dim=resize_dim, channels=channels)
+    assert batch.shape == (num_images, channels, *resize_dim)
+    assert torch.all(batch == 1)

--- a/tests/loaddata/test_signal_access.py
+++ b/tests/loaddata/test_signal_access.py
@@ -1,0 +1,56 @@
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+
+from kale.loaddata.signal_access import load_ecg_from_dir
+
+
+@pytest.fixture
+def make_csv(tmp_path):
+    def _make(file_names):
+        csv_path = tmp_path / "signals.csv"
+        df = pd.DataFrame({"path": file_names})
+        df.to_csv(csv_path, index=False)
+        return csv_path
+
+    return _make
+
+
+@pytest.mark.parametrize("bad_shape", [False, True])
+def test_load_ecg_from_dir(tmp_path, monkeypatch, make_csv, bad_shape):
+    # -- Setup
+    file_names = ["a1.dat", "a2.dat"]
+    csv_path = make_csv(file_names)
+    root = str(tmp_path)
+
+    # Dummy signal: 10 samples x 2 channels
+    dummy_wave = torch.arange(20).reshape(10, 2).numpy()
+    dummy_meta = {"n_sig": 2}
+
+    # If bad_shape, fudge the array to the wrong shape to force the skip code path
+    if bad_shape:
+        dummy_wave = np.arange(22)
+        dummy_meta = {"n_sig": 3}
+
+    # Patch dependencies
+    monkeypatch.setattr("kale.loaddata.signal_access.wfdb.rdsamp", lambda f: (dummy_wave, dummy_meta))
+    monkeypatch.setattr("kale.loaddata.signal_access.interpolate_signal", lambda s: s)
+    monkeypatch.setattr("kale.loaddata.signal_access.normalize_signal", lambda s: s)
+
+    # Prepare ecg tensor always returns shape (1, 1, total_samples)
+    def dummy_prepare_ecg_tensor(signal):
+        n = signal.shape[0] * signal.shape[1]
+        return torch.ones(1, 1, n)
+
+    monkeypatch.setattr("kale.loaddata.signal_access.prepare_ecg_tensor", dummy_prepare_ecg_tensor)
+
+    # -- Test
+    batch = load_ecg_from_dir(root, csv_path.name)
+    if not bad_shape:
+        # Should stack both
+        assert batch.shape == (2, 1, 20)
+        assert torch.all(batch == 1)
+    else:
+        # Both fail and should get empty tensor
+        assert batch.shape == (0,)

--- a/tests/loaddata/test_signal_access.py
+++ b/tests/loaddata/test_signal_access.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 import torch
 
-from kale.loaddata.signal_access import load_ecg_from_dir
+from kale.loaddata.signal_access import load_ecg_from_folder
 
 
 @pytest.fixture
@@ -46,7 +46,7 @@ def test_load_ecg_from_dir(tmp_path, monkeypatch, make_csv, bad_shape):
     monkeypatch.setattr("kale.loaddata.signal_access.prepare_ecg_tensor", dummy_prepare_ecg_tensor)
 
     # -- Test
-    batch = load_ecg_from_dir(root, csv_path.name)
+    batch = load_ecg_from_folder(root, csv_path.name)
     if not bad_shape:
         # Should stack both
         assert batch.shape == (2, 1, 20)

--- a/tests/loaddata/test_signal_image_access.py
+++ b/tests/loaddata/test_signal_image_access.py
@@ -1,0 +1,22 @@
+import torch
+
+from kale.loaddata.signal_image_access import SignalImageDataset
+
+
+def test_signal_image_dataset_full_coverage():
+    # Create dummy data
+    num_samples = 4
+    signal_features = torch.randn(num_samples, 20)  # 4 samples, 20-dim signal features
+    image_features = torch.randn(num_samples, 1, 8, 8)  # 4 samples, 1x8x8 images
+
+    # Test __init__ and __len__
+    dataset = SignalImageDataset(signal_features, image_features)
+    assert len(dataset) == num_samples
+
+    # Test __getitem__ for each index
+    for i in range(num_samples):
+        signal, image = dataset[i]
+        assert torch.equal(signal, signal_features[i])
+        assert torch.equal(image, image_features[i])
+        assert signal.shape == (20,)
+        assert image.shape == (1, 8, 8)

--- a/tests/loaddata/test_signal_image_access.py
+++ b/tests/loaddata/test_signal_image_access.py
@@ -3,7 +3,7 @@ import torch
 from kale.loaddata.signal_image_access import SignalImageDataset
 
 
-def test_signal_image_dataset_full_coverage():
+def test_signal_image_dataset():
     # Create dummy data
     num_samples = 4
     signal_features = torch.randn(num_samples, 20)  # 4 samples, 20-dim signal features
@@ -20,3 +20,24 @@ def test_signal_image_dataset_full_coverage():
         assert torch.equal(image, image_features[i])
         assert signal.shape == (20,)
         assert image.shape == (1, 8, 8)
+
+    # Test prepare_data_loaders (train/val split)
+    train_dataset, val_dataset = SignalImageDataset.prepare_data_loaders(
+        signal_features, image_features, train_ratio=0.75, random_seed=42
+    )
+    # The split should be deterministic due to random_seed=42
+    assert isinstance(train_dataset, SignalImageDataset)
+    assert isinstance(val_dataset, SignalImageDataset)
+
+    total = len(train_dataset) + len(val_dataset)
+    assert total == num_samples
+    # Shapes should match original
+    assert train_dataset.signal_features.shape[1:] == signal_features.shape[1:]
+    assert train_dataset.image_features.shape[1:] == image_features.shape[1:]
+    assert val_dataset.signal_features.shape[1:] == signal_features.shape[1:]
+    assert val_dataset.image_features.shape[1:] == image_features.shape[1:]
+
+    # Check non-overlapping indices between train and val (due to shuffling)
+    all_train_indices = set(tuple(sf.tolist()) for sf in train_dataset.signal_features)
+    all_val_indices = set(tuple(sf.tolist()) for sf in val_dataset.signal_features)
+    assert all_train_indices.isdisjoint(all_val_indices) or len(val_dataset) == 0

--- a/tests/pipeline/test_mida_trainer.py
+++ b/tests/pipeline/test_mida_trainer.py
@@ -342,7 +342,7 @@ def test_auto_mida_trainer_coef_shape(toy_data, augment, monkeypatch):
     x, y, domains, factors = toy_data
 
     monkeypatch.setitem(CLASSIFIER_PARAMS["lr"], "C", [1])
-    monkeypatch.setitem(MIDA_PARAMS, "mu", [1])
+    monkeypatch.setitem(MIDA_PARAMS, "mean", [1])
     monkeypatch.setitem(MIDA_PARAMS, "augment", [augment])
     monkeypatch.setitem(MIDA_PARAMS, "ignore_y", [True])
 

--- a/tests/pipeline/test_mida_trainer.py
+++ b/tests/pipeline/test_mida_trainer.py
@@ -342,7 +342,7 @@ def test_auto_mida_trainer_coef_shape(toy_data, augment, monkeypatch):
     x, y, domains, factors = toy_data
 
     monkeypatch.setitem(CLASSIFIER_PARAMS["lr"], "C", [1])
-    monkeypatch.setitem(MIDA_PARAMS, "mean", [1])
+    monkeypatch.setitem(MIDA_PARAMS, "mu", [1])
     monkeypatch.setitem(MIDA_PARAMS, "augment", [augment])
     monkeypatch.setitem(MIDA_PARAMS, "ignore_y", [True])
 

--- a/tests/pipeline/test_multimodal_trainer.py
+++ b/tests/pipeline/test_multimodal_trainer.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn as nn
 from torch.utils.data import Dataset
 
-from kale.pipeline.multimodal_trainer import MultimodalTrainer, MultimodalTriStreamVAETrainer
+from kale.pipeline.multimodal_trainer import SignalImageFineTuningTrainer, SignalImageTriStreamVAETrainer
 
 
 class DummyMVAE(nn.Module):
@@ -65,7 +65,7 @@ def test_multimodal_tristream_vae_trainer_steps():
     model = DummyMVAE()
     train_ds = DummyDataset(num_samples=3, in_dim=10, labels=False)
     val_ds = DummyDataset(num_samples=2, in_dim=10, labels=False)
-    trainer_module = MultimodalTriStreamVAETrainer(
+    trainer_module = SignalImageTriStreamVAETrainer(
         model=model,
         train_dataset=train_ds,
         val_dataset=val_ds,
@@ -100,7 +100,7 @@ def test_multimodal_tristream_vae_trainer_steps():
 
 def test_multimodal_trainer_step_and_metrics():
     torch.manual_seed(0)
-    model = MultimodalTrainer(DummyPretrainedModel(), num_classes=2, lr=1e-3)
+    model = SignalImageFineTuningTrainer(DummyPretrainedModel(), num_classes=2, lr=1e-3)
 
     # Use DummyDataset with labels=True (returns image, signal, label)
     dataset = DummyDataset(num_samples=6, in_dim=5, labels=True)

--- a/tests/pipeline/test_multimodal_trainer.py
+++ b/tests/pipeline/test_multimodal_trainer.py
@@ -1,0 +1,133 @@
+import torch
+import torch.nn as nn
+from torch.utils.data import Dataset
+
+from kale.pipeline.multimodal_trainer import MultimodalTrainer, MultimodalTriStreamVAETrainer
+
+
+class DummyMVAE(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.dummy_param = nn.Parameter(torch.zeros(1))  # <-- Fake parameter
+
+    def forward(self, image=None, signal=None):
+        batch_size = image.size(0) if image is not None else signal.size(0)
+        recon_image = torch.zeros(batch_size, 4, 4)
+        recon_signal = torch.zeros(batch_size, 10)
+        mu = torch.zeros(batch_size, 6)
+        logvar = torch.zeros(batch_size, 6)
+        return recon_image, recon_signal, mu, logvar
+
+
+class DummyDataset(Dataset):
+    """
+    Flexible dummy dataset for tests. If labels=True, returns (image, signal, label),
+    otherwise returns (signal, image).
+    """
+
+    def __init__(self, num_samples=6, in_dim=5, num_classes=2, labels=False):
+        self.num_samples = num_samples
+        self.labels = labels
+        self.images = torch.randn(num_samples, in_dim)
+        self.signals = torch.randn(num_samples, in_dim)
+        self.all_labels = torch.randint(0, num_classes, (num_samples,))
+
+    def __len__(self):
+        return self.num_samples
+
+    def __getitem__(self, idx):
+        if self.labels:
+            return self.images[idx], self.signals[idx], self.all_labels[idx]
+        else:
+            # For the VAE test, mimic (signal, image) tuple for compatibility.
+            return self.signals[idx], self.images[idx]
+
+
+# Dummy pre-trained model with frozen encoders
+class DummyEncoder(nn.Module):
+    def __init__(self, latent_dim=4):
+        super().__init__()
+        self.linear = nn.Linear(5, latent_dim)
+
+    def forward(self, x):
+        return self.linear(x), torch.zeros(x.size(0), self.linear.out_features)
+
+
+class DummyPretrainedModel(nn.Module):
+    def __init__(self, latent_dim=4):
+        super().__init__()
+        self.image_encoder = DummyEncoder(latent_dim)
+        self.signal_encoder = DummyEncoder(latent_dim)
+        self.n_latents = latent_dim
+
+
+def test_multimodal_tristream_vae_trainer_steps():
+    model = DummyMVAE()
+    train_ds = DummyDataset(num_samples=3, in_dim=10, labels=False)
+    val_ds = DummyDataset(num_samples=2, in_dim=10, labels=False)
+    trainer_module = MultimodalTriStreamVAETrainer(
+        model=model,
+        train_dataset=train_ds,
+        val_dataset=val_ds,
+        batch_size=2,
+        num_workers=0,
+        lambda_image=1.0,
+        lambda_signal=2.0,
+        lr=1e-2,
+        annealing_epochs=2,
+        scale_factor=1e-4,
+    )
+
+    # Test forward
+    dummy_signal = torch.randn(2, 10)
+    dummy_image = torch.randn(2, 4, 4)
+    out = trainer_module.forward(image=dummy_image, signal=dummy_signal)
+    assert isinstance(out, tuple) and len(out) == 4
+
+    # Test training_step and validation_step
+    batch = (torch.ones(2, 10), torch.ones(2, 4, 4))
+    train_loss = trainer_module.training_step(batch, batch_idx=0)
+    assert isinstance(train_loss, torch.Tensor)
+    assert torch.isfinite(train_loss)
+    val_loss = trainer_module.validation_step(batch, batch_idx=0)
+    assert val_loss is not None
+
+    # Test optimizer configuration
+    optim = trainer_module.configure_optimizers()
+    assert isinstance(optim, torch.optim.Adam)
+    assert any([p.requires_grad for p in optim.param_groups[0]["params"]])
+
+
+def test_multimodal_trainer_step_and_metrics():
+    torch.manual_seed(0)
+    model = MultimodalTrainer(DummyPretrainedModel(), num_classes=2, lr=1e-3)
+
+    # Use DummyDataset with labels=True (returns image, signal, label)
+    dataset = DummyDataset(num_samples=6, in_dim=5, labels=True)
+    batch = (
+        dataset.images[:2],
+        dataset.signals[:2],
+        dataset.all_labels[:2],
+    )
+    # Test forward (logits shape)
+    logits = model.forward(batch[0], batch[1])
+    assert logits.shape == (2, 2)
+
+    # Test training_step (returns loss tensor)
+    loss = model.training_step(batch, batch_idx=0)
+    assert isinstance(loss, torch.Tensor)
+    model.on_train_epoch_end()  # logs average loss and clears train_losses
+
+    # Test validation_step (fills validation_step_outputs and val_losses)
+    model.validation_step(batch, batch_idx=0)
+    model.validation_step(batch, batch_idx=1)
+    model.on_validation_epoch_end()
+
+    # Test optimizer config
+    optim = model.configure_optimizers()
+    assert isinstance(optim, torch.optim.Adam)
+    assert any([p.requires_grad for p in optim.param_groups[0]["params"]])
+
+    # Check that buffers are cleared
+    assert model.validation_step_outputs == []
+    assert model.val_losses == []

--- a/tests/pipeline/test_multimodal_trainer.py
+++ b/tests/pipeline/test_multimodal_trainer.py
@@ -109,25 +109,35 @@ def test_multimodal_trainer_step_and_metrics():
         dataset.signals[:2],
         dataset.all_labels[:2],
     )
-    # Test forward (logits shape)
+    # Normal case (should hit success branches)
     logits = model.forward(batch[0], batch[1])
     assert logits.shape == (2, 2)
 
-    # Test training_step (returns loss tensor)
     loss = model.training_step(batch, batch_idx=0)
     assert isinstance(loss, torch.Tensor)
-    model.on_train_epoch_end()  # logs average loss and clears train_losses
+    model.on_train_epoch_end()
 
-    # Test validation_step (fills validation_step_outputs and val_losses)
     model.validation_step(batch, batch_idx=0)
     model.validation_step(batch, batch_idx=1)
     model.on_validation_epoch_end()
 
-    # Test optimizer config
     optim = model.configure_optimizers()
     assert isinstance(optim, torch.optim.Adam)
     assert any([p.requires_grad for p in optim.param_groups[0]["params"]])
-
-    # Check that buffers are cleared
     assert model.validation_step_outputs == []
     assert model.val_losses == []
+
+    # Construct outputs so that roc_auc_score and matthews_corrcoef will fail
+    model.validation_step_outputs = []
+    # Create a batch with only one class present (invalid for AUC)
+    labels = torch.zeros(3, dtype=torch.long)
+    preds = torch.zeros(3, dtype=torch.long)
+    probs = torch.zeros(3)  # Shape (3,), should be fine for code
+    model.validation_step_outputs.append((labels, preds, probs))
+    # MCC for one class should return 0, but to trigger except, pass empty
+    model.val_losses = [torch.tensor(0.5)]
+    model.on_validation_epoch_end()  # Should now hit both except branches
+
+    model.validation_step_outputs = []
+    model.validation_step_outputs.append((torch.tensor([]), torch.tensor([]), torch.tensor([])))
+    model.on_validation_epoch_end()

--- a/tests/predict/test_decode.py
+++ b/tests/predict/test_decode.py
@@ -1,7 +1,15 @@
 import pytest
 import torch
+import torch.nn as nn
 
-from kale.predict.decode import LinearClassifier, MLPDecoder, VCDN
+from kale.predict.decode import (
+    ImageVAEDecoder,
+    LinearClassifier,
+    MLPDecoder,
+    MultimodalClassifier,
+    SignalVAEDecoder,
+    VCDN,
+)
 from kale.utils.seed import set_seed
 
 
@@ -102,3 +110,98 @@ def test_vcdn_reset_parameters(vcdn):
     # Check that the parameters are now different
     for param in vcdn.parameters():
         assert torch.any(param != 1.0)
+
+
+def test_image_vae_decoder_forward():
+    latent_dim = 8
+    output_channels = 2
+    batch_size = 3
+
+    decoder = ImageVAEDecoder(latent_dim=latent_dim, output_channels=output_channels)
+    decoder.eval()
+
+    z = torch.randn(batch_size, latent_dim)
+    recon = decoder(z)
+
+    assert recon.shape == (batch_size, output_channels, 224, 224)
+
+
+def test_image_vae_decoder_repr_and_init():
+    # Test that the class can be constructed and repr doesn't crash
+    decoder = ImageVAEDecoder(latent_dim=16, output_channels=3)
+    assert isinstance(decoder, ImageVAEDecoder)
+    assert "ImageVAEDecoder" in repr(decoder)
+
+
+def test_signal_vae_decoder_forward():
+    latent_dim = 8
+    output_dim = 32  # Small for test
+    batch_size = 4
+
+    decoder = SignalVAEDecoder(latent_dim=latent_dim, output_dim=output_dim)
+    decoder.eval()
+
+    z = torch.randn(batch_size, latent_dim)
+    out = decoder(z)
+
+    # The output should have shape (batch_size, 1, output_dim)
+    assert out.shape == (batch_size, 1, output_dim)
+
+    # Output should be float
+    assert out.dtype == torch.float32
+
+
+def test_signal_vae_decoder_init_repr():
+    decoder = SignalVAEDecoder(latent_dim=16, output_dim=64)
+    assert isinstance(decoder, SignalVAEDecoder)
+    assert "SignalVAEDecoder" in repr(decoder)
+
+
+# Optionally: test with batch_size=1 and latent_dim=1 for extreme edge cases
+def test_signal_vae_decoder_edge_case():
+    decoder = SignalVAEDecoder(latent_dim=1, output_dim=8)
+    z = torch.randn(1, 1)
+    out = decoder(z)
+    assert out.shape == (1, 1, 8)
+
+
+# Dummy encoder that returns (mu, logvar)
+class DummyEncoder(nn.Module):
+    def __init__(self, feature_dim, latent_dim):
+        super().__init__()
+        self.feature_dim = feature_dim
+        self.latent_dim = latent_dim
+
+    def forward(self, x):
+        batch_size = x.shape[0]
+        mu = torch.ones(batch_size, self.latent_dim)
+        logvar = torch.zeros(batch_size, self.latent_dim)
+        return mu, logvar
+
+
+class DummyPretrainedModel(nn.Module):
+    def __init__(self, n_latents):
+        super().__init__()
+        self.image_encoder = DummyEncoder(10, n_latents)
+        self.signal_encoder = DummyEncoder(20, n_latents)
+        self.n_latents = n_latents
+
+
+def test_multimodal_classifier_forward():
+    n_latents = 8
+    num_classes = 3
+    batch_size = 5
+    pretrained_model = DummyPretrainedModel(n_latents=n_latents)
+    classifier = MultimodalClassifier(pretrained_model, num_classes=num_classes)
+    for p in classifier.image_encoder.parameters():
+        assert not p.requires_grad
+    for p in classifier.signal_encoder.parameters():
+        assert not p.requires_grad
+    image = torch.randn(batch_size, 10)
+    signal = torch.randn(batch_size, 20)
+    logits = classifier(image, signal)
+    assert logits.shape == (batch_size, num_classes)
+    assert logits.requires_grad
+    labels = torch.randint(0, num_classes, (batch_size,))
+    loss = nn.CrossEntropyLoss()(logits, labels)
+    loss.backward()

--- a/tests/predict/test_decode.py
+++ b/tests/predict/test_decode.py
@@ -3,11 +3,11 @@ import torch
 import torch.nn as nn
 
 from kale.predict.decode import (
-    ImageVAEDecoder,
+    ImageVaeDecoder,
     LinearClassifier,
     MLPDecoder,
-    MultimodalClassifier,
-    SignalVAEDecoder,
+    SignalImageFineTuningClassifier,
+    SignalVaeDecoder,
     VCDN,
 )
 from kale.utils.seed import set_seed
@@ -117,7 +117,7 @@ def test_image_vae_decoder_forward():
     output_channels = 2
     batch_size = 3
 
-    decoder = ImageVAEDecoder(latent_dim=latent_dim, output_channels=output_channels)
+    decoder = ImageVaeDecoder(latent_dim=latent_dim, output_channels=output_channels)
     decoder.eval()
 
     z = torch.randn(batch_size, latent_dim)
@@ -128,8 +128,8 @@ def test_image_vae_decoder_forward():
 
 def test_image_vae_decoder_repr_and_init():
     # Test that the class can be constructed and repr doesn't crash
-    decoder = ImageVAEDecoder(latent_dim=16, output_channels=3)
-    assert isinstance(decoder, ImageVAEDecoder)
+    decoder = ImageVaeDecoder(latent_dim=16, output_channels=3)
+    assert isinstance(decoder, ImageVaeDecoder)
     assert "ImageVAEDecoder" in repr(decoder)
 
 
@@ -138,7 +138,7 @@ def test_signal_vae_decoder_forward():
     output_dim = 32  # Small for test
     batch_size = 4
 
-    decoder = SignalVAEDecoder(latent_dim=latent_dim, output_dim=output_dim)
+    decoder = SignalVaeDecoder(latent_dim=latent_dim, output_dim=output_dim)
     decoder.eval()
 
     z = torch.randn(batch_size, latent_dim)
@@ -152,14 +152,14 @@ def test_signal_vae_decoder_forward():
 
 
 def test_signal_vae_decoder_init_repr():
-    decoder = SignalVAEDecoder(latent_dim=16, output_dim=64)
-    assert isinstance(decoder, SignalVAEDecoder)
+    decoder = SignalVaeDecoder(latent_dim=16, output_dim=64)
+    assert isinstance(decoder, SignalVaeDecoder)
     assert "SignalVAEDecoder" in repr(decoder)
 
 
 # Optionally: test with batch_size=1 and latent_dim=1 for extreme edge cases
 def test_signal_vae_decoder_edge_case():
-    decoder = SignalVAEDecoder(latent_dim=1, output_dim=8)
+    decoder = SignalVaeDecoder(latent_dim=1, output_dim=8)
     z = torch.randn(1, 1)
     out = decoder(z)
     assert out.shape == (1, 1, 8)
@@ -192,7 +192,7 @@ def test_multimodal_classifier_forward():
     num_classes = 3
     batch_size = 5
     pretrained_model = DummyPretrainedModel(n_latents=n_latents)
-    classifier = MultimodalClassifier(pretrained_model, num_classes=num_classes)
+    classifier = SignalImageFineTuningClassifier(pretrained_model, num_classes=num_classes)
     for p in classifier.image_encoder.parameters():
         assert not p.requires_grad
     for p in classifier.signal_encoder.parameters():

--- a/tests/predict/test_decode.py
+++ b/tests/predict/test_decode.py
@@ -162,7 +162,7 @@ def test_signal_vae_decoder_edge_case():
     assert signal_recon.shape == (1, 1, 8)
 
 
-# Dummy encoder that returns (mu, logvar)
+# Dummy encoder that returns (mean, log_var)
 class DummyEncoder(nn.Module):
     def __init__(self, feature_dim, latent_dim):
         super().__init__()
@@ -171,9 +171,9 @@ class DummyEncoder(nn.Module):
 
     def forward(self, x):
         batch_size = x.shape[0]
-        mu = torch.ones(batch_size, self.latent_dim)
-        logvar = torch.zeros(batch_size, self.latent_dim)
-        return mu, logvar
+        mean = torch.ones(batch_size, self.latent_dim)
+        log_var = torch.zeros(batch_size, self.latent_dim)
+        return mean, log_var
 
 
 class DummyPretrainedModel(nn.Module):

--- a/tests/prepdata/test_signal_transform.py
+++ b/tests/prepdata/test_signal_transform.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 import torch
 
 from kale.prepdata.signal_transform import interpolate_signal, normalize_signal, prepare_ecg_tensor
@@ -40,8 +41,8 @@ def test_interpolate_signal_no_nan():
     assert np.allclose(arr, interpolated)
 
 
-def test_prepare_ecg_tensor_shape_dtype():
-    arr = np.arange(6).reshape(3, 2)  # (3,2)
+def test_prepare_ecg_tensor_numpy():
+    arr = np.arange(6).reshape(3, 2)
     tensor = prepare_ecg_tensor(arr)
     assert isinstance(tensor, torch.Tensor)
     assert tensor.shape == (1, 6)
@@ -50,7 +51,29 @@ def test_prepare_ecg_tensor_shape_dtype():
     assert torch.allclose(tensor, torch.tensor(arr.reshape(1, -1), dtype=torch.float32))
 
 
-def test_prepare_ecg_tensor_empty():
+def test_prepare_ecg_tensor_tensor():
+    arr = torch.arange(6).reshape(3, 2)
+    tensor = prepare_ecg_tensor(arr)
+    assert isinstance(tensor, torch.Tensor)
+    assert tensor.shape == (1, 6)
+    assert tensor.dtype == torch.float32
+    assert torch.allclose(tensor, arr.reshape(1, -1).to(torch.float32))
+
+
+def test_prepare_ecg_tensor_empty_numpy():
     arr = np.array([]).reshape(0, 2)
     tensor = prepare_ecg_tensor(arr)
     assert tensor.shape == (1, 0)
+    assert tensor.dtype == torch.float32
+
+
+def test_prepare_ecg_tensor_empty_tensor():
+    arr = torch.empty(0, 2)
+    tensor = prepare_ecg_tensor(arr)
+    assert tensor.shape == (1, 0)
+    assert tensor.dtype == torch.float32
+
+
+def test_prepare_ecg_tensor_wrong_type():
+    with pytest.raises(TypeError):
+        prepare_ecg_tensor([1, 2, 3])  # List, not supported

--- a/tests/prepdata/test_signal_transform.py
+++ b/tests/prepdata/test_signal_transform.py
@@ -1,0 +1,56 @@
+import numpy as np
+import torch
+
+from kale.prepdata.signal_transform import interpolate_signal, normalize_signal, prepare_ecg_tensor
+
+
+def test_normalize_signal_regular():
+    # Shape: (samples, channels)
+    arr = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+    normed = normalize_signal(arr)
+    assert normed.shape == arr.shape
+    # Mean should be zero after normalization (numerical tolerance)
+    assert np.allclose(np.mean(normed, axis=0), 0, atol=1e-6)
+    # Std should be one after normalization
+    assert np.allclose(np.std(normed, axis=0), 1, atol=1e-6)
+
+
+def test_normalize_signal_zero_std():
+    # All same values in one channel
+    arr = np.array([[1.0, 2.0], [1.0, 2.0]])
+    normed = normalize_signal(arr)
+    # No division by zero, still finite
+    assert np.isfinite(normed).all()
+    # The column with constant value should be all zeros
+    assert np.all(normed[:, 0] == 0)
+    assert np.all(normed[:, 1] == 0)
+
+
+def test_interpolate_signal_nan_middle():
+    arr = np.array([[1.0, 2.0], [np.nan, np.nan], [3.0, 6.0]])
+    interpolated = interpolate_signal(arr)
+    assert interpolated.shape == arr.shape
+    # Should fill the nan as average of neighbors
+    assert np.allclose(interpolated[1], [2.0, 4.0], atol=1e-6)
+
+
+def test_interpolate_signal_no_nan():
+    arr = np.arange(6).reshape(3, 2)
+    interpolated = interpolate_signal(arr)
+    assert np.allclose(arr, interpolated)
+
+
+def test_prepare_ecg_tensor_shape_dtype():
+    arr = np.arange(6).reshape(3, 2)  # (3,2)
+    tensor = prepare_ecg_tensor(arr)
+    assert isinstance(tensor, torch.Tensor)
+    assert tensor.shape == (1, 6)
+    assert tensor.dtype == torch.float32
+    # Values preserved and order correct
+    assert torch.allclose(tensor, torch.tensor(arr.reshape(1, -1), dtype=torch.float32))
+
+
+def test_prepare_ecg_tensor_empty():
+    arr = np.array([]).reshape(0, 2)
+    tensor = prepare_ecg_tensor(arr)
+    assert tensor.shape == (1, 0)


### PR DESCRIPTION
### Description
Added multimodal tri-stream pre-training and fine-tuning support for image and signal modalities (e.g., Chest X-ray and ECG). The API is refactored from the [CardioVAE](https://github.com/Shef-AIRE/AI4Cardiothoracic-CardioVAE) repository, and the corresponding paper is available [here](https://link.springer.com/chapter/10.1007/978-3-031-72378-0_28). The major changes that have been made in this pull request are: 
1. Implemented a multimodal tri-stream VAE pre-training and fine-tuning pipeline with:
    - 3-layer CNN encoders for image and signal modalities  
    - Corresponding CNN decoders  
    - Product-of-Experts (PoE) fusion  
    - ELBO loss for VAE pre-training
    - BimodalVAE
    - MultimodalTrainer
2. Added test cases for all new components in the API.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
