### PR TITLE
Upgrade Changelog CI

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run changelog
-        uses: saadmk11/changelog-ci@v1.1.2
+        uses: saadmk11/changelog-ci@v1.2.0
         with:
           changelog_filename: .github/CHANGELOG.md
           config_file: .github/changelog-ci-config.json


### PR DESCRIPTION
### Description
Upgrade Changelog CI from 1.1.2 to 1.2.0. This [upgrade](https://github.com/saadmk11/changelog-ci/pull/109/commits/87ebf0233077af4acfa44d6cf4e9beaec70f9902) updated the Dockerfile base image from buster to bullseye.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
