### PR TITLE
Add PyG as core dependencies

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -16,7 +16,7 @@ Install PyKale using `pip` for the stable version:
 pip install pykale  # for the core API only
 ```
 
-For users who wants to use PyKale in Google Colab, prefers quicker installation while requiring specific CUDA version, we highly recommend using PyTorch Geometric's pre-built wheel to prevent building the wheel manually during the runtime.
+For users who want to use PyKale in Google Colab, prefer quicker installation while requiring specific CUDA version, we highly recommend using PyTorch Geometric's pre-built wheel to prevent building the wheel manually during the runtime.
 
 If you need CUDA for GPU runtime, please install PyKale with command:
 ```bash

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ install_requires = [
     "torch==2.3.0",  # also change the version in the test.yaml when changing this next time, and update the pytorch version in the bindingdb_deepdta tutorial notebook
     "torchvision>=0.12.0",  # in download, sampler (NON-ideal), and vision API only
     # Given now many modules requires PyG with torch_sparse and torch_scatter,
-    # it will now included as core dependencies.
+    # it will now be included as core dependencies.
     # For installing PyG's pre-build wheels, can be done either:
     # pip install pykale -f https://data.pyg.org/whl/torch-2.3.0+cpu.html
     # pip install pykale -f https://data.pyg.org/whl/torch-2.3.0+cu118.html


### PR DESCRIPTION
### Description
This PR adds PyG (`torch-geometric==2.3.0`) and its extensions (`torch-scatter` and `torch-sparse`) as one of the core dependencies.

Given that there are so many modules now requiring PyG to be installed (e.g., `kale.interpret.model_weights`, `kale.predict.decode`), it can be a nuisance to install PyG separately, especially for users who don't need graph-based methods, but forced to installed it anyway. Including PyG as a core dependency is hoped to help alleviate this headache from the user's end.

`pyg-lib` will remain optional for users who want to use the GNNs available in PyKale.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [x] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
