### PR TITLE
Allow custom param_grid for AutoMIDAClassificationTrainer

### DIFF
--- a/kale/pipeline/multi_domain_adapter.py
+++ b/kale/pipeline/multi_domain_adapter.py
@@ -992,7 +992,7 @@ class AutoMIDAClassificationTrainer(MetaEstimatorMixin, BaseEstimator):
         param_grid (dict or None, optional): Dictionary with parameter names as keys and lists of parameter settings
             to try as values. If None, uses default parameters for the selected classifier.
         use_mida (bool, optional): Whether to use MIDA for domain adaptation. Default is True.
-        nonlinear (bool, optional): Whether to enable nonlinear MIDA. Default is False.
+        nonlinear (bool, optional): Whether to enable nonlinear MIDA. Ignored when `param_grid` is defined. Default is False.
         transformer (sklearn.base.BaseEstimator or None, optional): Optional transformer to apply before MIDA.
             Must implement `fit` and `transform`. Default is None.
         search_strategy (str, optional): "grid" or "random" search for hyperparameter optimization. Default is "random".

--- a/kale/pipeline/multi_domain_adapter.py
+++ b/kale/pipeline/multi_domain_adapter.py
@@ -1,8 +1,7 @@
 # =============================================================================
 # Author: Shuo Zhou, shuo.zhou@sheffield.ac.uk/sz144@outlook.com
 # =============================================================================
-"""Multi-source domain adaptation pipelines
-"""
+"""Multi-source domain adaptation pipelines"""
 
 import logging
 import time
@@ -990,6 +989,8 @@ class AutoMIDAClassificationTrainer(MetaEstimatorMixin, BaseEstimator):
     Args:
         classifier (str, optional): Classifier type or "auto" to automatically select one.
             Supported strings include {"lr", "linear_svm", "svm", "ridge"}. Default is "auto".
+        param_grid (dict or None, optional): Dictionary with parameter names as keys and lists of parameter settings
+            to try as values. If None, uses default parameters for the selected classifier.
         use_mida (bool, optional): Whether to use MIDA for domain adaptation. Default is True.
         nonlinear (bool, optional): Whether to enable nonlinear MIDA. Default is False.
         transformer (sklearn.base.BaseEstimator or None, optional): Optional transformer to apply before MIDA.
@@ -1012,6 +1013,7 @@ class AutoMIDAClassificationTrainer(MetaEstimatorMixin, BaseEstimator):
 
     _parameter_constraints = {
         "classifier": [StrOptions({"auto"} | set(CLASSIFIERS))],
+        "param_grid": [None, dict],
         "use_mida": ["boolean"],
         "nonlinear": ["boolean"],
         "transformer": [HasMethods(["fit", "transform"]), None],
@@ -1032,6 +1034,7 @@ class AutoMIDAClassificationTrainer(MetaEstimatorMixin, BaseEstimator):
     def __init__(
         self,
         classifier="auto",
+        param_grid=None,
         use_mida=True,
         nonlinear=False,
         transformer=None,
@@ -1049,6 +1052,7 @@ class AutoMIDAClassificationTrainer(MetaEstimatorMixin, BaseEstimator):
         return_train_score=False,
     ):
         self.classifier = classifier
+        self.param_grid = param_grid
         self.use_mida = use_mida
         self.nonlinear = nonlinear
         self.transformer = transformer
@@ -1074,8 +1078,14 @@ class AutoMIDAClassificationTrainer(MetaEstimatorMixin, BaseEstimator):
         """
         check_is_fitted(self)
 
-        if self.nonlinear:
-            raise ValueError("coef_ is not available when `nonlinear=True`.")
+        best_params = self.best_params_
+        kernels = [k for k in best_params if k.endswith("__kernel")]
+        has_nonlinear_kernel = any(k != "linear" for k in kernels)
+
+        if self.nonlinear or has_nonlinear_kernel:
+            raise ValueError(
+                "coef_ is not available when `nonlinear=True` or found `kernel != 'linear'` in `best_params`."
+            )
 
         augment = None
         coef = self.best_classifier_.coef_
@@ -1204,8 +1214,15 @@ class AutoMIDAClassificationTrainer(MetaEstimatorMixin, BaseEstimator):
         if hasattr(base_classifier, "max_iter"):
             base_classifier.set_params(max_iter=self.num_solver_iter, random_state=self.random_state)
 
+        # If a custom param_grid is provided, use it directly
+        if self.param_grid is not None:
+            # "auto" is not usable with custom param_grid
+            if self.classifier == "auto":
+                raise ValueError("Cannot provide a custom param_grid when classifier is set to 'auto'.")
+            return base_classifier, clone(self.param_grid, safe=False)
+
         if self.classifier != "auto":
-            return base_classifier, CLASSIFIER_PARAMS[self.classifier]
+            return base_classifier, clone(CLASSIFIER_PARAMS[self.classifier], safe=False)
 
         # Workaround to allow classifier selection
         base_classifier = Pipeline([("classifier", base_classifier)])
@@ -1231,7 +1248,9 @@ class AutoMIDAClassificationTrainer(MetaEstimatorMixin, BaseEstimator):
         Returns:
             dict: Parameter grid for MIDA.
         """
-        if not self.use_mida:
+        # Just return empty if param_grid is provided or MIDA is not used
+        # Assuming param_grid have predefined MIDA parameters
+        if not self.use_mida or self.param_grid is not None:
             return {}
 
         param_grid = {f"domain_adapter__{param}": value for param, value in MIDA_PARAMS.items()}

--- a/tests/pipeline/test_mida_trainer.py
+++ b/tests/pipeline/test_mida_trainer.py
@@ -473,3 +473,30 @@ def test_auto_mida_trainer_callable_score(toy_data, classifier):
         "Please provide group_labels when calling fit.",
     ):
         _ = trainer.groups_
+
+
+def test_auto_mida_trainer_custom_param_grid():
+    custom_param_grid = {
+        "C": [0.1, 1, 10],
+        "domain_adapter__mu": [0.01, 0.1, 1],
+        "domain_adapter__num_components": [2, 4],
+    }
+
+    trainer = AutoMIDAClassificationTrainer(
+        classifier="lr",
+        search_strategy="random",
+        scoring="accuracy",
+        num_search_iter=3,
+        num_solver_iter=10,
+        cv=2,
+        param_grid=custom_param_grid,
+        error_score="raise",
+        random_state=0,
+    )
+    _, generated_param_grid = trainer._get_classifier_and_grid()
+    generated_mida_grid = trainer._get_mida_and_grid()
+
+    assert generated_param_grid == custom_param_grid, (
+        f"Expected custom_param_grid to be {custom_param_grid}, " f"but got {generated_param_grid}"
+    )
+    assert generated_mida_grid == {}, "MIDA grid should be empty with predefined param_grid"


### PR DESCRIPTION
### Description
1. Adds `param_grid` to `AutoMIDAClassificationTrainer` to customize search grid.
2. Adds checking for `param_grid is not None` and returning pre-defined `param_grid` and empty dict  for both `_get_classifier_and_grid()` and `_get_mida_and_grid()` respectively
3. Adds checking for `coef_` when found either `nonlinear=True` or `kernel != "linear"` in `self.best_params_`.
4. Adds test case for for `(2)` and `(3)` respectively.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
