### PR TITLE
deps: bump docs requirements floor versions (pillow, torchsummary, yacs)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,7 +15,7 @@ nbsphinx-link
 numpy
 
 pandas
-pillow>=6.2.0
+pillow>=12.2.0
 pwlf
 pydicom
 PyTDC
@@ -31,8 +31,8 @@ tensorly
 # torch>=2.0.0
 torch-geometric
 
-torchsummary>=1.5.0
+torchsummary>=1.5.1
 torchvision
 urllib3<2.0
 wfdb
-yacs>=0.1.7
+yacs>=0.1.8


### PR DESCRIPTION
## Summary

Aligns the minimum version floors in `docs/requirements.txt` with what the project already uses in CI and locally.

- `pillow`: `>=6.2.0` → `>=12.2.0` — only stable APIs used (`Image.open`, `Image.fromarray`, `.convert`), confirmed compatible; CI passes on dependabot PRs #534
- `torchsummary`: `>=1.5.0` → `>=1.5.1` — docs-only dependency, CI passes on dependabot PR #531
- `yacs`: `>=0.1.7` → `>=0.1.8` — only `CfgNode` import used across 4 files, fully compatible; dependabot PR #532 CI failure was a transient HTTP 503 from an external S3 data source, not a yacs issue

Supersedes dependabot PRs #531, #532, #534.

## Test plan

- [x] CI pre-commit, tests (3.10/3.11/3.12), CodeQL pass