### PR TITLE
deps: bump setuptools build requirement from 74.1.0 to 82.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools==74.1.0",
+    "setuptools==82.0.1",
     "wheel",
     "numpy",
 ]
@@ -21,7 +21,7 @@ known_first_party = [
 known_third_party = [
     "matplotlib<=3.10.0",  # matplotlib 3.10.1 will cause "Building wheel for matplotlib (setup.py): finished with status 'error'" for tests
     "numpy",
-    "setuptools==74.1.0",
+    "setuptools==82.0.1",
     "sphinx_rtd_theme",
     "torch",
 ]


### PR DESCRIPTION
## Summary

Bumps the pinned `setuptools` version in `pyproject.toml` from `74.1.0` to `82.0.1`.

**Compatibility check:** setuptools 82.0.0 removes `pkg_resources`. A full grep of the pykale codebase confirms zero usage of `pkg_resources` — the removal has no impact. CI passes on dependabot PR #533.

Supersedes dependabot PR #533.

## Test plan

- [x] CI pre-commit, tests (3.10/3.11/3.12), CodeQL pass