### PR TITLE
Set neurokit2<=0.2.11 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ example_requires = [
     "xlsxwriter",
     "prettytable",
     "comet_ml",
-    "neurokit2",
+    "neurokit2<=0.2.11",  # neurokit2 0.2.11 requires requires python>=3.10
     "captum",
     "pywavelets",
     "rdkit>=2025.3.1",  # For DrugBAN example


### PR DESCRIPTION
### Description
Set neurokit2<=0.2.11 in setup.py,  neurokit2 0.2.12 requires Python>=3.10

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
