### PR TITLE
Fix np.float64 to float conversion in _calculate_correlations for Python 3.12

### DIFF
--- a/kale/interpret/uncertainty_utils.py
+++ b/kale/interpret/uncertainty_utils.py
@@ -478,7 +478,10 @@ def _calculate_correlations(uncertainties: np.ndarray, scaled_errors: np.ndarray
     """
     smp_corr, smp_p = stats.spearmanr(uncertainties, scaled_errors, alternative="greater")
     pear_corr, pear_p = stats.pearsonr(uncertainties, scaled_errors)
-    return {"spearman": [smp_corr, smp_p], "pearson": [pear_corr, pear_p]}
+    return {
+        "spearman": [float(smp_corr), float(smp_p)],
+        "pearson": [float(pear_corr), float(pear_p)],
+    }
 
 
 def _fit_piecewise_model(


### PR DESCRIPTION
Fixes #572

### Description
`_calculate_correlations` in `kale/interpret/uncertainty_utils.py` returns 
`np.float64` values from `scipy.stats.spearmanr` and `scipy.stats.pearsonr`. 
In Python 3.12 with newer numpy, `isinstance(np.float64(x), float)` returns 
`False`, causing `test_uncertainty_utils.py::TestBasicCorrelation` to fail 
with `IndexError: too many indices for array: array is 0-dimensional`.

Fix: explicitly convert to Python `float` before returning.

### Status
Ready for review

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality)

### Checklist
- [x] Pre-commit hooks pass (black, flake8, isort, mypy)
- [x] Fixes failing tests on Python 3.12
- [x] No functional change — same values returned, different type wrapper
