### PR TITLE
Fix cross-DataFrame index alignment in bin_wise_bound_eval and bin_wise_errors

### DIFF
--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -23,7 +23,6 @@ Main Classes:
     - QuantileCalculator: Quantile-based error distribution analysis
     - MetricsCalculator: Statistical metrics computation
 """
-
 import copy
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -1545,12 +1544,12 @@ def evaluate_bounds(
             ]
 
             for target_idx in range(len(all_concat_errorbound_bins_target_sep_foldwise)):
-                all_concat_errorbound_bins_target_sep_foldwise[target_idx][model + " " + uncertainty_type] = (
-                    fold_all_bins_concat_targets_sep_foldwise[target_idx]
-                )
-                all_concat_errorbound_bins_target_sep_all[target_idx][model + " " + uncertainty_type] = (
-                    fold_all_bins_concat_targets_sep_all[target_idx]
-                )
+                all_concat_errorbound_bins_target_sep_foldwise[target_idx][
+                    model + " " + uncertainty_type
+                ] = fold_all_bins_concat_targets_sep_foldwise[target_idx]
+                all_concat_errorbound_bins_target_sep_all[target_idx][
+                    model + " " + uncertainty_type
+                ] = fold_all_bins_concat_targets_sep_all[target_idx]
 
     return {
         "error_bounds_all": all_bound_percents,
@@ -1871,12 +1870,12 @@ def get_mean_errors(
             all_concat_error_bins_target_nosep[model + " " + uncertainty_type] = fold_all_bins_concat_targets_nosep
 
             for target_idx in range(len(fold_all_bins_concat_targets_sep_foldwise)):
-                all_concat_error_bins_target_sep_foldwise[target_idx][model + " " + uncertainty_type] = (
-                    fold_all_bins_concat_targets_sep_foldwise[target_idx]
-                )
-                all_concat_error_bins_target_sep_all[target_idx][model + " " + uncertainty_type] = (
-                    fold_all_bins_concat_targets_sep_all[target_idx]
-                )
+                all_concat_error_bins_target_sep_foldwise[target_idx][
+                    model + " " + uncertainty_type
+                ] = fold_all_bins_concat_targets_sep_foldwise[target_idx]
+                all_concat_error_bins_target_sep_all[target_idx][
+                    model + " " + uncertainty_type
+                ] = fold_all_bins_concat_targets_sep_all[target_idx]
 
     return {
         "all_mean_error_bins_nosep": all_mean_error_bins,

--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -23,6 +23,7 @@ Main Classes:
     - QuantileCalculator: Quantile-based error distribution analysis
     - MetricsCalculator: Statistical metrics computation
 """
+
 import copy
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -1544,12 +1545,12 @@ def evaluate_bounds(
             ]
 
             for target_idx in range(len(all_concat_errorbound_bins_target_sep_foldwise)):
