### PR TITLE
Skip forked PRs and update add-to-project to v1.0.2

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -1,7 +1,8 @@
-# This workflow will automatically add an issue or pull request to the project defined on lines 22 and 32.
+# This workflow will automatically add an issue or pull request to the project defined on lines 24 and 37.
 # The project needs to be updated when we move to a new project.
 # https://github.com/marketplace/actions/add-to-github-projects
 # The encrypted secret key "ADD_TO_PROJECT_PAT" has been created in accordance with the guidelines provided in https://docs.github.com/en/actions/security-guides/encrypted-secrets
+# In PRs, the action will only run if the PR is from pykale repository to avoid requesting secrets for forks.
 
 name: assign-project
 
@@ -14,7 +15,9 @@ on:
 jobs:
   add-issue-to-project:
     name: Add issue to project
-    if: github.event_name == 'issues' && github.event.action == 'opened'
+    if: |
+      github.event_name == 'issues' &&
+      github.event.action == 'opened'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@v0.5.0
@@ -24,7 +27,10 @@ jobs:
 
   add-pull-request-to-project:
     name: Add pull request to project
-    if: github.event_name == 'pull_request' && github.event.action == 'opened'
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.action == 'opened' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@v0.5.0

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -20,7 +20,7 @@ jobs:
       github.event.action == 'opened'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/pykale/projects/4
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
@@ -33,7 +33,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/pykale/projects/4
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -1,4 +1,4 @@
-# This workflow will automatically add an issue or pull request to the project defined on lines 24 and 37.
+# This workflow will automatically add an issue or pull request to the project defined on lines 25 and 38.
 # The project needs to be updated when we move to a new project.
 # https://github.com/marketplace/actions/add-to-github-projects
 # The encrypted secret key "ADD_TO_PROJECT_PAT" has been created in accordance with the guidelines provided in https://docs.github.com/en/actions/security-guides/encrypted-secrets


### PR DESCRIPTION
### Description
- Adding a condition to skip forked PRs when using secrets (`github-token`) to prevent exposure
- Updating `actions/add-to-project` from v0.5.0 to v1.0.2

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
