### PR TITLE
Stop support Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,8 @@ jobs:
       matrix:
 #        os: [ubuntu-latest, windows-latest]
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"] # list of Python versions to test
+        python-version: ["3.10", "3.11", "3.12"] # list of Python versions to test
 #        exclude:
-#          - os: windows-latest
-#            python-version: "3.9"
 #          - os: windows-latest
 #            python-version: "3.10"
         include:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![tests](https://github.com/pykale/pykale/workflows/test/badge.svg)](https://github.com/pykale/pykale/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/pykale/pykale/branch/main/graph/badge.svg?token=jmIYPbA2le)](https://codecov.io/gh/pykale/pykale)
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/pykale/pykale/blob/main/LICENSE)
-[![Python](https://img.shields.io/badge/python-3.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue)](https://www.python.org)
+[![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue)](https://www.python.org)
 [![PyPI version](https://img.shields.io/pypi/v/pykale?color=blue)](https://pypi.org/project/pykale/)
 [![PyPI downloads](https://pepy.tech/badge/pykale)](https://pepy.tech/project/pykale)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/pykale/pykale)
@@ -55,7 +55,7 @@ See our [arXiv preprint](https://arxiv.org/abs/2106.09756) and four short introd
 
 ### Step 0: Installation
 
-PyKale supports Python 3.9, 3.10, 3.11, or 3.12. Before installing `pykale`, we suggest you to first [install PyTorch](https://pytorch.org/get-started/locally/) matching your hardware, and if graphs will be used, install [PyTorch Geometric](https://github.com/rusty1s/pytorch_geometric) following its [official instructions](https://github.com/rusty1s/pytorch_geometric#installation).
+PyKale supports Python 3.10, 3.11, or 3.12. Before installing `pykale`, we suggest you to first [install PyTorch](https://pytorch.org/get-started/locally/) matching your hardware, and if graphs will be used, install [PyTorch Geometric](https://github.com/rusty1s/pytorch_geometric) following its [official instructions](https://github.com/rusty1s/pytorch_geometric#installation).
 
 Simple installation of `pykale` from [PyPI](https://pypi.org/project/pykale/):
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-PyKale requires Python 3.9, 3.10, 3.11, or 3.12. Before installing pykale, you should
+PyKale requires Python 3.10, 3.11, or 3.12. Before installing pykale, you should
 
 - manually [install PyTorch](https://pytorch.org/get-started/locally/) matching your hardware first,
 - if you will use APIs related to graphs, you need to manually install [PyTorch Geometric](https://github.com/rusty1s/pytorch_geometric) first following its [official instructions](https://github.com/rusty1s/pytorch_geometric#installation) and matching your PyTorch installation, and

--- a/examples/video_loading/README.md
+++ b/examples/video_loading/README.md
@@ -77,7 +77,7 @@ for image in frames:
 # Without these three, VideoFrameDataset will not work.
 torchvision >= 0.10.0
 torch >= 1.9.0
-python >= 3.9,<3.12
+python >= 3.10,<3.12
 ```
 
 ### 2. Custom Dataset

--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ setup(
         "Source": "https://github.com/pykale/pykale",
     },
     packages=find_packages(exclude=("docs", "examples", "tests")),
-    python_requires=">=3.9,<3.13",
+    python_requires=">=3.10,<3.13",
     install_requires=install_requires,
     extras_require={
         "graph": graph_requires,


### PR DESCRIPTION
### Description
Remove Python 3.9 from tests

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] [Source for documentation at `docs`](https://github.com/pykale/pykale/tree/main/docs/source) manually updated for new API.
