### PR TITLE
Remove PyG from setup.py

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -16,20 +16,6 @@ Install PyKale using `pip` for the stable version:
 pip install pykale  # for the core API only
 ```
 
-For users who want to use PyKale in Google Colab, prefer quicker installation while requiring specific CUDA version, we highly recommend using PyTorch Geometric's pre-built wheel to prevent building the wheel manually during the runtime.
-
-If you need CUDA for GPU runtime, please install PyKale with command:
-```bash
-pip install pykale -f https://data.pyg.org/whl/torch-2.3.0+${CUDA}.html
-```
-where `${CUDA}` can either be `cu121` or `cu118`. We recommend to use `cu121` for Google Colab runtime.
-
-Alternatively, if you don't need GPUs for your workflow please run:
-```bash
-pip install pykale -f https://data.pyg.org/whl/torch-2.3.0+cpu.html
-```
-
-
 ## Install from source
 
 Install from source for the latest version and/or development:

--- a/setup.py
+++ b/setup.py
@@ -23,15 +23,6 @@ install_requires = [
     "tensorly>=0.5.1",  # in factorization and model_weights API only
     "torch==2.3.0",  # also change the version in the test.yaml when changing this next time, and update the pytorch version in the bindingdb_deepdta tutorial notebook
     "torchvision>=0.12.0",  # in download, sampler (NON-ideal), and vision API only
-    # Given now many modules requires PyG with torch_sparse and torch_scatter,
-    # it will now be included as core dependencies.
-    # For installing PyG's pre-build wheels, can be done either:
-    # pip install pykale -f https://data.pyg.org/whl/torch-2.3.0+cpu.html
-    # pip install pykale -f https://data.pyg.org/whl/torch-2.3.0+cu118.html
-    # pip install pykale -f https://data.pyg.org/whl/torch-2.3.0+cu121.html
-    "torch-geometric==2.3.0",
-    "torch_sparse",
-    "torch_scatter",
 ]
 
 # Application-specific dependencies sorted alphabetically below


### PR DESCRIPTION
### Description
Building wheels for torch-geometric, torch_sparse, and torch_scatter takes much time. Remove them from setup.py to accelerate installation time. 

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
