### PR TITLE
Fix mutable default argument in visualize_connectome ( #543 issue)

### DIFF
--- a/kale/interpret/visualize.py
+++ b/kale/interpret/visualize.py
@@ -215,7 +215,7 @@ def distplot_1d(
         "p": [Interval(Real, 0, 1, closed="neither")],
         "cmap": [str],
         "marker_size": [Real],
-        "legend_params": [dict],
+        "legend_params": [dict, None],
     },
     prefer_skip_nested_validation=True,
 )

--- a/kale/interpret/visualize.py
+++ b/kale/interpret/visualize.py
@@ -219,7 +219,7 @@ def distplot_1d(
     },
     prefer_skip_nested_validation=True,
 )
-def visualize_connectome(weights, labels, coords, p=1e-3, cmap="tab20", marker_size=100, legend_params={}):
+def visualize_connectome(weights, labels, coords, p=1e-3, cmap="tab20", marker_size=100, legend_params=None):
     """
     Visualize the top-p weighted ROI connections as a symmetric connectome plot.
 
@@ -272,6 +272,8 @@ def visualize_connectome(weights, labels, coords, p=1e-3, cmap="tab20", marker_s
         )
 
     # Set legend parameters
+    if legend_params is None:
+        legend_params = {}
     proj.axes[next(iter(proj.axes))].ax.legend(**legend_params)
 
     return proj


### PR DESCRIPTION
Fixes #543

## Changes
- `kale/interpret/visualize.py` — changed `legend_params={}` to
  `legend_params=None` with a None guard before use

## Why
Mutable default arguments in Python are shared across all calls.
Using None as sentinel and creating a fresh {} inside the function
body ensures each call gets its own independent dict.

## Checklist
- [x] Pre-commit hooks pass (black, isort, flake8, mypy)
- [x] Change is backward compatible — callers passing no argument
      get identical behaviour
