### PR TITLE
Fix circular import and refactor correlation analysis

### DIFF
--- a/docs/source/kale.interpret.rst
+++ b/docs/source/kale.interpret.rst
@@ -6,6 +6,14 @@ Interpret
 Submodules
 ----------
 
+kale.interpret.correlation\_analysis module
+--------------------------------------------
+
+.. automodule:: kale.interpret.correlation_analysis
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 kale.interpret.model\_weights module
 ------------------------------------
 

--- a/examples/landmark_uncertainty/main.py
+++ b/examples/landmark_uncertainty/main.py
@@ -13,10 +13,8 @@ Paper link: https://arxiv.org/abs/2203.02351
 
 import argparse
 import os
-import warnings
 
 import numpy as np
-import pandas as pd
 import seaborn as sns
 from config import get_cfg_defaults
 from pandas import *

--- a/examples/landmark_uncertainty/main.py
+++ b/examples/landmark_uncertainty/main.py
@@ -26,14 +26,14 @@ from kale.utils.download import download_file_by_url
 
 def arg_parse():
     """
-    Parsing arguments
+    Parse command-line arguments.
 
     Example:
-    python main.py
+        Default settings:
+            python main.py
 
-    To use a custom config, or a config file provided in the configs folder:
-    python main.py --cfg ../configs/isbi_config.yaml
-
+        With custom config:
+            python main.py --cfg ../configs/isbi_config.yaml
     """
     parser = argparse.ArgumentParser(description="Quantile Binning for landmark uncertainty estimation.")
     parser.add_argument("--cfg", required=False, help="path to config file", type=str)

--- a/examples/landmark_uncertainty/main.py
+++ b/examples/landmark_uncertainty/main.py
@@ -126,7 +126,7 @@ def main():
                         cfg.DATASET.ROOT, base_dir, model, dataset, uncertainty_pairs_test + "_t" + str(landmark)
                     )
 
-                    quantile_binning_output_dir = os.path.join(save_folder, "fitted_quantile_binning", model, dataset)
+                    output_dir = os.path.join(save_folder, "fitted_quantile_binning", model, dataset)
                     os.makedirs(save_folder, exist_ok=True)
 
                     fit_and_predict(
@@ -137,7 +137,7 @@ def main():
                         num_bins,
                         cfg,
                         groundtruth_test_errors=gt_test_error_available,
-                        save_folder=quantile_binning_output_dir,
+                        save_folder=output_dir,
                     )
 
         ############ Evaluation Phase ##########################

--- a/examples/landmark_uncertainty/main.py
+++ b/examples/landmark_uncertainty/main.py
@@ -25,19 +25,20 @@ from kale.utils.download import download_file_by_url
 
 
 def arg_parse():
-    """Parsing arguments"""
-    parser = argparse.ArgumentParser(description="Quantile Binning for landmark uncertainty estimation.")
-    parser.add_argument("--cfg", required=False, help="path to config file", type=str)
+    """
+    Parsing arguments
 
-    args = parser.parse_args()
-
-    """Example:
+    Example:
     python main.py
 
     To use a custom config, or a config file provided in the configs folder:
     python main.py --cfg ../configs/isbi_config.yaml
 
     """
+    parser = argparse.ArgumentParser(description="Quantile Binning for landmark uncertainty estimation.")
+    parser.add_argument("--cfg", required=False, help="path to config file", type=str)
+
+    args = parser.parse_args()
     return args
 
 
@@ -125,10 +126,10 @@ def main():
                         cfg.DATASET.ROOT, base_dir, model, dataset, uncertainty_pairs_test + "_t" + str(landmark)
                     )
 
-                    fitted_save_at = os.path.join(save_folder, "fitted_quantile_binning", model, dataset)
+                    quantile_binning_output_dir = os.path.join(save_folder, "fitted_quantile_binning", model, dataset)
                     os.makedirs(save_folder, exist_ok=True)
 
-                    uncert_boundaries, estimated_errors, predicted_bins = fit_and_predict(
+                    fit_and_predict(
                         landmark,
                         all_uncert_error_pairs_to_compare,
                         landmark_results_path_val,
@@ -136,7 +137,7 @@ def main():
                         num_bins,
                         cfg,
                         groundtruth_test_errors=gt_test_error_available,
-                        save_folder=fitted_save_at,
+                        save_folder=quantile_binning_output_dir,
                     )
 
         ############ Evaluation Phase ##########################
@@ -206,7 +207,7 @@ def main():
                             ]
                         )
 
-                        all_fitted_save_paths = [
+                        quantile_binning_dirs = [
                             os.path.join(cfg.OUTPUT.OUT_DIR, dataset, str(x_bins) + "Bins", "fitted_quantile_binning")
                             for x_bins in cfg.PIPELINE.NUM_QUANTILE_BINS
                         ]
@@ -227,7 +228,7 @@ def main():
                                 landmarks,
                                 cfg.PIPELINE.NUM_QUANTILE_BINS,
                                 cmaps,
-                                all_fitted_save_paths,
+                                quantile_binning_dirs,
                                 save_folder_comparison,
                                 save_file_preamble,
                                 cfg.PIPELINE.COMBINE_MIDDLE_BINS,

--- a/examples/landmark_uncertainty/main.py
+++ b/examples/landmark_uncertainty/main.py
@@ -17,7 +17,6 @@ import os
 import numpy as np
 import seaborn as sns
 from config import get_cfg_defaults
-from pandas import *
 
 import kale.utils.logger as logging
 from kale.embed.uncertainty_fitting import fit_and_predict
@@ -59,8 +58,8 @@ def main():
     # ---- setup dataset ----
     base_dir = cfg.DATASET.BASE_DIR
 
-    # download data if neccesary
-    if cfg.DATASET.SOURCE != None:
+    # download data if Dataset source is provided
+    if cfg.DATASET.SOURCE is not None:
         logger.info("Downloading data...")
         data_file_name = "%s.%s" % (base_dir, cfg.DATASET.FILE_FORMAT)
         download_file_by_url(
@@ -171,12 +170,12 @@ def main():
                         cmaps,
                         os.path.join(save_folder, "fitted_quantile_binning"),
                         save_file_preamble,
-                        cfg["PIPELINE"]["COMBINE_MIDDLE_BINS"],
-                        cfg["OUTPUT"]["SAVE_FIGURES"],
-                        cfg["DATASET"]["CONFIDENCE_INVERT"],
-                        cfg["BOXPLOT"]["SAMPLES_AS_DOTS"],
-                        cfg["BOXPLOT"]["SHOW_SAMPLE_INFO_MODE"],
-                        cfg["BOXPLOT"]["ERROR_LIM"],
+                        cfg.PIPELINE.COMBINE_MIDDLE_BINS,
+                        cfg.OUTPUT.SAVE_FIGURES,
+                        cfg.DATASET.CONFIDENCE_INVERT,
+                        cfg.BOXPLOT.SAMPLES_AS_DOTS,
+                        cfg.BOXPLOT.SHOW_SAMPLE_INFO_MODE,
+                        cfg.BOXPLOT.ERROR_LIM,
                         show_individual_landmark_plots,
                         interpret,
                         num_folds,
@@ -231,11 +230,11 @@ def main():
                                 all_fitted_save_paths,
                                 save_folder_comparison,
                                 save_file_preamble,
-                                cfg["PIPELINE"]["COMBINE_MIDDLE_BINS"],
-                                cfg["OUTPUT"]["SAVE_FIGURES"],
-                                cfg["BOXPLOT"]["SAMPLES_AS_DOTS"],
-                                cfg["BOXPLOT"]["SHOW_SAMPLE_INFO_MODE"],
-                                cfg["BOXPLOT"]["ERROR_LIM"],
+                                cfg.PIPELINE.COMBINE_MIDDLE_BINS,
+                                cfg.OUTPUT.SAVE_FIGURES,
+                                cfg.BOXPLOT.SAMPLES_AS_DOTS,
+                                cfg.BOXPLOT.SHOW_SAMPLE_INFO_MODE,
+                                cfg.BOXPLOT.ERROR_LIM,
                                 show_individual_landmark_plots,
                                 interpret,
                                 num_folds,

--- a/examples/landmark_uncertainty/main.py
+++ b/examples/landmark_uncertainty/main.py
@@ -26,8 +26,6 @@ from kale.embed.uncertainty_fitting import fit_and_predict
 from kale.interpret.uncertainty_quantiles import generate_fig_comparing_bins, generate_fig_individual_bin_comparison
 from kale.utils.download import download_file_by_url
 
-warnings.filterwarnings("error")
-
 
 def arg_parse():
     """Parsing arguments"""
@@ -124,10 +122,10 @@ def main():
                 for landmark in landmarks:
                     # Define Paths for this loop
                     landmark_results_path_val = os.path.join(
-                        cfg.DATASET.ROOT, base_dir, model, dataset, uncertainty_pairs_val + "_l" + str(landmark)
+                        cfg.DATASET.ROOT, base_dir, model, dataset, uncertainty_pairs_val + "_t" + str(landmark)
                     )
                     landmark_results_path_test = os.path.join(
-                        cfg.DATASET.ROOT, base_dir, model, dataset, uncertainty_pairs_test + "_l" + str(landmark)
+                        cfg.DATASET.ROOT, base_dir, model, dataset, uncertainty_pairs_test + "_t" + str(landmark)
                     )
 
                     fitted_save_at = os.path.join(save_folder, "fitted_quantile_binning", model, dataset)

--- a/kale/evaluate/similarity_metrics.py
+++ b/kale/evaluate/similarity_metrics.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 import pandas as pd
 
+from kale.interpret.correlation_analysis import fit_line_with_ci
 from kale.prepdata.tabular_transform import apply_confidence_inversion
 
 
@@ -94,7 +95,6 @@ def evaluate_correlations(
         The "all_folds" key contains the correlation statistics for all testing folds combined.
         The "quantiles" key contains the correlation statistics for each quantile bin separately.
     """
-    from kale.interpret.uncertainty_quantiles import fit_line_with_ci
 
     logger = logging.getLogger("qbin")
     # define dict to save correlations to.

--- a/kale/evaluate/similarity_metrics.py
+++ b/kale/evaluate/similarity_metrics.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 import pandas as pd
 
-from kale.interpret.correlation_analysis import fit_line_with_ci
+from kale.interpret.correlation_analysis import analyze_and_plot_uncertainty_correlation
 from kale.prepdata.tabular_transform import apply_confidence_inversion
 
 
