### PR TITLE
Refactor uncertainty_quantille with BoxPlotter class

### DIFF
--- a/kale/interpret/box_plot.py
+++ b/kale/interpret/box_plot.py
@@ -1,0 +1,93 @@
+from dataclasses import dataclass
+from typing import Optional, Tuple, List, Union
+from enum import Enum
+
+import matplotlib.patches as patches
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+class SampleInfoMode(Enum):
+    """Enumeration for sample information display modes."""
+    NONE = "None"
+    ALL = "All"
+    AVERAGE = "Average"
+
+
+@dataclass
+class BoxplotStyleConfig:
+    """Configuration class for boxplot styling with type hints and default values."""
+    # Plot style
+    matplotlib_style: str = "fivethirtyeight"
+    hatch_type: str = "o"
+    
+    # Colors and styling
+    box_edge_color: str = "black"
+    box_linewidth: float = 1.0
+    median_color: str = "crimson"
+    median_linewidth: float = 3.0
+    mean_facecolor: str = "crimson"
+    mean_edgecolor: str = "black"
+    mean_markersize: float = 10.0
+    
+    # Individual dots
+    dot_alpha_normal: float = 0.75
+    dot_alpha_alt: float = 0.2
+    
+    # Spacing values
+    inner_spacing: float = 0.1
+    middle_spacing: float = 0.02
+    gap_large: float = 0.25
+    gap_small: float = 0.12
+    outer_gap_small: float = 0.35
+    outer_gap_large: float = 0.24
+    comparing_q_spacing: float = 0.2
+    
+    # Box widths
+    default_box_width: float = 0.25
+    comparing_q_width_base: float = 0.2
+    
+    # Font sizes
+    sample_info_fontsize: int = 25
+    legend_fontsize: int = 20
+    
+    # Layout
+    legend_columnspacing: float = 2.0
+    legend_bbox_anchor: Tuple[float, float] = (0.5, 1.18)
+    subplot_bottom: float = 0.15
+    subplot_left: float = 0.15
+    
+    # Figure saving
+    figure_size: Tuple[float, float] = (16.0, 10.0)
+    dpi: int = 600
+    bbox_inches: str = "tight"
+    pad_inches: float = 0.1
+
+class BoxPlotter:
+    """
+    A comprehensive boxplot creator with flexible styling and configuration.
+    
+    This class provides methods to create various types of boxplots with
+    customizable styling, sample information display, and legend handling.
+    """
+    
+    def __init__(self, style_config: Optional[BoxplotStyleConfig] = None):
+        """
+        Initialize the BoxPlotter with optional style configuration.
+        
+        Args:
+            style_config: Custom styling configuration. If None, uses default.
+        """
+        self.config = style_config or BoxplotStyleConfig()
+        self.ax = None
+        self.fig = None
+        self.circ_patches: List[patches.Patch] = []
+        self.max_bin_height = 0.0
+        self.all_sample_label_x_locs: List[float] = []
+        self.all_sample_percs: List[Union[float, List[float]]] = []  
+
+    def setup_plot(self) -> None:
+        """Initialize plot with common settings."""
+        plt.style.use(self.config.matplotlib_style)
+        self.fig, self.ax = plt.subplots(figsize=self.config.figure_size, dpi=self.config.dpi)
+        self.ax.xaxis.grid(False)

--- a/kale/interpret/correlation_analysis.py
+++ b/kale/interpret/correlation_analysis.py
@@ -35,6 +35,7 @@ def analyze_and_plot_uncertainty_correlation(
     n_bootstrap: int = 1000,
     sample_ratio: float = 0.6,
     font_size: int = 25,
+    show: bool = False,
     **fig_kwargs: Any,
 ) -> Dict[str, List[Any]]:
     """
@@ -71,9 +72,11 @@ def analyze_and_plot_uncertainty_correlation(
         font_size (int, optional): Font size for all text elements in the plot
             including axis labels, correlation text, and quantile labels.
             Defaults to 25.
+        show (bool, optional): Whether to display the plot interactively. Defaults to False.
         **fig_kwargs: Additional keyword arguments for figure creation and styling:
             - figsize (tuple): Figure size in inches (default: (16, 8))
-            - dpi (int): Resolution in dots per inch (default: 600)
+            - save_dpi (int): Resolution in dots per inch for the saved figure (default: 600)
+            - show_dpi (int): Resolution in dots per inch for the shown figure (default: 100)
             - bottom (float): Bottom margin for subplot adjustment (default: 0.2)
             - left (float): Left margin for subplot adjustment (default: 0.15)
             - Any other matplotlib figure parameters
@@ -109,6 +112,7 @@ def analyze_and_plot_uncertainty_correlation(
         colormap,
         to_log,
         save_path,
+        show=show,
         font_size=font_size,
         **fig_kwargs,
     )
@@ -192,6 +196,7 @@ def plot_uncertainty_correlation(
     colormap: str = "Set1",
     to_log: bool = False,
     save_path: Optional[str] = None,
+    show: bool = False,
     font_size: int = 25,
     **fig_kwargs: Any,
 ) -> None:
@@ -206,12 +211,13 @@ def plot_uncertainty_correlation(
             Defaults to "Set1".
         to_log (bool, optional): Whether to use logarithmic scale for both axes.
             Defaults to False.
-        save_path (Optional[str], optional): File path to save the plot. If None,
-            displays the plot interactively. Defaults to None.
+        save_path (Optional[str], optional): File path to save the plot. Defaults to None.
+        show (bool, optional): Whether to show the figure. Defaults to False.
         font_size (int, optional): Font size for all text elements. Defaults to 25.
         **fig_kwargs: Additional keyword arguments for figure creation and styling:
             - figsize (tuple): Figure size in inches (default: (16, 8))
-            - dpi (int): Dots per inch for resolution (default: 600)
+            - save_dpi (int): Dots per inch for resolution (default: 600)
+            - show_dpi (int): Dots per inch for the shown figure (default: 100)
             - bottom (float): Bottom margin for subplots_adjust (default: 0.2)
             - left (float): Left margin for subplots_adjust (default: 0.15)
             - Any other matplotlib figure parameters
@@ -225,12 +231,11 @@ def plot_uncertainty_correlation(
     """
     # Extract figure-specific kwargs with defaults
     figsize = fig_kwargs.pop("figsize", (16, 8))