-                all_concat_errorbound_bins_target_sep_foldwise[target_idx][
-                    model + " " + uncertainty_type
-                ] = fold_all_bins_concat_targets_sep_foldwise[target_idx]
-                all_concat_errorbound_bins_target_sep_all[target_idx][
-                    model + " " + uncertainty_type
-                ] = fold_all_bins_concat_targets_sep_all[target_idx]
+                all_concat_errorbound_bins_target_sep_foldwise[target_idx][model + " " + uncertainty_type] = (
+                    fold_all_bins_concat_targets_sep_foldwise[target_idx]
+                )
+                all_concat_errorbound_bins_target_sep_all[target_idx][model + " " + uncertainty_type] = (
+                    fold_all_bins_concat_targets_sep_all[target_idx]
+                )
 
     return {
         "error_bounds_all": all_bound_percents,
@@ -1628,7 +1629,7 @@ def bin_wise_bound_eval(
 
     for i_ti, target_idx in enumerate(targets):
         true_errors_ti = fold_errors[(fold_errors["Target Index"] == target_idx)][["uid", uncertainty_type + " Error"]]
-        pred_bins_ti = fold_bins[(fold_errors["Target Index"] == target_idx)][
+        pred_bins_ti = fold_bins[(fold_bins["Target Index"] == target_idx)][
             ["uid", uncertainty_type + " Uncertainty bins"]
         ]
 
@@ -1870,12 +1871,12 @@ def get_mean_errors(
             all_concat_error_bins_target_nosep[model + " " + uncertainty_type] = fold_all_bins_concat_targets_nosep
 
             for target_idx in range(len(fold_all_bins_concat_targets_sep_foldwise)):
-                all_concat_error_bins_target_sep_foldwise[target_idx][
-                    model + " " + uncertainty_type
-                ] = fold_all_bins_concat_targets_sep_foldwise[target_idx]
-                all_concat_error_bins_target_sep_all[target_idx][
-                    model + " " + uncertainty_type
-                ] = fold_all_bins_concat_targets_sep_all[target_idx]
+                all_concat_error_bins_target_sep_foldwise[target_idx][model + " " + uncertainty_type] = (
+                    fold_all_bins_concat_targets_sep_foldwise[target_idx]
+                )
+                all_concat_error_bins_target_sep_all[target_idx][model + " " + uncertainty_type] = (
+                    fold_all_bins_concat_targets_sep_all[target_idx]
+                )
 
     return {
         "all_mean_error_bins_nosep": all_mean_error_bins,
@@ -1908,7 +1909,7 @@ def bin_wise_errors(fold_errors, fold_bins, num_bins, targets, uncertainty_key, 
 
     for i, target_idx in enumerate(targets):
         true_errors_ti = fold_errors[(fold_errors["Target Index"] == target_idx)][["uid", uncertainty_key + " Error"]]
-        pred_bins_ti = fold_bins[(fold_errors["Target Index"] == target_idx)][
+        pred_bins_ti = fold_bins[(fold_bins["Target Index"] == target_idx)][
             ["uid", uncertainty_key + " Uncertainty bins"]
         ]
 

--- a/tests/evaluate/test_uncertainty_metrics.py
+++ b/tests/evaluate/test_uncertainty_metrics.py
@@ -5,6 +5,8 @@ import pandas as pd
 import pytest
 
 from kale.evaluate.uncertainty_metrics import (
+    bin_wise_bound_eval,
+    bin_wise_errors,
     ColumnNames,
     DataProcessor,
     evaluate_bounds,
@@ -619,3 +621,83 @@ class TestJaccardBinResults:
         assert results.mean_all_bins_recall == [0.5, 0.6, 0.7]
         assert results.mean_all_targets_precision == 0.7
         assert results.mean_all_bins_precision == [0.6, 0.7, 0.8]
+
+
+class TestCrossDataFrameIndexAlignment:
+    """Regression tests for issue #553.
+
+    ``bin_wise_bound_eval`` and ``bin_wise_errors`` must group errors by ``uid`` using each
+    frame's own ``Target Index`` column, independently of how ``fold_errors`` and ``fold_bins``
+    are indexed. Before the fix, ``fold_bins`` was filtered with a boolean mask built from
+    ``fold_errors``, so a difference in row order/index between the two frames silently produced
+    the wrong grouping (or raised). These tests deliberately misalign the two frames.
+    """
+
+    @staticmethod
+    def _errors_df():
+        return pd.DataFrame(
+            {
+                "uid": ["u0", "u1", "u2", "u3"],
+                "Target Index": [0, 0, 1, 1],
+                "S-MHA Error": [1.0, 3.0, 5.0, 7.0],
+            }
+        )
+
+    @staticmethod
+    def _bins_df():
+        return pd.DataFrame(
+            {
+                "uid": ["u0", "u1", "u2", "u3"],
+                "Target Index": [0, 0, 1, 1],
+                "S-MHA Uncertainty bins": [0, 1, 0, 1],
+            }
+        )
+
+    def test_bin_wise_errors_misaligned_index(self):
+        """Bins must be grouped by uid even when ``fold_bins`` rows are reordered/reindexed.
+
+        The reordered ``fold_bins`` holds the same per-uid data as the aligned frame; only its
+        row order and index differ. The result must match the aligned case and the hand-computed
+        expectation.
+        """
+        errors_df = self._errors_df()
+        bins_aligned = self._bins_df()
+        # Same data, rows reversed and index reset, so a label-aligned mask taken from
+        # fold_errors points at the wrong rows of fold_bins under cross-frame indexing.
+        bins_misaligned = self._bins_df().iloc[[3, 2, 1, 0]].reset_index(drop=True)
+
+        result = bin_wise_errors(
+            errors_df, bins_misaligned, num_bins=2, targets=[0, 1], uncertainty_key="S-MHA", error_scaling_factor=1
+        )
+
+        # Hand-computed: target 0 -> {bin0: 1.0, bin1: 3.0}, target 1 -> {bin0: 5.0, bin1: 7.0}
+        assert result["mean all targets"] == pytest.approx(4.0)
+        assert result["mean all bins"] == pytest.approx([3.0, 5.0])
+        assert result["all bins"] == [[1.0, 5.0], [3.0, 7.0]]
+
+        aligned = bin_wise_errors(
+            errors_df, bins_aligned, num_bins=2, targets=[0, 1], uncertainty_key="S-MHA", error_scaling_factor=1
+        )
+        assert result["mean all targets"] == pytest.approx(aligned["mean all targets"])
+        assert result["mean all bins"] == pytest.approx(aligned["mean all bins"])
+        assert result["all bins"] == aligned["all bins"]
+
+    def test_bin_wise_bound_eval_misaligned_index(self):
+        """Bound accuracy must not depend on the index alignment between the two frames."""
+        errors_df = self._errors_df()
+        bins_aligned = self._bins_df()
+        bins_misaligned = self._bins_df().iloc[[3, 2, 1, 0]].reset_index(drop=True)
+        fold_bounds_all_targets = [[2.0], [6.0]]  # one threshold per target for num_bins=2
+
+        aligned = bin_wise_bound_eval(
+            fold_bounds_all_targets, errors_df, bins_aligned, targets=[0, 1], uncertainty_type="S-MHA", num_bins=2
+        )
+        misaligned = bin_wise_bound_eval(
+            fold_bounds_all_targets, errors_df, bins_misaligned, targets=[0, 1], uncertainty_type="S-MHA", num_bins=2
+        )
+
+        # With these bounds every error falls inside its own bin, so accuracy is perfect,
+        # and the misaligned frame must yield the same result.
+        assert aligned["mean all targets"] == pytest.approx(1.0)
+        assert misaligned["mean all targets"] == pytest.approx(aligned["mean all targets"])
+        assert misaligned["mean all bins"] == pytest.approx(aligned["mean all bins"])


### PR DESCRIPTION
Fixes #553.

### Description
`bin_wise_bound_eval` and `bin_wise_errors` filtered `fold_bins` using a boolean mask built from a *different* DataFrame (`fold_errors["Target Index"] == target_idx`). This relied on `fold_errors` and `fold_bins` always sharing an identical index and row order. That invariant holds for the current callers — both frames are sibling slices of the same `data_structs` taken with the same `Testing Fold == fold` mask — but it is implicit and fragile: if either frame is ever reindexed independently, pandas aligns by index and silently returns the wrong rows.

Both functions now filter `fold_bins` on its own `Target Index` column, removing the hidden cross-DataFrame alignment dependency. Because the two frames are aligned today, the change is behavior-preserving for existing callers; it hardens against a latent, silent mis-grouping bug.

Adds `TestCrossDataFrameIndexAlignment`, which deliberately reorders/reindexes `fold_bins` and asserts that grouping is still by `uid`:
- `test_bin_wise_errors_misaligned_index` — checks a hand-computed expectation and equality with the aligned result.
- `test_bin_wise_bound_eval_misaligned_index` — checks bound accuracy is identical for aligned vs misaligned frames.

Both tests fail on the previous cross-frame indexing and pass with this fix.

### Status
Ready

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] Source for documentation at `docs` manually updated for new API.