@@ -40,9 +40,9 @@ def jaccard_similarity(list1: list, list2: list) -> float:
 def evaluate_correlations(
     bin_predictions: Dict[str, pd.DataFrame],
     uncertainty_error_pairs: List[Tuple[str, str, str]],
-    cmaps: List[Dict[Any, Any]],
     num_bins: int,
     confidence_invert_tuples: List[Tuple[str, bool]],
+    colormap: str = "Set1",
     num_folds: int = 8,
     error_scaling_factor: float = 1,
     combine_middle_bins: bool = False,
@@ -59,11 +59,11 @@ def evaluate_correlations(
         bin_predictions: A dictionary of Pandas DataFrames containing model predictions for each testing fold.
         uncertainty_error_pairs: A list of tuples specifying the names of the uncertainty,
             error, and uncertainty inversion keys for each pair.
-        cmaps: A dictionary of colour maps to use for plotting the results.
         num_bins: The number of quantile bins to divide the data into.
         confidence_invert_tuples: A list of tuples specifying whether to invert the uncertainty values for each method.
                           First element is a string specifying the uncertainty method name and the second element is
                           a boolean whether to invert e.g. [["E-MHA", True], ["E-CPV", False]]
+        colormap (str): Name of matplotlib colormap. Defaults to 'Set1'.
         num_folds: The number of folds to use for cross-validation (default: 8).
         error_scaling_factor: The scale factor to transform error by (default: 1).
         combine_middle_bins: Whether to combine the middle bins into one bin (default: False).
@@ -144,11 +144,10 @@ def evaluate_correlations(
                 if save_path
                 else None
             )
-            corr_dict = fit_line_with_ci(
+            corr_dict = analyze_and_plot_uncertainty_correlation(
                 fold_errors,
                 fold_uncertainty_values,
                 quantile_thresholds,
-                cmaps,
                 error_scaling_factor=error_scaling_factor,
                 save_path=save_path_fig,
                 to_log=to_log,

--- a/kale/interpret/correlation_analysis.py
+++ b/kale/interpret/correlation_analysis.py
@@ -28,13 +28,13 @@ def fit_line_with_ci(
         errors (np.ndarray): Array of errors.
         uncertainties (np.ndarray): Array of uncertainties.
         quantile_thresholds (List[float]): List of quantile thresholds.
-        cmaps (List[str]): List of colormap names.
+        cmaps (List[Dict[str, str]]): List of colormap dictionaries.
         to_log (bool, optional): Whether to apply logarithmic transformation on axes. Defaults to False.
         error_scaling_factor (float, optional): Scaling factor for error. Defaults to 1.0.
         save_path (Optional[str], optional): Path to save the plot, if None, the plot will be shown. Defaults to None.
 
     Returns:
-        Dict[str, Tuple[float, float]]: Dictionary containing Spearman and Pearson correlation coefficients and p-values.
+        Dict[str, List[Any]]: Dictionary containing Spearman and Pearson correlation coefficients and p-values.
     """
 
     plt.figure(figsize=(12, 8))
@@ -94,13 +94,13 @@ def fit_line_with_ci(
             min_ = quantile_thresholds[idx - 1]
             max_ = max(X)
 
-        plot_indicies = [i for i in range(len(xHat)) if min_ <= xHat[i] < max_]
+        plot_indices = [i for i in range(len(xHat)) if min_ <= xHat[i] < max_]
         bin_label_locs.append((min_ + max_) / 2)
-        quantile_data_indicies = [i for i in range(len(X)) if min_ <= X[i] < max_]
+        quantile_data_indices = [i for i in range(len(X)) if min_ <= X[i] < max_]
         # shade background to make slices per quantile
-        q_spm_corr, q_spm_p = stats.spearmanr(X[quantile_data_indicies], y[quantile_data_indicies])
-        plt.axvspan(xHat[plot_indicies][0], xHat[plot_indicies][-1], facecolor=color, alpha=0.1)
-        plt.plot(xHat[plot_indicies], yHat[plot_indicies], "-", color=color, zorder=3)
+        q_spm_corr, q_spm_p = stats.spearmanr(X[quantile_data_indices], y[quantile_data_indices])
+        plt.axvspan(xHat[plot_indices][0], xHat[plot_indices][-1], facecolor=color, alpha=0.1)
+        plt.plot(xHat[plot_indices], yHat[plot_indices], "-", color=color, zorder=3)
 
     ax.set_xticks(bin_label_locs)
     new_labels = [r"$Q_{{{}}}$".format(x + 1) for x in range(len(quantile_thresholds) + 1)]

--- a/kale/interpret/correlation_analysis.py
+++ b/kale/interpret/correlation_analysis.py
@@ -1,6 +1,10 @@
-"""
-Authors: Lawrence Schobs, Zhao Wenjie, Ji Zhongwei
+# =============================================================================
+# Author: JLawrence Schobs, lawrenceschobs@gmail.com
+#         Wenjie Zhao, 1534779821@qq.com
+#         Zhongwei Ji, jizhongwei1999@outlook.com
+# =============================================================================
 
+"""
 Module for correlation analysis between uncertainty and error in landmark localization.
 
 Functions related to uncertainty-error correlation analysis in terms of:
@@ -20,146 +24,96 @@ from scipy import stats
 from kale.interpret.visualize import save_or_show_plot
 
 
-def _calculate_correlations(uncertainties: np.ndarray, scaled_errors: np.ndarray) -> Dict[str, List[float]]:
-    """Calculate Spearman and Pearson correlations."""
-    smp_corr, smp_p = stats.spearmanr(uncertainties, scaled_errors, alternative="greater")
-    pear_corr, pear_p = stats.pearsonr(uncertainties, scaled_errors)
-    return {"spearman": [smp_corr, smp_p], "pearson": [pear_corr, pear_p]}
-
-
-def _fit_piecewise_model(
-    uncertainties: np.ndarray, scaled_errors: np.ndarray, quantile_thresholds: List[float]
-) -> pwlf.PiecewiseLinFit:
-    """Fit piecewise linear model to data."""
-    piecewise_model = pwlf.PiecewiseLinFit(uncertainties, scaled_errors)
-    piecewise_model.fit_with_breaks(quantile_thresholds)
-    return piecewise_model
-
-
-def _generate_bootstrap_models(
+def analyze_and_plot_uncertainty_correlation(
+    errors: np.ndarray,
     uncertainties: np.ndarray,
-    scaled_errors: np.ndarray,
     quantile_thresholds: List[float],
+    colormap: str = "Set1",
+    to_log: bool = False,
+    error_scaling_factor: float = 1.0,
+    save_path: Optional[str] = None,
     n_bootstrap: int = 1000,
     sample_ratio: float = 0.6,
-) -> List[pwlf.PiecewiseLinFit]:
-    """Generate bootstrap piecewise models for confidence intervals."""
-    bootstrap_models = []
-
-    for i in range(n_bootstrap):
-        sample_index = np.random.choice(range(len(scaled_errors)), int(len(scaled_errors) * sample_ratio))
-
-        uncertainties_samples = uncertainties[sample_index]
-        scaled_errors_samples = scaled_errors[sample_index]
-
-        bootstrap_model = _fit_piecewise_model(uncertainties_samples, scaled_errors_samples, quantile_thresholds)
-        bootstrap_models.append(bootstrap_model)
-
-    return bootstrap_models
-
-
-def _get_quantile_bounds(quantile_thresholds: List[float], uncertainties: np.ndarray, idx: int) -> tuple[float, float]:
-    """Get min and max bounds for a quantile segment."""
-    if idx == 0:
-        min_val = min(uncertainties)
-        max_val = quantile_thresholds[idx]
-    elif idx <= len(quantile_thresholds) - 1:
-        min_val = quantile_thresholds[idx - 1]
-        max_val = quantile_thresholds[idx]
-    else:
-        min_val = quantile_thresholds[idx - 1]
-        max_val = max(uncertainties)
-
-    return min_val, max_val
-
-
-def _calculate_segment_centers(quantile_thresholds: List[float], uncertainties: np.ndarray) -> List[float]:
-    """Calculate center positions for each quantile segment."""
-    bin_label_locs = []
-    for idx in range(len(quantile_thresholds) + 1):
-        min_val, max_val = _get_quantile_bounds(quantile_thresholds, uncertainties, idx)
-        bin_label_locs.append((min_val + max_val) / 2)
-    return bin_label_locs
-
-
-def _plot_bootstrap_confidence_bands(
-    ax, bootstrap_models: List[pwlf.PiecewiseLinFit], uncertainties: np.ndarray, num_pred_points: int = 10000
-) -> None:
-    """Plot bootstrap confidence bands."""
-    uncertainties_pred = np.linspace(min(uncertainties), max(uncertainties), num=num_pred_points)
-
-    for model in bootstrap_models:
-        scaled_errors_pred = model.predict(uncertainties_pred)
-        ax.plot(uncertainties_pred[::-1], scaled_errors_pred[::-1], "-", color="grey", alpha=0.2, zorder=2)
-
-
-def _plot_scatter_points(ax, uncertainties: np.ndarray, scaled_errors: np.ndarray, scatter_color: str) -> None:
-    """Plot scatter points of uncertainties vs errors."""
-    ax.scatter(uncertainties, scaled_errors, marker="o", color=scatter_color, zorder=1, alpha=0.2)
-
-
-def _plot_piecewise_segments(
-    ax,
-    piecewise_model: pwlf.PiecewiseLinFit,
-    uncertainties: np.ndarray,
-    quantile_thresholds: List[float],
-    colors: List[str],
-    num_pred_points: int = 20000,
-) -> None:
-    """Plot piecewise linear segments with different colors."""
-    uncertainties_pred = np.linspace(min(uncertainties), max(uncertainties), num=num_pred_points)
-    scaled_errors_pred = piecewise_model.predict(uncertainties_pred)
-
-    for idx in range(len(quantile_thresholds) + 1):
-        color = colors[idx % len(colors)]
-        min_val, max_val = _get_quantile_bounds(quantile_thresholds, uncertainties, idx)
-
-        plot_indices = [i for i in range(len(uncertainties_pred)) if min_val <= uncertainties_pred[i] < max_val]
-
-        # Shade background to make slices per quantile
-        ax.axvspan(
-            uncertainties_pred[plot_indices][0], uncertainties_pred[plot_indices][-1], facecolor=color, alpha=0.1
-        )
-        ax.plot(uncertainties_pred[plot_indices], scaled_errors_pred[plot_indices], "-", color=color, zorder=3)
-
-
-def _setup_plot_formatting(
-    ax,
-    bin_label_locs: List[float],
-    quantile_thresholds: List[float],
-    correlation_dict: Dict[str, List[float]],
     font_size: int = 25,
-) -> None:
-    """Setup plot formatting including labels, ticks, and correlation text."""
-    # Set x-axis ticks and labels
-    ax.set_xticks(bin_label_locs)
-    new_labels = [r"$Q_{{{}}}$".format(x + 1) for x in range(len(quantile_thresholds) + 1)]
-    ax.xaxis.set_major_formatter(plt.FixedFormatter(new_labels))
-    ax.yaxis.set_major_formatter(ScalarFormatter())
+    **fig_kwargs: Any,
+) -> Dict[str, List[Any]]:
+    """
+    Complete uncertainty-error correlation analysis with visualization.
 
-    # Add correlation text
-    smp_corr, smp_p = correlation_dict["spearman"]
-    p_val = 0.001 if np.round(smp_p, 3) == 0 else np.round(smp_p, 3)
-    bold_text = (
-        r"$\bf{\rho:} $" + r"$\bf{{{}}}$".format(np.round(smp_corr, 2)) + ", p-value < " + r"${{{}}}$".format(p_val)
+    This is the recommended entry point for most uncertainty analysis workflows
+    as it provides both numerical results and visual insights.
+
+    Args:
+        errors (np.ndarray): Array of prediction errors. Must have same length
+            as uncertainties array.
+        uncertainties (np.ndarray): Array of uncertainty estimates corresponding
+            to each prediction.
+        quantile_thresholds (List[float]): List of quantile threshold values that
+            define breakpoints for piecewise linear modeling. These determine
+            how the uncertainty range is segmented for analysis.
+        colormap (str, optional): Matplotlib colormap name for coloring different
+            quantile segments. Defaults to "Set1".
+        to_log (bool, optional): Whether to apply logarithmic scaling to both
+            axes of the plot. Useful for data spanning multiple orders of magnitude.
+            Defaults to False.
+        error_scaling_factor (float, optional): Multiplicative factor to scale
+            error values (e.g., for unit conversion from pixels to mm).
+            Defaults to 1.0.
+        save_path (Optional[str], optional): File path to save the generated plot.
+            If None, displays the plot interactively. Supports common formats
+            like PNG, PDF, SVG. Defaults to None.
+        n_bootstrap (int, optional): Number of bootstrap iterations for confidence
+            interval estimation. Higher values provide more robust estimates but
+            increase computation time. Defaults to 1000.
+        sample_ratio (float, optional): Fraction of data to sample in each bootstrap
+            iteration. Must be between 0 and 1. Lower values increase diversity
+            but may reduce stability. Defaults to 0.6.
+        font_size (int, optional): Font size for all text elements in the plot
+            including axis labels, correlation text, and quantile labels.
+            Defaults to 25.
+        **fig_kwargs: Additional keyword arguments for figure creation and styling:
+            - figsize (tuple): Figure size in inches (default: (16, 8))
+            - dpi (int): Resolution in dots per inch (default: 600)
+            - bottom (float): Bottom margin for subplot adjustment (default: 0.2)
+            - left (float): Left margin for subplot adjustment (default: 0.15)
+            - Any other matplotlib figure parameters
+
+    Returns:
+        Dict[str, List[Any]]: Dictionary containing correlation statistics with keys:
+            - 'spearman': [correlation_coefficient, p_value] for Spearman rank correlation
+            - 'pearson': [correlation_coefficient, p_value] for Pearson linear correlation
+
+    Raises:
+        ValueError: If input arrays have different lengths, are empty, or contain
+            invalid parameter values (e.g., sample_ratio not in (0,1])
+        KeyError: If required analysis components fail to generate expected results
+
+    Note:
+        - The function automatically validates inputs and provides informative error messages
+        - Bootstrap confidence bands provide visual uncertainty around the main fit
+        - Quantile-based analysis reveals how correlation varies across uncertainty ranges
+        - Both parametric (Pearson) and non-parametric (Spearman) correlations are computed
+        - The plot includes correlation statistics prominently displayed for quick assessment
+    """
+
+    # Analyze correlation
+    analysis_results = analyze_uncertainty_correlation(
+        errors, uncertainties, quantile_thresholds, error_scaling_factor, n_bootstrap, sample_ratio
     )
 
-    ax.text(
-        0.5,
-        0.9,
-        bold_text,
-        size=font_size,
-        color="black",
-        horizontalalignment="center",
-        verticalalignment="center",
-        transform=ax.transAxes,
+    # Plot results
+    plot_uncertainty_correlation(
+        uncertainties,
+        analysis_results,
+        quantile_thresholds,
+        colormap,
+        to_log,
+        save_path,
+        font_size=font_size,
+        **fig_kwargs,
     )
 
-    # Set axis labels and formatting
-    ax.set_xlabel("Uncertainty Quantile", fontsize=font_size)
-    ax.set_ylabel("Error (mm)", fontsize=font_size)
-    ax.tick_params(axis="x", labelsize=font_size)
-    ax.tick_params(axis="y", labelsize=font_size)
+    return analysis_results["correlations"]
 
 
 def analyze_uncertainty_correlation(
@@ -171,18 +125,30 @@ def analyze_uncertainty_correlation(
     sample_ratio: float = 0.6,
 ) -> Dict[str, Any]:
     """
-    Analyze correlation between errors and uncertainties.
+    Analyze correlation between prediction errors and uncertainty estimates.
 
     Args:
-        errors: Array of errors
-        uncertainties: Array of uncertainties
-        quantile_thresholds: List of quantile thresholds
-        error_scaling_factor: Scaling factor for errors
-        n_bootstrap: Number of bootstrap samples for confidence intervals
-        sample_ratio: Ratio of samples to use for each bootstrap sample
+        errors (np.ndarray): Array of prediction errors
+        uncertainties (np.ndarray): Array of uncertainty estimates
+        quantile_thresholds (List[float]): List of quantile threshold values
+            that define breakpoints for piecewise linear modeling
+        error_scaling_factor (float, optional): Multiplicative factor to scale
+            errors (e.g., for unit conversion). Defaults to 1.0.
+        n_bootstrap (int, optional): Number of bootstrap samples for confidence
+            interval estimation. Defaults to 1000.
+        sample_ratio (float, optional): Fraction of data to sample in each
+            bootstrap iteration. Must be between 0 and 1. Defaults to 0.6.
 
     Returns:
-        Dictionary containing correlation stats and fitted models
+        Dict[str, Any]: Dictionary containing analysis results with keys:
+            - 'correlations': Dict with Spearman and Pearson correlation results
+            - 'piecewise_model': Fitted piecewise linear model
+            - 'bootstrap_models': List of bootstrap piecewise models
+            - 'bin_label_locs': X-axis positions for quantile bin labels
+            - 'scaled_errors': Array of scaled error values used in analysis
+
+    Raises:
+        ValueError: If input arrays have different lengths or invalid parameters
     """
     # Input validation
     if len(errors) != len(uncertainties):
@@ -190,6 +156,8 @@ def analyze_uncertainty_correlation(
             f"Errors and uncertainties arrays must have the same length. "
             f"Got errors: {len(errors)}, uncertainties: {len(uncertainties)}"
         )
+    if len(errors) == 0 or len(uncertainties) == 0:
+        raise ValueError("Errors and uncertainties arrays cannot be empty.")
 
     # Scale errors
     scaled_errors = errors * error_scaling_factor
@@ -228,22 +196,32 @@ def plot_uncertainty_correlation(
     **fig_kwargs: Any,
 ) -> None:
     """
-    Plot uncertainty correlation analysis results.
+    Create a comprehensive visualization of uncertainty-error correlation analysis.
 
     Args:
-        uncertainties: Array of uncertainties
-        analysis_results: Results from analyze_uncertainty_correlation
-        quantile_thresholds: List of quantile thresholds
-        colormap: Name of matplotlib colormap
-        to_log: Whether to use log scale
-        save_path: Path to save plot
-        font_size: Font size for labels and titles
-        **fig_kwargs: Additional keyword arguments for figure creation. Supported parameters:
-            - figsize: tuple, figure size in inches (default: (16, 8))
-            - dpi: int, dots per inch (default: 600)
-            - bottom: float, bottom margin for subplots_adjust (default: 0.2)
-            - left: float, left margin for subplots_adjust (default: 0.15)
+        uncertainties (np.ndarray): Array of uncertainty estimates
+        analysis_results (Dict[str, Any]): Results from analyze_uncertainty_correlation
+        quantile_thresholds (List[float]): Quantile threshold values for segmentation
+        colormap (str, optional): Matplotlib colormap name for segment coloring.
+            Defaults to "Set1".
+        to_log (bool, optional): Whether to use logarithmic scale for both axes.
+            Defaults to False.
+        save_path (Optional[str], optional): File path to save the plot. If None,
+            displays the plot interactively. Defaults to None.
+        font_size (int, optional): Font size for all text elements. Defaults to 25.
+        **fig_kwargs: Additional keyword arguments for figure creation and styling:
+            - figsize (tuple): Figure size in inches (default: (16, 8))
+            - dpi (int): Dots per inch for resolution (default: 600)
+            - bottom (float): Bottom margin for subplots_adjust (default: 0.2)
+            - left (float): Left margin for subplots_adjust (default: 0.15)
             - Any other matplotlib figure parameters
+
+    Returns:
+        None: Creates and displays or saves the plot
+
+    Raises:
+        ValueError: If input parameters are invalid
+        KeyError: If analysis_results is missing required keys
     """
     # Extract figure-specific kwargs with defaults
     figsize = fig_kwargs.pop("figsize", (16, 8))
@@ -285,68 +263,321 @@ def plot_uncertainty_correlation(
     save_or_show_plot(save_path=save_path, fig_width=figsize[0], fig_height=figsize[1], dpi=dpi)
 
 
-def analyze_and_plot_uncertainty_correlation(
-    errors: np.ndarray,
-    uncertainties: np.ndarray,
-    quantile_thresholds: List[float],
-    colormap: str = "Set1",
-    to_log: bool = False,
-    error_scaling_factor: float = 1.0,
-    save_path: Optional[str] = None,
-    n_bootstrap: int = 1000,
-    sample_ratio: float = 0.6,
-    font_size: int = 25,
-    **fig_kwargs: Any,
-) -> Dict[str, List[Any]]:
+def _calculate_correlations(uncertainties: np.ndarray, scaled_errors: np.ndarray) -> Dict[str, List[float]]:
     """
-    Calculates Spearman correlation between errors and uncertainties.
-    Plots piecewise linear regression with bootstrap confidence intervals.
+    Calculate Spearman and Pearson correlations between uncertainties and errors.
 
-    This is a convenience function that combines analysis and plotting.
+    This function computes both Spearman rank correlation (non-parametric) and
+    Pearson correlation (parametric) to assess the relationship between uncertainty
+    estimates and prediction errors.
 
     Args:
-        errors (np.ndarray): Array of errors.
-        uncertainties (np.ndarray): Array of uncertainties.
-        quantile_thresholds (List[float]): List of quantile thresholds.
-        colormap (str): Name of matplotlib colormap. Defaults to 'Set1'.
-        to_log (bool, optional): Whether to apply logarithmic transformation on axes. Defaults to False.
-        error_scaling_factor (float, optional): Scaling factor for error. Defaults to 1.0.
-        save_path (Optional[str], optional): Path to save the plot, if None, the plot will be shown. Defaults to None.
-        n_bootstrap (int, optional): Number of bootstrap samples for confidence intervals. Defaults to 1000.
-        sample_ratio (float, optional): Ratio of samples to use for each bootstrap sample. Defaults to 0.6.
-        font_size (int, optional): Font size for plot labels and titles. Defaults to 25.
-        **fig_kwargs: Additional keyword arguments for figure creation. Supported parameters:
-            - figsize: tuple, figure size in inches (default: (12, 8))
-            - dpi: int, dots per inch (default: 600)
-            - bottom: float, bottom margin for subplots_adjust (default: 0.2)
-            - left: float, left margin for subplots_adjust (default: 0.15)
-            - Any other matplotlib figure parameters
+        uncertainties (np.ndarray): Array of uncertainty values
+        scaled_errors (np.ndarray): Array of scaled error values
 
     Returns:
-        Dict[str, List[Any]]: Dictionary containing Spearman and Pearson correlation coefficients and p-values.
+        Dict[str, List[float]]: Dictionary containing correlation results with keys:
+            - 'spearman': [correlation_coefficient, p_value] for Spearman correlation
+            - 'pearson': [correlation_coefficient, p_value] for Pearson correlation
     """
-    # Input validation
-    if len(errors) != len(uncertainties):
-        raise ValueError(
-            f"Errors and uncertainties arrays must have the same length. "
-            f"Got errors: {len(errors)}, uncertainties: {len(uncertainties)}"
+    smp_corr, smp_p = stats.spearmanr(uncertainties, scaled_errors, alternative="greater")
+    pear_corr, pear_p = stats.pearsonr(uncertainties, scaled_errors)
+    return {"spearman": [smp_corr, smp_p], "pearson": [pear_corr, pear_p]}
+
+
+def _fit_piecewise_model(
+    uncertainties: np.ndarray, scaled_errors: np.ndarray, quantile_thresholds: List[float]
+) -> pwlf.PiecewiseLinFit:
+    """
+    Fit a piecewise linear model to uncertainty-error data using specified breakpoints.
+
+    This function creates and fits a piecewise linear regression model that can capture
+    non-linear relationships between uncertainties and errors by fitting different
+    linear segments at different uncertainty ranges.
+
+    Args:
+        uncertainties (np.ndarray): Array of uncertainty values (independent variable)
+        scaled_errors (np.ndarray): Array of scaled error values (dependent variable)
+        quantile_thresholds (List[float]): List of quantile threshold values that serve
+            as breakpoints for the piecewise linear model
+
+    Returns:
+        pwlf.PiecewiseLinFit: Fitted piecewise linear model object that can be used
+            for predictions and plotting
+    """
+    piecewise_model = pwlf.PiecewiseLinFit(uncertainties, scaled_errors)
+    piecewise_model.fit_with_breaks(quantile_thresholds)
+    return piecewise_model
+
+
+def _generate_bootstrap_models(
+    uncertainties: np.ndarray,
+    scaled_errors: np.ndarray,
+    quantile_thresholds: List[float],
+    n_bootstrap: int = 1000,
+    sample_ratio: float = 0.6,
+) -> List[pwlf.PiecewiseLinFit]:
+    """
+    Generate bootstrap piecewise models for confidence interval estimation.
+
+    This function creates multiple piecewise linear models using bootstrap sampling
+    to estimate confidence intervals around the main piecewise fit. Each bootstrap
+    model is fitted on a random subset of the original data.
+
+    Args:
+        uncertainties (np.ndarray): Array of uncertainty values
+        scaled_errors (np.ndarray): Array of scaled error values
+        quantile_thresholds (List[float]): Quantile threshold breakpoints for piecewise fitting
+        n_bootstrap (int, optional): Number of bootstrap samples to generate. Defaults to 1000.
+        sample_ratio (float, optional): Fraction of data to sample for each bootstrap.
+            Must be between 0 and 1. Defaults to 0.6.
+
+    Returns:
+        List[pwlf.PiecewiseLinFit]: List of fitted bootstrap piecewise models
+
+    Note:
+        Each bootstrap model is fitted on a random sample of size
+        int(len(data) * sample_ratio) drawn without replacement from the original data.
+    """
+    bootstrap_models = []
+
+    for i in range(n_bootstrap):
+        sample_index = np.random.choice(range(len(scaled_errors)), int(len(scaled_errors) * sample_ratio))
+
+        uncertainties_samples = uncertainties[sample_index]
+        scaled_errors_samples = scaled_errors[sample_index]
+
+        bootstrap_model = _fit_piecewise_model(uncertainties_samples, scaled_errors_samples, quantile_thresholds)
+        bootstrap_models.append(bootstrap_model)
+
+    return bootstrap_models
+
+
+def _get_quantile_bounds(quantile_thresholds: List[float], uncertainties: np.ndarray, idx: int) -> tuple[float, float]:
+    """
+    Get minimum and maximum bounds for a specific quantile segment.
+
+    This function determines the boundary values for a quantile segment based on
+    the segment index and the list of quantile thresholds. It handles edge cases
+    for the first and last segments.
+
+    Args:
+        quantile_thresholds (List[float]): List of quantile threshold values that
+            define segment boundaries
+        uncertainties (np.ndarray): Array of uncertainty values used to determine
+            global min/max bounds
+        idx (int): Index of the quantile segment (0-based)
+
+    Returns:
+        tuple[float, float]: Tuple containing (min_value, max_value) for the segment
+
+    Note:
+        - For idx=0 (first segment): min_val = min(uncertainties), max_val = first threshold
+        - For middle segments: min_val = previous threshold, max_val = current threshold
+        - For last segment: min_val = last threshold, max_val = max(uncertainties)
+    """
+    if idx == 0:
+        min_val = min(uncertainties)
+        max_val = quantile_thresholds[idx]
+    elif idx <= len(quantile_thresholds) - 1:
+        min_val = quantile_thresholds[idx - 1]
+        max_val = quantile_thresholds[idx]
+    else:
+        min_val = quantile_thresholds[idx - 1]
+        max_val = max(uncertainties)
+
+    return min_val, max_val
+
+
+def _calculate_segment_centers(quantile_thresholds: List[float], uncertainties: np.ndarray) -> List[float]:
+    """
+    Calculate center positions for each quantile segment for label placement.
+
+    This function computes the midpoint of each quantile segment, which is used
+    for positioning x-axis labels in plots. The center is calculated as the
+    arithmetic mean of the segment's minimum and maximum bounds.
+
+    Args:
+        quantile_thresholds (List[float]): List of quantile threshold values
+        uncertainties (np.ndarray): Array of uncertainty values for determining bounds
+
+    Returns:
+        List[float]: List of center positions for each quantile segment
+
+    Note:
+        The number of segments is len(quantile_thresholds) + 1, as thresholds
+        define boundaries between segments.
+    """
+    bin_label_locs = []
+    for idx in range(len(quantile_thresholds) + 1):
+        min_val, max_val = _get_quantile_bounds(quantile_thresholds, uncertainties, idx)
+        bin_label_locs.append((min_val + max_val) / 2)
+    return bin_label_locs
+
+
+def _plot_bootstrap_confidence_bands(
+    ax, bootstrap_models: List[pwlf.PiecewiseLinFit], uncertainties: np.ndarray, num_pred_points: int = 10000
+) -> None:
+    """
+    Plot bootstrap confidence bands on the given axes.
+
+    This function visualizes uncertainty in the piecewise linear fit by plotting
+    prediction lines from multiple bootstrap models. The ensemble of lines creates
+    a confidence band around the main fit.
+
+    Args:
+        ax: Matplotlib axes object to plot on
+        bootstrap_models (List[pwlf.PiecewiseLinFit]): List of fitted bootstrap models
+        uncertainties (np.ndarray): Array of uncertainty values for determining plot range
+        num_pred_points (int, optional): Number of prediction points for smooth curves.
+            Defaults to 10000.
+
+    Returns:
+        None: Plots directly on the provided axes
+
+    Note:
+        - Each bootstrap model is plotted as a grey line with low alpha (0.2)
+        - Lines are plotted in reverse order ([::-1]) for proper visualization
+        - Uses zorder=2 to place confidence bands behind main elements
+    """
+    uncertainties_pred = np.linspace(min(uncertainties), max(uncertainties), num=num_pred_points)
+
+    for model in bootstrap_models:
+        scaled_errors_pred = model.predict(uncertainties_pred)
+        ax.plot(uncertainties_pred[::-1], scaled_errors_pred[::-1], "-", color="grey", alpha=0.2, zorder=2)
+
+
+def _plot_scatter_points(ax, uncertainties: np.ndarray, scaled_errors: np.ndarray, scatter_color: str) -> None:
+    """
+    Plot scatter points of uncertainties vs errors on the given axes.
+
+    This function creates a scatter plot showing the relationship between uncertainty
+    estimates and scaled errors. Each point represents one data sample.
+
+    Args:
+        ax: Matplotlib axes object to plot on
+        uncertainties (np.ndarray): Array of uncertainty values (x-axis)
+        scaled_errors (np.ndarray): Array of scaled error values (y-axis)
+        scatter_color (str): Color for the scatter points
+
+    Returns:
+        None: Plots directly on the provided axes
+
+    Note:
+        - Uses circular markers ('o') with low alpha (0.2) for transparency
+        - Points are placed at zorder=1 to appear behind other plot elements
+        - Alpha blending helps visualize point density in overlapping regions
+    """
+    ax.scatter(uncertainties, scaled_errors, marker="o", color=scatter_color, zorder=1, alpha=0.2)
+
+
+def _plot_piecewise_segments(
+    ax,
+    piecewise_model: pwlf.PiecewiseLinFit,
+    uncertainties: np.ndarray,
+    quantile_thresholds: List[float],
+    colors: List[str],
+    num_pred_points: int = 20000,
+) -> None:
+    """
+    Plot piecewise linear segments with different colors and background shading.
+
+    This function visualizes the fitted piecewise linear model by plotting each
+    segment in a different color and adding background shading to distinguish
+    quantile regions.
+
+    Args:
+        ax: Matplotlib axes object to plot on
+        piecewise_model (pwlf.PiecewiseLinFit): Fitted piecewise linear model
+        uncertainties (np.ndarray): Array of uncertainty values for range determination
+        quantile_thresholds (List[float]): Quantile thresholds defining segment boundaries
+        colors (List[str]): List of colors for different segments (cycles if needed)
+        num_pred_points (int, optional): Number of prediction points for smooth curves.
+            Defaults to 20000.
+
+    Returns:
+        None: Plots directly on the provided axes
+
+    Note:
+        - Each segment gets a different color from the colors list (cycles using modulo)
+        - Background shading (axvspan) with alpha=0.1 highlights quantile regions
+        - Piecewise lines use zorder=3 to appear on top of other elements
+        - High num_pred_points ensures smooth curve appearance
+    """
+    uncertainties_pred = np.linspace(min(uncertainties), max(uncertainties), num=num_pred_points)
+    scaled_errors_pred = piecewise_model.predict(uncertainties_pred)
+
+    for idx in range(len(quantile_thresholds) + 1):
+        color = colors[idx % len(colors)]
+        min_val, max_val = _get_quantile_bounds(quantile_thresholds, uncertainties, idx)
+
+        plot_indices = [i for i in range(len(uncertainties_pred)) if min_val <= uncertainties_pred[i] < max_val]
+
+        # Shade background to make slices per quantile
+        ax.axvspan(
+            uncertainties_pred[plot_indices][0], uncertainties_pred[plot_indices][-1], facecolor=color, alpha=0.1
         )
+        ax.plot(uncertainties_pred[plot_indices], scaled_errors_pred[plot_indices], "-", color=color, zorder=3)
 
-    # Analyze correlation
-    analysis_results = analyze_uncertainty_correlation(
-        errors, uncertainties, quantile_thresholds, error_scaling_factor, n_bootstrap, sample_ratio
+
+def _setup_plot_formatting(
+    ax,
+    bin_label_locs: List[float],
+    quantile_thresholds: List[float],
+    correlation_dict: Dict[str, List[float]],
+    font_size: int = 25,
+) -> None:
+    """
+    Setup comprehensive plot formatting including labels, ticks, and correlation text.
+
+    This function handles all aspects of plot formatting including axis labels,
+    tick formatting, correlation coefficient display, and overall plot styling.
+    It creates a publication-ready visualization of the uncertainty-error correlation.
+
+    Args:
+        ax: Matplotlib axes object to format
+        bin_label_locs (List[float]): X-axis positions for quantile bin labels
+        quantile_thresholds (List[float]): Quantile thresholds for determining label count
+        correlation_dict (Dict[str, List[float]]): Dictionary containing correlation results
+            with 'spearman' key containing [correlation, p_value]
+        font_size (int, optional): Font size for labels and text. Defaults to 25.
+
+    Returns:
+        None: Modifies the provided axes object in-place
+
+    Note:
+        - X-axis labels are formatted as Q_1, Q_2, ..., Q_n using LaTeX notation
+        - Correlation coefficient (ρ) and p-value are displayed prominently
+        - P-values < 0.001 are shown as "< 0.001" for readability
+        - Uses bold formatting for correlation statistics
+        - Axis labels indicate uncertainty quantiles and error in mm
+    """
+    # Set x-axis ticks and labels
+    ax.set_xticks(bin_label_locs)
+    new_labels = [r"$Q_{{{}}}$".format(x + 1) for x in range(len(quantile_thresholds) + 1)]
+    ax.xaxis.set_major_formatter(plt.FixedFormatter(new_labels))
+    ax.yaxis.set_major_formatter(ScalarFormatter())
+
+    # Add correlation text
+    smp_corr, smp_p = correlation_dict["spearman"]
+    p_val = 0.001 if np.round(smp_p, 3) == 0 else np.round(smp_p, 3)
+    bold_text = (
+        r"$\bf{\rho:} $" + r"$\bf{{{}}}$".format(np.round(smp_corr, 2)) + ", p-value < " + r"${{{}}}$".format(p_val)
     )
 
-    # Plot results
-    plot_uncertainty_correlation(
-        uncertainties,
-        analysis_results,
-        quantile_thresholds,
-        colormap,
-        to_log,
-        save_path,
-        font_size=font_size,
-        **fig_kwargs,
+    ax.text(
+        0.5,
+        0.9,
+        bold_text,
+        size=font_size,
+        color="black",
+        horizontalalignment="center",
+        verticalalignment="center",
+        transform=ax.transAxes,
     )
 
-    return analysis_results["correlations"]
+    # Set axis labels and formatting
+    ax.set_xlabel("Uncertainty Quantile", fontsize=font_size)
+    ax.set_ylabel("Error (mm)", fontsize=font_size)
+    ax.tick_params(axis="x", labelsize=font_size)
+    ax.tick_params(axis="y", labelsize=font_size)

--- a/kale/interpret/correlation_analysis.py
+++ b/kale/interpret/correlation_analysis.py
@@ -1,144 +1,352 @@
 """
-Correlation of uncertainty with error (fit_line_with_ci)
+Authors: Lawrence Schobs, Zhao Wenjie, Ji Zhongwei
+
+Module for correlation analysis between uncertainty and error in landmark localization.
+
+Functions related to uncertainty-error correlation analysis in terms of:
+   A) Calculate correlations: analyze_uncertainty_correlation
+   B) Plotting: plot_uncertainty_correlation
+   C) Main analysis functions: analyze_and_plot_uncertainty_correlation
 """
 from typing import Any, Dict, List, Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
 import pwlf
+from matplotlib import colormaps
 from matplotlib.ticker import ScalarFormatter
 from scipy import stats
 
+from kale.interpret.visualize import save_or_show_plot
 
-def fit_line_with_ci(
-    errors: np.ndarray,
+
+def _calculate_correlations(uncertainties: np.ndarray, scaled_errors: np.ndarray) -> Dict[str, List[float]]:
+    """Calculate Spearman and Pearson correlations."""
+    smp_corr, smp_p = stats.spearmanr(uncertainties, scaled_errors, alternative="greater")
+    pear_corr, pear_p = stats.pearsonr(uncertainties, scaled_errors)
+    return {"spearman": [smp_corr, smp_p], "pearson": [pear_corr, pear_p]}
+
+
+def _fit_piecewise_model(
+    uncertainties: np.ndarray, scaled_errors: np.ndarray, quantile_thresholds: List[float]
+) -> pwlf.PiecewiseLinFit:
+    """Fit piecewise linear model to data."""
+    piecewise_model = pwlf.PiecewiseLinFit(uncertainties, scaled_errors)
+    piecewise_model.fit_with_breaks(quantile_thresholds)
+    return piecewise_model
+
+
+def _generate_bootstrap_models(
     uncertainties: np.ndarray,
+    scaled_errors: np.ndarray,
     quantile_thresholds: List[float],
-    cmaps: List[Dict[str, str]],
-    to_log: bool = False,
-    error_scaling_factor: float = 1.0,
-    save_path: Optional[str] = None,
-) -> Dict[str, List[Any]]:
-    """
-    Calculates Spearman correlation between errors and uncertainties.
-    Plots piecewise linear regression with bootstrap confidence intervals.
-    Breakpoints in linear regression are defined by the uncertainty quantiles of the data.
+    n_bootstrap: int = 1000,
+    sample_ratio: float = 0.6,
+) -> List[pwlf.PiecewiseLinFit]:
+    """Generate bootstrap piecewise models for confidence intervals."""
+    bootstrap_models = []
 
-    Args:
-        errors (np.ndarray): Array of errors.
-        uncertainties (np.ndarray): Array of uncertainties.
-        quantile_thresholds (List[float]): List of quantile thresholds.
-        cmaps (List[Dict[str, str]]): List of colormap dictionaries.
-        to_log (bool, optional): Whether to apply logarithmic transformation on axes. Defaults to False.
-        error_scaling_factor (float, optional): Scaling factor for error. Defaults to 1.0.
-        save_path (Optional[str], optional): Path to save the plot, if None, the plot will be shown. Defaults to None.
+    for i in range(n_bootstrap):
+        sample_index = np.random.choice(range(len(scaled_errors)), int(len(scaled_errors) * sample_ratio))
 
-    Returns:
-        Dict[str, List[Any]]: Dictionary containing Spearman and Pearson correlation coefficients and p-values.
-    """
+        uncertainties_samples = uncertainties[sample_index]
+        scaled_errors_samples = scaled_errors[sample_index]
 
-    plt.figure(figsize=(12, 8))
-    ax = plt.gca()
+        bootstrap_model = _fit_piecewise_model(uncertainties_samples, scaled_errors_samples, quantile_thresholds)
+        bootstrap_models.append(bootstrap_model)
 
-    if to_log:
-        plt.xscale("log", base=2)
-        plt.yscale("log", base=2)
+    return bootstrap_models
 
-    X = uncertainties
-    y = errors * error_scaling_factor
-    plt.xlim(max(X), min(X))
 
-    # Calculate correlations
-    spm_corr, spm_p = stats.spearmanr(X, y, alternative="greater")
-    pear_corr, pear__p = stats.pearsonr(X, y)
-    correlation_dict = {"spearman": [spm_corr, spm_p], "pearson": [pear_corr, pear__p]}
+def _get_quantile_bounds(quantile_thresholds: List[float], uncertainties: np.ndarray, idx: int) -> tuple[float, float]:
+    """Get min and max bounds for a quantile segment."""
+    if idx == 0:
+        min_val = min(uncertainties)
+        max_val = quantile_thresholds[idx]
+    elif idx <= len(quantile_thresholds) - 1:
+        min_val = quantile_thresholds[idx - 1]
+        max_val = quantile_thresholds[idx]
+    else:
+        min_val = quantile_thresholds[idx - 1]
+        max_val = max(uncertainties)
 
-    # Bootstrap sample for confidence intervals
-    for i in range(0, 1000):
-        sample_index = np.random.choice(range(0, len(y)), int(len(y) * 0.6))
+    return min_val, max_val
 
-        X_samples = X[sample_index]
-        y_samples = y[sample_index]
-        my_pwlf = pwlf.PiecewiseLinFit(X_samples, y_samples)
-        my_pwlf.fit_with_breaks(quantile_thresholds)
-        xHat = np.linspace(min(X), max(X), num=10000)
-        yHat = my_pwlf.predict(xHat)
 
-        # Plot each bootstrap as a grey line
-        plt.plot(xHat[::-1], yHat[::-1], "-", color="grey", alpha=0.2, zorder=2)
-
-    # Display all datapoints on plot
-    plt.scatter(X, y, marker="o", color=cmaps[2], zorder=1, alpha=0.2)
-
-    # Final fit on ALL the data
-    my_pwlf = pwlf.PiecewiseLinFit(X, y)
-
-    # Manually set the piecewise breaks as the quantile thresholds.
-    my_pwlf.fit_with_breaks(quantile_thresholds)
-
-    # Plot the final fitted line, changing the color of the line segments for each quantile for visualisation.
+def _calculate_segment_centers(quantile_thresholds: List[float], uncertainties: np.ndarray) -> List[float]:
+    """Calculate center positions for each quantile segment."""
     bin_label_locs = []
     for idx in range(len(quantile_thresholds) + 1):
-        color = "blue" if idx % 2 == 0 else "red"
-        xHat = np.linspace(min(X), max(X), num=20000)
-        yHat = my_pwlf.predict(xHat)
+        min_val, max_val = _get_quantile_bounds(quantile_thresholds, uncertainties, idx)
+        bin_label_locs.append((min_val + max_val) / 2)
+    return bin_label_locs
 
-        if idx == 0:
-            min_ = min(X)
-            max_ = quantile_thresholds[idx]
 
-        elif idx <= len(quantile_thresholds) - 1:
-            min_ = quantile_thresholds[idx - 1]
-            max_ = quantile_thresholds[idx]
-        else:
-            min_ = quantile_thresholds[idx - 1]
-            max_ = max(X)
+def _plot_bootstrap_confidence_bands(
+    ax, bootstrap_models: List[pwlf.PiecewiseLinFit], uncertainties: np.ndarray, num_pred_points: int = 10000
+) -> None:
+    """Plot bootstrap confidence bands."""
+    uncertainties_pred = np.linspace(min(uncertainties), max(uncertainties), num=num_pred_points)
 
-        plot_indices = [i for i in range(len(xHat)) if min_ <= xHat[i] < max_]
-        bin_label_locs.append((min_ + max_) / 2)
-        quantile_data_indices = [i for i in range(len(X)) if min_ <= X[i] < max_]
-        # shade background to make slices per quantile
-        q_spm_corr, q_spm_p = stats.spearmanr(X[quantile_data_indices], y[quantile_data_indices])
-        plt.axvspan(xHat[plot_indices][0], xHat[plot_indices][-1], facecolor=color, alpha=0.1)
-        plt.plot(xHat[plot_indices], yHat[plot_indices], "-", color=color, zorder=3)
+    for model in bootstrap_models:
+        scaled_errors_pred = model.predict(uncertainties_pred)
+        ax.plot(uncertainties_pred[::-1], scaled_errors_pred[::-1], "-", color="grey", alpha=0.2, zorder=2)
 
+
+def _plot_scatter_points(ax, uncertainties: np.ndarray, scaled_errors: np.ndarray, scatter_color: str) -> None:
+    """Plot scatter points of uncertainties vs errors."""
+    ax.scatter(uncertainties, scaled_errors, marker="o", color=scatter_color, zorder=1, alpha=0.2)
+
+
+def _plot_piecewise_segments(
+    ax,
+    piecewise_model: pwlf.PiecewiseLinFit,
+    uncertainties: np.ndarray,
+    quantile_thresholds: List[float],
+    colors: List[str],
+    num_pred_points: int = 20000,
+) -> None:
+    """Plot piecewise linear segments with different colors."""
+    uncertainties_pred = np.linspace(min(uncertainties), max(uncertainties), num=num_pred_points)
+    scaled_errors_pred = piecewise_model.predict(uncertainties_pred)
+
+    for idx in range(len(quantile_thresholds) + 1):
+        color = colors[idx % len(colors)]
+        min_val, max_val = _get_quantile_bounds(quantile_thresholds, uncertainties, idx)
+
+        plot_indices = [i for i in range(len(uncertainties_pred)) if min_val <= uncertainties_pred[i] < max_val]
+
+        # Shade background to make slices per quantile
+        ax.axvspan(
+            uncertainties_pred[plot_indices][0], uncertainties_pred[plot_indices][-1], facecolor=color, alpha=0.1
+        )
+        ax.plot(uncertainties_pred[plot_indices], scaled_errors_pred[plot_indices], "-", color=color, zorder=3)
+
+
+def _setup_plot_formatting(
+    ax,
+    bin_label_locs: List[float],
+    quantile_thresholds: List[float],
+    correlation_dict: Dict[str, List[float]],
+    font_size: int = 25,
+) -> None:
+    """Setup plot formatting including labels, ticks, and correlation text."""
+    # Set x-axis ticks and labels
     ax.set_xticks(bin_label_locs)
     new_labels = [r"$Q_{{{}}}$".format(x + 1) for x in range(len(quantile_thresholds) + 1)]
     ax.xaxis.set_major_formatter(plt.FixedFormatter(new_labels))
     ax.yaxis.set_major_formatter(ScalarFormatter())
 
-    # Put text on plot showing the correlation
-    p_vl = 0.001 if np.round(spm_p, 3) == 0 else np.round(spm_p, 3)
+    # Add correlation text
+    smp_corr, smp_p = correlation_dict["spearman"]
+    p_val = 0.001 if np.round(smp_p, 3) == 0 else np.round(smp_p, 3)
     bold_text = (
-        r"$\bf{\rho:} $" + r"$\bf{{{}}}$".format(np.round(spm_corr, 2)) + ", p-value < " + r"${{{}}}$".format(p_vl)
+        r"$\bf{\rho:} $" + r"$\bf{{{}}}$".format(np.round(smp_corr, 2)) + ", p-value < " + r"${{{}}}$".format(p_val)
     )
 
-    plt.text(
+    ax.text(
         0.5,
         0.9,
         bold_text,
-        size=25,
+        size=font_size,
         color="black",
         horizontalalignment="center",
         verticalalignment="center",
         transform=ax.transAxes,
     )
-    ax.set_xlabel("Uncertainty Quantile", fontsize=25)
-    ax.set_ylabel("Error (mm)", fontsize=25)
-    plt.subplots_adjust(bottom=0.2)
-    plt.subplots_adjust(left=0.15)
 
-    plt.xticks(fontsize=25)
-    plt.yticks(fontsize=25)
+    # Set axis labels and formatting
+    ax.set_xlabel("Uncertainty Quantile", fontsize=font_size)
+    ax.set_ylabel("Error (mm)", fontsize=font_size)
+    ax.tick_params(axis="x", labelsize=font_size)
+    ax.tick_params(axis="y", labelsize=font_size)
 
-    if save_path is not None:
-        plt.gcf().set_size_inches(16.0, 8.0)
-        plt.tight_layout()
-        plt.savefig(save_path, dpi=600, bbox_inches="tight", pad_inches=0.1)
-        plt.close()
-    else:
-        plt.gcf().set_size_inches(16.0, 10.0)
-        plt.show()
-        plt.close()
 
-    return correlation_dict
+def analyze_uncertainty_correlation(
+    errors: np.ndarray,
+    uncertainties: np.ndarray,
+    quantile_thresholds: List[float],
+    error_scaling_factor: float = 1.0,
+    n_bootstrap: int = 1000,
+    sample_ratio: float = 0.6,
+) -> Dict[str, Any]:
+    """
+    Analyze correlation between errors and uncertainties.
+
+    Args:
+        errors: Array of errors
+        uncertainties: Array of uncertainties
+        quantile_thresholds: List of quantile thresholds
+        error_scaling_factor: Scaling factor for errors
+        n_bootstrap: Number of bootstrap samples for confidence intervals
+        sample_ratio: Ratio of samples to use for each bootstrap sample
+
+    Returns:
+        Dictionary containing correlation stats and fitted models
+    """
+    # Input validation
+    if len(errors) != len(uncertainties):
+        raise ValueError(
+            f"Errors and uncertainties arrays must have the same length. "
+            f"Got errors: {len(errors)}, uncertainties: {len(uncertainties)}"
+        )
+
+    # Scale errors
+    scaled_errors = errors * error_scaling_factor
+
+    # Calculate correlations
+    correlation_dict = _calculate_correlations(uncertainties, scaled_errors)
+
+    # Fit main piecewise model
+    piecewise_model = _fit_piecewise_model(uncertainties, scaled_errors, quantile_thresholds)
+
+    # Generate bootstrap models
+    bootstrap_models = _generate_bootstrap_models(
+        uncertainties, scaled_errors, quantile_thresholds, n_bootstrap, sample_ratio
+    )
+
+    # Calculate segment centers
+    bin_label_locs = _calculate_segment_centers(quantile_thresholds, uncertainties)
+
+    return {
+        "correlations": correlation_dict,
+        "piecewise_model": piecewise_model,
+        "bootstrap_models": bootstrap_models,
+        "bin_label_locs": bin_label_locs,
+        "scaled_errors": scaled_errors,
+    }
+
+
+def plot_uncertainty_correlation(
+    uncertainties: np.ndarray,
+    analysis_results: Dict[str, Any],
+    quantile_thresholds: List[float],
+    colormap: str = "Set1",
+    to_log: bool = False,
+    save_path: Optional[str] = None,
+    font_size: int = 25,
+    **fig_kwargs: Any,
+) -> None:
+    """
+    Plot uncertainty correlation analysis results.
+
+    Args:
+        uncertainties: Array of uncertainties
+        analysis_results: Results from analyze_uncertainty_correlation
+        quantile_thresholds: List of quantile thresholds
+        colormap: Name of matplotlib colormap
+        to_log: Whether to use log scale
+        save_path: Path to save plot
+        font_size: Font size for labels and titles
+        **fig_kwargs: Additional keyword arguments for figure creation. Supported parameters:
+            - figsize: tuple, figure size in inches (default: (16, 8))
+            - dpi: int, dots per inch (default: 600)
+            - bottom: float, bottom margin for subplots_adjust (default: 0.2)
+            - left: float, left margin for subplots_adjust (default: 0.15)
+            - Any other matplotlib figure parameters
+    """
+    # Extract figure-specific kwargs with defaults
+    figsize = fig_kwargs.pop("figsize", (16, 8))
+    dpi = fig_kwargs.pop("dpi", 600)
+    bottom = fig_kwargs.pop("bottom", 0.2)
+    left = fig_kwargs.pop("left", 0.15)
+
+    # Initialize plot
+    fig, ax = plt.subplots(figsize=figsize, dpi=dpi, **fig_kwargs)
+
+    # Handle color configuration
+    colors = colormaps.get_cmap(colormap)(np.arange(3))
+    scatter_color = colors[2]
+
+    # Set axis scales
+    if to_log:
+        ax.set_xscale("log", base=2)
+        ax.set_yscale("log", base=2)
+    ax.set_xlim(max(uncertainties), min(uncertainties))
+
+    # Plot bootstrap confidence bands
+    _plot_bootstrap_confidence_bands(ax, analysis_results["bootstrap_models"], uncertainties)
+
+    # Plot scatter points
+    _plot_scatter_points(ax, uncertainties, analysis_results["scaled_errors"], scatter_color)
+
+    # Plot piecewise segments
+    _plot_piecewise_segments(ax, analysis_results["piecewise_model"], uncertainties, quantile_thresholds, colors[:2])
+
+    # Setup plot formatting
+    _setup_plot_formatting(
+        ax, analysis_results["bin_label_locs"], quantile_thresholds, analysis_results["correlations"], font_size
+    )
+
+    # Adjust layout
+    plt.subplots_adjust(bottom=bottom, left=left)
+
+    # Save or show plot using all remaining fig_kwargs
+    save_or_show_plot(save_path=save_path, fig_width=figsize[0], fig_height=figsize[1], dpi=dpi)
+
+
+def analyze_and_plot_uncertainty_correlation(
+    errors: np.ndarray,
+    uncertainties: np.ndarray,
+    quantile_thresholds: List[float],
+    colormap: str = "Set1",
+    to_log: bool = False,
+    error_scaling_factor: float = 1.0,
+    save_path: Optional[str] = None,
+    n_bootstrap: int = 1000,
+    sample_ratio: float = 0.6,
+    font_size: int = 25,
+    **fig_kwargs: Any,
+) -> Dict[str, List[Any]]:
+    """
+    Calculates Spearman correlation between errors and uncertainties.
+    Plots piecewise linear regression with bootstrap confidence intervals.
+
+    This is a convenience function that combines analysis and plotting.
+
+    Args:
+        errors (np.ndarray): Array of errors.
+        uncertainties (np.ndarray): Array of uncertainties.
+        quantile_thresholds (List[float]): List of quantile thresholds.
+        colormap (str): Name of matplotlib colormap. Defaults to 'Set1'.
+        to_log (bool, optional): Whether to apply logarithmic transformation on axes. Defaults to False.
+        error_scaling_factor (float, optional): Scaling factor for error. Defaults to 1.0.
+        save_path (Optional[str], optional): Path to save the plot, if None, the plot will be shown. Defaults to None.
+        n_bootstrap (int, optional): Number of bootstrap samples for confidence intervals. Defaults to 1000.
+        sample_ratio (float, optional): Ratio of samples to use for each bootstrap sample. Defaults to 0.6.
+        font_size (int, optional): Font size for plot labels and titles. Defaults to 25.
+        **fig_kwargs: Additional keyword arguments for figure creation. Supported parameters:
+            - figsize: tuple, figure size in inches (default: (12, 8))
+            - dpi: int, dots per inch (default: 600)
+            - bottom: float, bottom margin for subplots_adjust (default: 0.2)
+            - left: float, left margin for subplots_adjust (default: 0.15)
+            - Any other matplotlib figure parameters
+
+    Returns:
+        Dict[str, List[Any]]: Dictionary containing Spearman and Pearson correlation coefficients and p-values.
+    """
+    # Input validation
+    if len(errors) != len(uncertainties):
+        raise ValueError(
+            f"Errors and uncertainties arrays must have the same length. "
+            f"Got errors: {len(errors)}, uncertainties: {len(uncertainties)}"
+        )
+
+    # Analyze correlation
+    analysis_results = analyze_uncertainty_correlation(
+        errors, uncertainties, quantile_thresholds, error_scaling_factor, n_bootstrap, sample_ratio
+    )
+
+    # Plot results
+    plot_uncertainty_correlation(
+        uncertainties,
+        analysis_results,
+        quantile_thresholds,
+        colormap,
+        to_log,
+        save_path,
+        font_size=font_size,
+        **fig_kwargs,
+    )
+
+    return analysis_results["correlations"]

--- a/kale/interpret/correlation_analysis.py
+++ b/kale/interpret/correlation_analysis.py
@@ -1,0 +1,144 @@
+"""
+Correlation of uncertainty with error (fit_line_with_ci)
+"""
+from typing import Any, Dict, List, Optional
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pwlf
+from matplotlib.ticker import ScalarFormatter
+from scipy import stats
+
+
+def fit_line_with_ci(
+    errors: np.ndarray,
+    uncertainties: np.ndarray,
+    quantile_thresholds: List[float],
+    cmaps: List[Dict[str, str]],
+    to_log: bool = False,
+    error_scaling_factor: float = 1.0,
+    save_path: Optional[str] = None,
+) -> Dict[str, List[Any]]:
+    """
+    Calculates Spearman correlation between errors and uncertainties.
+    Plots piecewise linear regression with bootstrap confidence intervals.
+    Breakpoints in linear regression are defined by the uncertainty quantiles of the data.
+
+    Args:
+        errors (np.ndarray): Array of errors.
+        uncertainties (np.ndarray): Array of uncertainties.
+        quantile_thresholds (List[float]): List of quantile thresholds.
+        cmaps (List[str]): List of colormap names.
+        to_log (bool, optional): Whether to apply logarithmic transformation on axes. Defaults to False.
+        error_scaling_factor (float, optional): Scaling factor for error. Defaults to 1.0.
+        save_path (Optional[str], optional): Path to save the plot, if None, the plot will be shown. Defaults to None.
+
+    Returns:
+        Dict[str, Tuple[float, float]]: Dictionary containing Spearman and Pearson correlation coefficients and p-values.
+    """
+
+    plt.figure(figsize=(12, 8))
+    ax = plt.gca()
+
+    if to_log:
+        plt.xscale("log", base=2)
+        plt.yscale("log", base=2)
+
+    X = uncertainties
+    y = errors * error_scaling_factor
+    plt.xlim(max(X), min(X))
+
+    # Calculate correlations
+    spm_corr, spm_p = stats.spearmanr(X, y, alternative="greater")
+    pear_corr, pear__p = stats.pearsonr(X, y)
+    correlation_dict = {"spearman": [spm_corr, spm_p], "pearson": [pear_corr, pear__p]}
+
+    # Bootstrap sample for confidence intervals
+    for i in range(0, 1000):
+        sample_index = np.random.choice(range(0, len(y)), int(len(y) * 0.6))
+
+        X_samples = X[sample_index]
+        y_samples = y[sample_index]
+        my_pwlf = pwlf.PiecewiseLinFit(X_samples, y_samples)
+        my_pwlf.fit_with_breaks(quantile_thresholds)
+        xHat = np.linspace(min(X), max(X), num=10000)
+        yHat = my_pwlf.predict(xHat)
+
+        # Plot each bootstrap as a grey line
+        plt.plot(xHat[::-1], yHat[::-1], "-", color="grey", alpha=0.2, zorder=2)
+
+    # Display all datapoints on plot
+    plt.scatter(X, y, marker="o", color=cmaps[2], zorder=1, alpha=0.2)
+
+    # Final fit on ALL the data
+    my_pwlf = pwlf.PiecewiseLinFit(X, y)
+
+    # Manually set the piecewise breaks as the quantile thresholds.
+    my_pwlf.fit_with_breaks(quantile_thresholds)
+
+    # Plot the final fitted line, changing the color of the line segments for each quantile for visualisation.
+    bin_label_locs = []
+    for idx in range(len(quantile_thresholds) + 1):
+        color = "blue" if idx % 2 == 0 else "red"
+        xHat = np.linspace(min(X), max(X), num=20000)
+        yHat = my_pwlf.predict(xHat)
+
+        if idx == 0:
+            min_ = min(X)
+            max_ = quantile_thresholds[idx]
+
+        elif idx <= len(quantile_thresholds) - 1:
+            min_ = quantile_thresholds[idx - 1]
+            max_ = quantile_thresholds[idx]
+        else:
+            min_ = quantile_thresholds[idx - 1]
+            max_ = max(X)
+
+        plot_indicies = [i for i in range(len(xHat)) if min_ <= xHat[i] < max_]
+        bin_label_locs.append((min_ + max_) / 2)
+        quantile_data_indicies = [i for i in range(len(X)) if min_ <= X[i] < max_]
+        # shade background to make slices per quantile
+        q_spm_corr, q_spm_p = stats.spearmanr(X[quantile_data_indicies], y[quantile_data_indicies])
+        plt.axvspan(xHat[plot_indicies][0], xHat[plot_indicies][-1], facecolor=color, alpha=0.1)
+        plt.plot(xHat[plot_indicies], yHat[plot_indicies], "-", color=color, zorder=3)
+
+    ax.set_xticks(bin_label_locs)
+    new_labels = [r"$Q_{{{}}}$".format(x + 1) for x in range(len(quantile_thresholds) + 1)]
+    ax.xaxis.set_major_formatter(plt.FixedFormatter(new_labels))
+    ax.yaxis.set_major_formatter(ScalarFormatter())
+
+    # Put text on plot showing the correlation
+    p_vl = 0.001 if np.round(spm_p, 3) == 0 else np.round(spm_p, 3)
+    bold_text = (
+        r"$\bf{\rho:} $" + r"$\bf{{{}}}$".format(np.round(spm_corr, 2)) + ", p-value < " + r"${{{}}}$".format(p_vl)
+    )
+
+    plt.text(
+        0.5,
+        0.9,
+        bold_text,
+        size=25,
+        color="black",
+        horizontalalignment="center",
+        verticalalignment="center",
+        transform=ax.transAxes,
+    )
+    ax.set_xlabel("Uncertainty Quantile", fontsize=25)
+    ax.set_ylabel("Error (mm)", fontsize=25)
+    plt.subplots_adjust(bottom=0.2)
+    plt.subplots_adjust(left=0.15)
+
+    plt.xticks(fontsize=25)
+    plt.yticks(fontsize=25)
+
+    if save_path is not None:
+        plt.gcf().set_size_inches(16.0, 8.0)
+        plt.tight_layout()
+        plt.savefig(save_path, dpi=600, bbox_inches="tight", pad_inches=0.1)
+        plt.close()
+    else:
+        plt.gcf().set_size_inches(16.0, 10.0)
+        plt.show()
+        plt.close()
+
+    return correlation_dict

--- a/kale/interpret/correlation_analysis.py
+++ b/kale/interpret/correlation_analysis.py
@@ -1,5 +1,5 @@
 # =============================================================================
-# Author: JLawrence Schobs, lawrenceschobs@gmail.com
+# Author: Lawrence Schobs, lawrenceschobs@gmail.com
 #         Wenjie Zhao, 1534779821@qq.com
 #         Zhongwei Ji, jizhongwei1999@outlook.com
 # =============================================================================

--- a/kale/interpret/uncertainty_quantiles.py
+++ b/kale/interpret/uncertainty_quantiles.py
@@ -1107,7 +1107,6 @@ def generate_fig_individual_bin_comparison(data: Tuple, display_settings: dict) 
             _ = evaluate_correlations(
                 bins_all_targets,
                 uncertainty_error_pairs,
-                cmaps,
                 num_bins,
                 confidence_invert,
                 num_folds=num_folds,

--- a/kale/interpret/uncertainty_quantiles.py
+++ b/kale/interpret/uncertainty_quantiles.py
@@ -1,6 +1,10 @@
-"""
-Authors: Lawrence Schobs, lawrenceschobs@gmail.com
+# =============================================================================
+# Author: JLawrence Schobs, lawrenceschobs@gmail.com
+#         Wenjie Zhao, 1534779821@qq.com
+#         Zhongwei Ji, jizhongwei1999@outlook.com
+# =============================================================================
 
+"""
 Module from the implementation of L. A. Schobs, A. J. Swift and H. Lu, "Uncertainty Estimation for Heatmap-Based Landmark Localization,"
 in IEEE Transactions on Medical Imaging, vol. 42, no. 4, pp. 1021-1034, April 2023, doi: 10.1109/TMI.2022.3222730.
 

--- a/kale/interpret/uncertainty_quantiles.py
+++ b/kale/interpret/uncertainty_quantiles.py
@@ -1,5 +1,5 @@
 # =============================================================================
-# Author: JLawrence Schobs, lawrenceschobs@gmail.com
+# Author: Lawrence Schobs, lawrenceschobs@gmail.com
 #         Wenjie Zhao, 1534779821@qq.com
 #         Zhongwei Ji, jizhongwei1999@outlook.com
 # =============================================================================

--- a/kale/interpret/uncertainty_quantiles.py
+++ b/kale/interpret/uncertainty_quantiles.py
@@ -5,11 +5,10 @@ Module from the implementation of L. A. Schobs, A. J. Swift and H. Lu, "Uncertai
 in IEEE Transactions on Medical Imaging, vol. 42, no. 4, pp. 1021-1034, April 2023, doi: 10.1109/TMI.2022.3222730.
 
 Functions related to interpreting the uncertainty quantiles from the quantile binning method in terms of:
-   A) Correlation of uncertainty with error (fit_line_with_ci)
-   B) Perform Isotonic regression on uncertainty & error pairs (quantile_binning_and_est_errors)
-   C) Plot boxplots: generic_box_plot_loop, format_plot, box_plot_per_model, box_plot_comparing_q
-   D) Plot cumularive error plots: plot_cumulative
-   E) Big caller functions for analysis loop for QBinning:  generate_fig_individual_bin_comparison, generate_fig_comparing_bins
+   A) Perform Isotonic regression on uncertainty & error pairs (quantile_binning_and_est_errors)
+   B) Plot boxplots: generic_box_plot_loop, format_plot, box_plot_per_model, box_plot_comparing_q
+   C) Plot cumularive error plots: plot_cumulative
+   D) Big caller functions for analysis loop for QBinning:  generate_fig_individual_bin_comparison, generate_fig_comparing_bins
 
 """
 import logging
@@ -23,149 +22,13 @@ import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
 import numpy as np
 import pandas as pd
-import pwlf
 from matplotlib.ticker import ScalarFormatter
-from scipy import stats
 from sklearn.isotonic import IsotonicRegression
 
 from kale.evaluate.similarity_metrics import evaluate_correlations
 from kale.evaluate.uncertainty_metrics import evaluate_bounds, evaluate_jaccard, get_mean_errors
 from kale.prepdata.tabular_transform import generate_struct_for_qbin
 from kale.utils.save_xlsx import generate_summary_df
-
-
-def fit_line_with_ci(
-    errors: np.ndarray,
-    uncertainties: np.ndarray,
-    quantile_thresholds: List[float],
-    cmaps: List[Dict[str, str]],
-    to_log: bool = False,
-    error_scaling_factor: float = 1.0,
-    save_path: Optional[str] = None,
-) -> Dict[str, List[Any]]:
-    """
-    Calculates Spearman correlation between errors and uncertainties.
-    Plots piecewise linear regression with bootstrap confidence intervals.
-    Breakpoints in linear regression are defined by the uncertainty quantiles of the data.
-
-    Args:
-        errors (np.ndarray): Array of errors.
-        uncertainties (np.ndarray): Array of uncertainties.
-        quantile_thresholds (List[float]): List of quantile thresholds.
-        cmaps (List[str]): List of colormap names.
-        to_log (bool, optional): Whether to apply logarithmic transformation on axes. Defaults to False.
-        error_scaling_factor (float, optional): Scaling factor for error. Defaults to 1.0.
-        save_path (Optional[str], optional): Path to save the plot, if None, the plot will be shown. Defaults to None.
-
-    Returns:
-        Dict[str, Tuple[float, float]]: Dictionary containing Spearman and Pearson correlation coefficients and p-values.
-    """
-
-    plt.figure(figsize=(12, 8))
-    ax = plt.gca()
-
-    if to_log:
-        plt.xscale("log", base=2)
-        plt.yscale("log", base=2)
-
-    X = uncertainties
-    y = errors * error_scaling_factor
-    plt.xlim(max(X), min(X))
-
-    # Calculate correlations
-    spm_corr, spm_p = stats.spearmanr(X, y, alternative="greater")
-    pear_corr, pear__p = stats.pearsonr(X, y)
-    correlation_dict = {"spearman": [spm_corr, spm_p], "pearson": [pear_corr, pear__p]}
-
-    # Bootstrap sample for confidence intervals
-    for i in range(0, 1000):
-        sample_index = np.random.choice(range(0, len(y)), int(len(y) * 0.6))
-
-        X_samples = X[sample_index]
-        y_samples = y[sample_index]
-        my_pwlf = pwlf.PiecewiseLinFit(X_samples, y_samples)
-        my_pwlf.fit_with_breaks(quantile_thresholds)
-        xHat = np.linspace(min(X), max(X), num=10000)
-        yHat = my_pwlf.predict(xHat)
-
-        # Plot each bootstrap as a grey line
-        plt.plot(xHat[::-1], yHat[::-1], "-", color="grey", alpha=0.2, zorder=2)
-
-    # Display all datapoints on plot
-    plt.scatter(X, y, marker="o", color=cmaps[2], zorder=1, alpha=0.2)
-
-    # Final fit on ALL the data
-    my_pwlf = pwlf.PiecewiseLinFit(X, y)
-
-    # Manually set the piecewise breaks as the quantile thresholds.
-    my_pwlf.fit_with_breaks(quantile_thresholds)
-
-    # Plot the final fitted line, changing the color of the line segments for each quantile for visualisation.
-    bin_label_locs = []
-    for idx in range(len(quantile_thresholds) + 1):
-        color = "blue" if idx % 2 == 0 else "red"
-        xHat = np.linspace(min(X), max(X), num=20000)
-        yHat = my_pwlf.predict(xHat)
-
-        if idx == 0:
-            min_ = min(X)
-            max_ = quantile_thresholds[idx]
-
-        elif idx <= len(quantile_thresholds) - 1:
-            min_ = quantile_thresholds[idx - 1]
-            max_ = quantile_thresholds[idx]
-        else:
-            min_ = quantile_thresholds[idx - 1]
-            max_ = max(X)
-
-        plot_indicies = [i for i in range(len(xHat)) if min_ <= xHat[i] < max_]
-        bin_label_locs.append((min_ + max_) / 2)
-        quantile_data_indicies = [i for i in range(len(X)) if min_ <= X[i] < max_]
-        # shade background to make slices per quantile
-        q_spm_corr, q_spm_p = stats.spearmanr(X[quantile_data_indicies], y[quantile_data_indicies])
-        plt.axvspan(xHat[plot_indicies][0], xHat[plot_indicies][-1], facecolor=color, alpha=0.1)
-        plt.plot(xHat[plot_indicies], yHat[plot_indicies], "-", color=color, zorder=3)
-
-    ax.set_xticks(bin_label_locs)
-    new_labels = [r"$Q_{{{}}}$".format(x + 1) for x in range(len(quantile_thresholds) + 1)]
-    ax.xaxis.set_major_formatter(plt.FixedFormatter(new_labels))
-    ax.yaxis.set_major_formatter(ScalarFormatter())
-
-    # Put text on plot showing the correlation
-    p_vl = 0.001 if np.round(spm_p, 3) == 0 else np.round(spm_p, 3)
-    bold_text = (
-        r"$\bf{\rho:} $" + r"$\bf{{{}}}$".format(np.round(spm_corr, 2)) + ", p-value < " + r"${{{}}}$".format(p_vl)
-    )
-
-    plt.text(
-        0.5,
-        0.9,
-        bold_text,
-        size=25,
-        color="black",
-        horizontalalignment="center",
-        verticalalignment="center",
-        transform=ax.transAxes,
-    )
-    ax.set_xlabel("Uncertainty Quantile", fontsize=25)
-    ax.set_ylabel("Error (mm)", fontsize=25)
-    plt.subplots_adjust(bottom=0.2)
-    plt.subplots_adjust(left=0.15)
-
-    plt.xticks(fontsize=25)
-    plt.yticks(fontsize=25)
-
-    if save_path is not None:
-        plt.gcf().set_size_inches(16.0, 8.0)
-        plt.tight_layout()
-        plt.savefig(save_path, dpi=600, bbox_inches="tight", pad_inches=0.1)
-        plt.close()
-    else:
-        plt.gcf().set_size_inches(16.0, 10.0)
-        plt.show()
-        plt.close()
-
-    return correlation_dict
 
 
 def quantile_binning_and_est_errors(

--- a/kale/interpret/visualize.py
+++ b/kale/interpret/visualize.py
@@ -4,6 +4,8 @@
 # =============================================================================
 
 
+from typing import Optional
+
 import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
@@ -308,3 +310,37 @@ def draw_mol_with_attention(attention_weights, smile, out_path, colormap="viridi
 
     with open(out_path, "w") as f:
         f.write(drawer.GetDrawingText())
+
+
+def save_or_show_plot(save_path: Optional[str] = None, **fig_kwargs) -> None:
+    """Save plot to file or show it.
+
+    Args:
+        save_path (str, optional): Path to save the figure. If None, the figure will be shown instead.
+        **fig_kwargs: Additional keyword arguments for figure configuration. Supported parameters:
+            - dpi: int, dots per inch for the saved figure (default: 600)
+            - fig_width: float, width of the figure in inches (default: 16.0)
+            - fig_height: float, height of the figure in inches (default: 8.0)
+            - bbox_inches: str, bounding box for saved figure (default: "tight")
+            - pad_inches: float, padding for saved figure (default: 0.1)
+            - Any other parameters supported by plt.savefig()
+
+    Returns:
+        None
+    """
+    # Extract figure parameters with defaults
+    dpi = fig_kwargs.pop("dpi", 600)
+    w = fig_kwargs.pop("fig_width", 16.0)
+    h = fig_kwargs.pop("fig_height", 8.0)
+    bbox_inches = fig_kwargs.pop("bbox_inches", "tight")
+    pad_inches = fig_kwargs.pop("pad_inches", 0.1)
+
+    if save_path is not None:
+        plt.gcf().set_size_inches(w, h)
+        plt.tight_layout()
+        plt.savefig(save_path, dpi=dpi, bbox_inches=bbox_inches, pad_inches=pad_inches, **fig_kwargs)
+        plt.close()
+    else:
+        plt.gcf().set_size_inches(w, h)
+        plt.show()
+        plt.close()

--- a/kale/interpret/visualize.py
+++ b/kale/interpret/visualize.py
@@ -312,11 +312,12 @@ def draw_mol_with_attention(attention_weights, smile, out_path, colormap="viridi
         f.write(drawer.GetDrawingText())
 
 
-def save_or_show_plot(save_path: Optional[str] = None, **fig_kwargs) -> None:
+def save_or_show_plot(save_path: Optional[str] = None, show: bool = True, **fig_kwargs) -> None:
     """Save plot to file or show it.
 
     Args:
         save_path (str, optional): Path to save the figure. If None, the figure will be shown instead.
+        show (bool, optional): Whether to show the figure. Defaults to True.
         **fig_kwargs: Additional keyword arguments for figure configuration. Supported parameters:
             - dpi: int, dots per inch for the saved figure (default: 600)
             - fig_width: float, width of the figure in inches (default: 16.0)
@@ -335,12 +336,13 @@ def save_or_show_plot(save_path: Optional[str] = None, **fig_kwargs) -> None:
     bbox_inches = fig_kwargs.pop("bbox_inches", "tight")
     pad_inches = fig_kwargs.pop("pad_inches", 0.1)
 
+    plt.gcf().set_size_inches(w, h)
+
     if save_path is not None:
-        plt.gcf().set_size_inches(w, h)
         plt.tight_layout()
         plt.savefig(save_path, dpi=dpi, bbox_inches=bbox_inches, pad_inches=pad_inches, **fig_kwargs)
-        plt.close()
-    else:
-        plt.gcf().set_size_inches(w, h)
+
+    if show:
         plt.show()
-        plt.close()
+
+    plt.close()

--- a/tests/interpret/test_correlation_analysis.py
+++ b/tests/interpret/test_correlation_analysis.py
@@ -20,15 +20,19 @@ def dummy_corr_data():
     return errors, uncertainties, quantile_thresholds
 
 
-class TestFitLineWithCI:
-    def test_basic(self):
+class TestBasicCorrelation:
+    """Test basic correlation analysis functionality."""
+
+    def test_basic_functionality(self, tmp_path):
+        """Test basic correlation analysis with default parameters."""
+        out_path = tmp_path / "test_correlation_plot.pdf"
         result = analyze_and_plot_uncertainty_correlation(
             errors=ERRORS,
             uncertainties=UNCERTAINTIES,
             quantile_thresholds=QUANTILE_THRESHOLDS,
             to_log=False,
             error_scaling_factor=1.0,
-            save_path=None,
+            save_path=out_path,
         )
         assert isinstance(result, dict)
         assert "spearman" in result
@@ -38,7 +42,9 @@ class TestFitLineWithCI:
         assert all(isinstance(x, float) for x in result["spearman"])
         assert all(isinstance(x, float) for x in result["pearson"])
 
-    def test_with_fixture(self, dummy_corr_data):
+    def test_with_logging(self, dummy_corr_data, tmp_path):
+        """Test correlation analysis with logarithmic scaling."""
+        out_path = tmp_path / "test_correlation_plot.pdf"
         errors, uncertainties, quantile_thresholds = dummy_corr_data
         result = analyze_and_plot_uncertainty_correlation(
             errors=errors,
@@ -46,39 +52,72 @@ class TestFitLineWithCI:
             quantile_thresholds=quantile_thresholds,
             to_log=True,
             error_scaling_factor=2.0,
-            save_path=None,
+            save_path=out_path,
         )
         assert isinstance(result, dict)
         assert "spearman" in result
         assert "pearson" in result
 
-    def test_invalid_input(self):
-        # errors and uncertainties must be same length
-        with pytest.raises(ValueError):
+    def test_save_functionality(self, tmp_path):
+        """Test that plots are properly saved and files are created."""
+        out_path = tmp_path / "test_correlation_plot.pdf"
+
+        result = analyze_and_plot_uncertainty_correlation(
+            errors=ERRORS,
+            uncertainties=UNCERTAINTIES,
+            quantile_thresholds=QUANTILE_THRESHOLDS,
+            to_log=False,
+            error_scaling_factor=1.0,
+            save_path=out_path,
+        )
+
+        # Verify the function returns expected results
+        assert isinstance(result, dict)
+        assert "spearman" in result
+        assert "pearson" in result
+
+        # Verify the file was actually created
+        assert out_path.exists(), f"Expected plot file was not created at {out_path}"
+
+        # Verify the file is not empty
+        assert out_path.stat().st_size > 0, "Created plot file is empty"
+
+        # Verify reasonable file size (PDF should be substantial but not huge)
+        file_size = out_path.stat().st_size
+        assert file_size > 1000, f"Plot file seems too small ({file_size} bytes)"
+        assert file_size < 10_000_000, f"Plot file seems too large ({file_size} bytes)"
+
+        # tmp_path automatically cleans up after test completes
+
+
+class TestInputValidation:
+    """Test input validation and error handling."""
+
+    def test_mismatched_array_lengths(self, tmp_path):
+        """Test that mismatched array lengths raise appropriate errors."""
+        out_path = tmp_path / "test_correlation_plot.pdf"
+        with pytest.raises(ValueError, match="must have the same length"):
             analyze_and_plot_uncertainty_correlation(
-                errors=np.array([1, 2, 3]), uncertainties=np.array([1, 2]), quantile_thresholds=[0.5]
+                errors=np.array([1, 2, 3]),
+                uncertainties=np.array([1, 2]),
+                quantile_thresholds=[0.5],
+                save_path=out_path,
             )
 
-        # empty arrays
-        with pytest.raises(ValueError):
+    def test_empty_arrays(self, tmp_path):
+        """Test that empty arrays raise appropriate errors."""
+        out_path = tmp_path / "test_correlation_plot.pdf"
+        with pytest.raises(ValueError, match="cannot be empty"):
             analyze_and_plot_uncertainty_correlation(
-                errors=np.array([]), uncertainties=np.array([]), quantile_thresholds=[0.5]
+                errors=np.array([]), uncertainties=np.array([]), quantile_thresholds=[0.5], save_path=out_path
             )
 
-        # negative values (should not error unless function restricts, but test for robustness)
+    def test_negative_quantile_thresholds(self, tmp_path):
+        """Test that negative quantile thresholds cause appropriate errors."""
+        out_path = tmp_path / "test_correlation_plot.pdf"
         errors = np.array([-1, -2, -3])
         uncertainties = np.array([-1, -2, -3])
         quantile_thresholds = [-0.5, -0.2]
-        # If function does not raise, just check it runs
-        try:
-            analyze_and_plot_uncertainty_correlation(errors, uncertainties, quantile_thresholds)
-        except Exception as e:
-            assert isinstance(e, Exception)
-
-        # invalid quantile thresholds (not sorted or out of range)
-        with pytest.raises(Exception):
-            analyze_and_plot_uncertainty_correlation(
-                errors=np.array([1, 2, 3]),
-                uncertainties=np.array([1, 2, 3]),
-                quantile_thresholds=[2, 1],  # not sorted, out of range
-            )
+        # Negative quantile thresholds are likely to cause issues in piecewise fitting
+        with pytest.raises((ValueError, RuntimeError, Exception)):
+            analyze_and_plot_uncertainty_correlation(errors, uncertainties, quantile_thresholds, save_path=out_path)

--- a/tests/interpret/test_correlation_analysis.py
+++ b/tests/interpret/test_correlation_analysis.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from kale.interpret.correlation_analysis import fit_line_with_ci
+from kale.interpret.correlation_analysis import analyze_and_plot_uncertainty_correlation
 
 SEED = 42
 np.random.seed(SEED)
@@ -9,7 +9,6 @@ np.random.seed(SEED)
 ERRORS = np.random.rand(50)
 UNCERTAINTIES = np.random.rand(50)
 QUANTILE_THRESHOLDS = [0.3, 0.6]
-CMAPS = ["red", "green", "blue"]
 
 
 @pytest.fixture(scope="module")
@@ -18,17 +17,15 @@ def dummy_corr_data():
     errors = np.random.rand(30)
     uncertainties = np.random.rand(30)
     quantile_thresholds = [0.2, 0.5, 0.8]
-    cmaps = ["red", "green", "blue", "orange"]
-    return errors, uncertainties, quantile_thresholds, cmaps
+    return errors, uncertainties, quantile_thresholds
 
 
 class TestFitLineWithCI:
     def test_basic(self):
-        result = fit_line_with_ci(
+        result = analyze_and_plot_uncertainty_correlation(
             errors=ERRORS,
             uncertainties=UNCERTAINTIES,
             quantile_thresholds=QUANTILE_THRESHOLDS,
-            cmaps=CMAPS,
             to_log=False,
             error_scaling_factor=1.0,
             save_path=None,
@@ -42,12 +39,11 @@ class TestFitLineWithCI:
         assert all(isinstance(x, float) for x in result["pearson"])
 
     def test_with_fixture(self, dummy_corr_data):
-        errors, uncertainties, quantile_thresholds, cmaps = dummy_corr_data
-        result = fit_line_with_ci(
+        errors, uncertainties, quantile_thresholds = dummy_corr_data
+        result = analyze_and_plot_uncertainty_correlation(
             errors=errors,
             uncertainties=uncertainties,
             quantile_thresholds=quantile_thresholds,
-            cmaps=cmaps,
             to_log=True,
             error_scaling_factor=2.0,
             save_path=None,
@@ -59,9 +55,30 @@ class TestFitLineWithCI:
     def test_invalid_input(self):
         # errors and uncertainties must be same length
         with pytest.raises(ValueError):
-            fit_line_with_ci(
+            analyze_and_plot_uncertainty_correlation(
+                errors=np.array([1, 2, 3]), uncertainties=np.array([1, 2]), quantile_thresholds=[0.5]
+            )
+
+        # empty arrays
+        with pytest.raises(ValueError):
+            analyze_and_plot_uncertainty_correlation(
+                errors=np.array([]), uncertainties=np.array([]), quantile_thresholds=[0.5]
+            )
+
+        # negative values (should not error unless function restricts, but test for robustness)
+        errors = np.array([-1, -2, -3])
+        uncertainties = np.array([-1, -2, -3])
+        quantile_thresholds = [-0.5, -0.2]
+        # If function does not raise, just check it runs
+        try:
+            analyze_and_plot_uncertainty_correlation(errors, uncertainties, quantile_thresholds)
+        except Exception as e:
+            assert isinstance(e, Exception)
+
+        # invalid quantile thresholds (not sorted or out of range)
+        with pytest.raises(Exception):
+            analyze_and_plot_uncertainty_correlation(
                 errors=np.array([1, 2, 3]),
-                uncertainties=np.array([1, 2]),
-                quantile_thresholds=[0.5],
-                cmaps=["red", "green"],
+                uncertainties=np.array([1, 2, 3]),
+                quantile_thresholds=[2, 1],  # not sorted, out of range
             )

--- a/tests/interpret/test_correlation_analysis.py
+++ b/tests/interpret/test_correlation_analysis.py
@@ -1,0 +1,67 @@
+import numpy as np
+import pytest
+
+from kale.interpret.correlation_analysis import fit_line_with_ci
+
+SEED = 42
+np.random.seed(SEED)
+
+ERRORS = np.random.rand(50)
+UNCERTAINTIES = np.random.rand(50)
+QUANTILE_THRESHOLDS = [0.3, 0.6]
+CMAPS = ["red", "green", "blue"]
+
+
+@pytest.fixture(scope="module")
+def dummy_corr_data():
+    # Fixture to provide dummy errors and uncertainties
+    errors = np.random.rand(30)
+    uncertainties = np.random.rand(30)
+    quantile_thresholds = [0.2, 0.5, 0.8]
+    cmaps = ["red", "green", "blue", "orange"]
+    return errors, uncertainties, quantile_thresholds, cmaps
+
+
+class TestFitLineWithCI:
+    def test_basic(self):
+        result = fit_line_with_ci(
+            errors=ERRORS,
+            uncertainties=UNCERTAINTIES,
+            quantile_thresholds=QUANTILE_THRESHOLDS,
+            cmaps=CMAPS,
+            to_log=False,
+            error_scaling_factor=1.0,
+            save_path=None,
+        )
+        assert isinstance(result, dict)
+        assert "spearman" in result
+        assert "pearson" in result
+        assert len(result["spearman"]) == 2
+        assert len(result["pearson"]) == 2
+        assert all(isinstance(x, float) for x in result["spearman"])
+        assert all(isinstance(x, float) for x in result["pearson"])
+
+    def test_with_fixture(self, dummy_corr_data):
+        errors, uncertainties, quantile_thresholds, cmaps = dummy_corr_data
+        result = fit_line_with_ci(
+            errors=errors,
+            uncertainties=uncertainties,
+            quantile_thresholds=quantile_thresholds,
+            cmaps=cmaps,
+            to_log=True,
+            error_scaling_factor=2.0,
+            save_path=None,
+        )
+        assert isinstance(result, dict)
+        assert "spearman" in result
+        assert "pearson" in result
+
+    def test_invalid_input(self):
+        # errors and uncertainties must be same length
+        with pytest.raises(ValueError):
+            fit_line_with_ci(
+                errors=np.array([1, 2, 3]),
+                uncertainties=np.array([1, 2]),
+                quantile_thresholds=[0.5],
+                cmaps=["red", "green"],
+            )

--- a/tests/interpret/test_visualize.py
+++ b/tests/interpret/test_visualize.py
@@ -171,3 +171,9 @@ def test_draw_mol_with_attention(tmp_path, dummy_smile):
 
     assert os.path.exists(out_path)
     assert os.path.getsize(out_path) > 0
+
+
+def test_save_or_show_plot(tmp_path):
+    out_path = tmp_path / "test_plot.png"
+    visualize.save_or_show_plot(save_path=str(out_path))
+    assert os.path.isfile(out_path)

--- a/tests/interpret/test_visualize.py
+++ b/tests/interpret/test_visualize.py
@@ -9,7 +9,7 @@ import torch
 from rdkit import Chem
 
 from kale.interpret import visualize
-from kale.interpret.visualize import draw_attention_map, draw_mol_with_attention
+from kale.interpret.visualize import draw_attention_map, draw_mol_with_attention, save_or_show_plot
 
 matplotlib.use("Agg")  # Use non-interactive backend for tests
 
@@ -164,7 +164,7 @@ def test_draw_attention_map_runs(dummy_attention):
 def test_draw_mol_with_attention(tmp_path, dummy_smile):
     mol = Chem.MolFromSmiles(dummy_smile)
     num_atoms = mol.GetNumAtoms()
-    attention_tensor = torch.rand(num_atoms)  # 确保长度与原子数一致
+    attention_tensor = torch.rand(num_atoms)
 
     out_path = tmp_path / "mol_attention.svg"
     draw_mol_with_attention(attention_tensor, dummy_smile, str(out_path))
@@ -175,5 +175,5 @@ def test_draw_mol_with_attention(tmp_path, dummy_smile):
 
 def test_save_or_show_plot(tmp_path):
     out_path = tmp_path / "test_plot.png"
-    visualize.save_or_show_plot(save_path=str(out_path))
+    save_or_show_plot(save_path=str(out_path))
     assert os.path.isfile(out_path)


### PR DESCRIPTION
Fixes part of #410, based on https://github.com/pykale/pykale/pull/485 and https://github.com/kungfudaibi/pykale/tree/Refactor_uncertainty

### Description
- Fix circular import issue in evaluate_correlations() function by moving fit_line_with_ci() function to correlation_analysis.py
- Fix a file name issue in examples/landmark_uncertainty/main.py. (The dataset download from [DATASET.SOURCE](https://github.com/pykale/data/raw/main/tabular/cardiac_landmark_uncertainty/Uncertainty_tuples.zip) use _t suffixes for .csv file instead of _l)
- Remove redundant imports in kale/interpret/uncertainty_quantiles.py
- Remove warnings.filterwarnings("error") in examples/landmark_uncertainty/main.py
- Break down fit_line_with_ci into modular functions for better maintainability

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [x] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