-    dpi = fig_kwargs.pop("dpi", 600)
     bottom = fig_kwargs.pop("bottom", 0.2)
     left = fig_kwargs.pop("left", 0.15)
 
     # Initialize plot
-    fig, ax = plt.subplots(figsize=figsize, dpi=dpi, **fig_kwargs)
+    fig, ax = plt.subplots(figsize=figsize, **fig_kwargs)
 
     # Handle color configuration
     colors = colormaps.get_cmap(colormap)(np.arange(3))
@@ -260,7 +265,7 @@ def plot_uncertainty_correlation(
     plt.subplots_adjust(bottom=bottom, left=left)
 
     # Save or show plot using all remaining fig_kwargs
-    save_or_show_plot(save_path=save_path, fig_width=figsize[0], fig_height=figsize[1], dpi=dpi)
+    save_or_show_plot(save_path=save_path, show=show, fig_size=figsize)
 
 
 def _calculate_correlations(uncertainties: np.ndarray, scaled_errors: np.ndarray) -> Dict[str, List[float]]:

--- a/kale/interpret/visualize.py
+++ b/kale/interpret/visualize.py
@@ -319,9 +319,9 @@ def save_or_show_plot(save_path: Optional[str] = None, show: bool = True, **fig_
         save_path (str, optional): Path to save the figure. If None, the figure will be shown instead.
         show (bool, optional): Whether to show the figure. Defaults to True.
         **fig_kwargs: Additional keyword arguments for figure configuration. Supported parameters:
-            - dpi: int, dots per inch for the saved figure (default: 600)
-            - fig_width: float, width of the figure in inches (default: 16.0)
-            - fig_height: float, height of the figure in inches (default: 8.0)
+            - save_dpi: int, dots per inch for the saved figure (default: 600)
+            - show_dpi: int, dots per inch for the shown figure (default: 100)
+            - fig_size: tuple, size of the figure in inches (default: (16.0, 8.0))
             - bbox_inches: str, bounding box for saved figure (default: "tight")
             - pad_inches: float, padding for saved figure (default: 0.1)
             - Any other parameters supported by plt.savefig()
@@ -330,9 +330,10 @@ def save_or_show_plot(save_path: Optional[str] = None, show: bool = True, **fig_
         None
     """
     # Extract figure parameters with defaults
-    dpi = fig_kwargs.pop("dpi", 600)
-    w = fig_kwargs.pop("fig_width", 16.0)
-    h = fig_kwargs.pop("fig_height", 8.0)
+    save_dpi = fig_kwargs.pop("save_dpi", 600)
+    show_dpi = fig_kwargs.pop("show_dpi", 100)
+    w = fig_kwargs.pop("fig_size", (16.0, 8.0))[0]
+    h = fig_kwargs.pop("fig_size", (16.0, 8.0))[1]
     bbox_inches = fig_kwargs.pop("bbox_inches", "tight")
     pad_inches = fig_kwargs.pop("pad_inches", 0.1)
 
@@ -340,9 +341,9 @@ def save_or_show_plot(save_path: Optional[str] = None, show: bool = True, **fig_
 
     if save_path is not None:
         plt.tight_layout()
-        plt.savefig(save_path, dpi=dpi, bbox_inches=bbox_inches, pad_inches=pad_inches, **fig_kwargs)
+        plt.savefig(save_path, dpi=save_dpi, bbox_inches=bbox_inches, pad_inches=pad_inches, **fig_kwargs)
 
     if show:
-        plt.show()
+        plt.show(dpi=show_dpi)
 
     plt.close()


### PR DESCRIPTION
Fixes #410.

### Description
- Add BoxPlotter class to encapsulate plotting configuration and logics
- Refactor `generic_box_plot_loop`, `format_plot`, `box_plot_per_model`, and `box_plot_comparing_q` with BoxPlotter

### Status
**Work in progress**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [] Non-breaking change (fix or new feature that would not break existing functionality).
- [ x] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x ] In-line docstrings updated.
- [x ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
