### PR TITLE
Correct "seperated" to "separated" in uncertainty result keys

### DIFF
--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -23,7 +23,6 @@ Main Classes:
     - QuantileCalculator: Quantile-based error distribution analysis
     - MetricsCalculator: Statistical metrics computation
 """
-
 import copy
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -1545,12 +1544,12 @@ def evaluate_bounds(
             ]
 
             for target_idx in range(len(all_concat_errorbound_bins_target_sep_foldwise)):
-                all_concat_errorbound_bins_target_sep_foldwise[target_idx][model + " " + uncertainty_type] = (
-                    fold_all_bins_concat_targets_sep_foldwise[target_idx]
-                )
-                all_concat_errorbound_bins_target_sep_all[target_idx][model + " " + uncertainty_type] = (
-                    fold_all_bins_concat_targets_sep_all[target_idx]
-                )
+                all_concat_errorbound_bins_target_sep_foldwise[target_idx][
+                    model + " " + uncertainty_type
+                ] = fold_all_bins_concat_targets_sep_foldwise[target_idx]
+                all_concat_errorbound_bins_target_sep_all[target_idx][
+                    model + " " + uncertainty_type
+                ] = fold_all_bins_concat_targets_sep_all[target_idx]
 
     return {
         "error_bounds_all": all_bound_percents,
@@ -1871,12 +1870,12 @@ def get_mean_errors(
             all_concat_error_bins_target_nosep[model + " " + uncertainty_type] = fold_all_bins_concat_targets_nosep
 
             for target_idx in range(len(fold_all_bins_concat_targets_sep_foldwise)):
-                all_concat_error_bins_target_sep_foldwise[target_idx][model + " " + uncertainty_type] = (
-                    fold_all_bins_concat_targets_sep_foldwise[target_idx]
-                )
-                all_concat_error_bins_target_sep_all[target_idx][model + " " + uncertainty_type] = (
-                    fold_all_bins_concat_targets_sep_all[target_idx]
-                )
+                all_concat_error_bins_target_sep_foldwise[target_idx][
+                    model + " " + uncertainty_type
+                ] = fold_all_bins_concat_targets_sep_foldwise[target_idx]
+                all_concat_error_bins_target_sep_all[target_idx][
+                    model + " " + uncertainty_type
+                ] = fold_all_bins_concat_targets_sep_all[target_idx]
 
     return {
         "all_mean_error_bins_nosep": all_mean_error_bins,

--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -23,6 +23,7 @@ Main Classes:
     - QuantileCalculator: Quantile-based error distribution analysis
     - MetricsCalculator: Statistical metrics computation
 """
+
 import copy
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -53,7 +54,7 @@ class ResultKeys:
     MEAN_ALL_TARGETS = "mean all targets"
     MEAN_ALL_BINS = "mean all bins"
     ALL_BINS = "all bins"
-    ALL_BINS_CONCAT_TARGETS_SEP = "all bins concatenated targets seperated"
+    ALL_BINS_CONCAT_TARGETS_SEP = "all bins concatenated targets separated"
 
     # Bounds specific
     ERROR_BOUNDS_ALL = "error_bounds_all"
@@ -70,11 +71,11 @@ class ResultKeys:
 
     # Jaccard specific
     JACCARD_ALL = "jaccard_all"
-    JACCARD_TARGETS_SEPARATED = "Jaccard targets seperated"
+    JACCARD_TARGETS_SEPARATED = "Jaccard targets separated"
     RECALL_ALL = "recall_all"
-    RECALL_TARGETS_SEPARATED = "Recall targets seperated"
+    RECALL_TARGETS_SEPARATED = "Recall targets separated"
     PRECISION_ALL = "precision_all"
-    PRECISION_TARGETS_SEPARATED = "Precision targets seperated"
+    PRECISION_TARGETS_SEPARATED = "Precision targets separated"
     ALL_JACC_CONCAT_BINS_TARGET_SEP_FOLDWISE = "all jacc concat bins targets sep foldwise"
     ALL_JACC_CONCAT_BINS_TARGET_SEP_ALL = "all_jaccard_concat_bins_targets_sep_all"
 
@@ -1528,11 +1529,11 @@ def evaluate_bounds(
                     for target_idx in range(len(targets)):
                         fold_all_bins_concat_targets_sep_foldwise[target_idx][idx_bin] = (
                             fold_all_bins_concat_targets_sep_foldwise[target_idx][idx_bin]
-                            + return_dict["all bins concatenated targets seperated"][target_idx][idx_bin]
+                            + return_dict["all bins concatenated targets separated"][target_idx][idx_bin]
                         )
                         combined = (
                             fold_all_bins_concat_targets_sep_all[target_idx][idx_bin]
-                            + return_dict["all bins concatenated targets seperated"][target_idx][idx_bin]
+                            + return_dict["all bins concatenated targets separated"][target_idx][idx_bin]
                         )
 
                         fold_all_bins_concat_targets_sep_all[target_idx][idx_bin] = combined
@@ -1544,12 +1545,12 @@ def evaluate_bounds(
             ]
 
             for target_idx in range(len(all_concat_errorbound_bins_target_sep_foldwise)):
-                all_concat_errorbound_bins_target_sep_foldwise[target_idx][
-                    model + " " + uncertainty_type
-                ] = fold_all_bins_concat_targets_sep_foldwise[target_idx]
-                all_concat_errorbound_bins_target_sep_all[target_idx][
-                    model + " " + uncertainty_type
-                ] = fold_all_bins_concat_targets_sep_all[target_idx]
+                all_concat_errorbound_bins_target_sep_foldwise[target_idx][model + " " + uncertainty_type] = (
+                    fold_all_bins_concat_targets_sep_foldwise[target_idx]
+                )
+                all_concat_errorbound_bins_target_sep_all[target_idx][model + " " + uncertainty_type] = (
+                    fold_all_bins_concat_targets_sep_all[target_idx]
+                )
 
     return {
         "error_bounds_all": all_bound_percents,
@@ -1740,7 +1741,7 @@ def bin_wise_bound_eval(
         "mean all targets": np.mean(all_target_perc),
         "mean all bins": weighted_ave_binwise,
         "mean all": all_qs_perc,
-        "all bins concatenated targets seperated": all_qs_errorbound_concat_targets_sep,
+        "all bins concatenated targets separated": all_qs_errorbound_concat_targets_sep,
     }
 
 
@@ -1832,7 +1833,7 @@ def get_mean_errors(
                     fold_mean_bins[idx_bin].append(return_dict["mean all bins"][idx_bin])
                     fold_all_bins[idx_bin] = fold_all_bins[idx_bin] + return_dict["all bins"][idx_bin]
 
-                    concat_no_sep = [x[idx_bin] for x in return_dict["all bins concatenated targets seperated"]]
+                    concat_no_sep = [x[idx_bin] for x in return_dict["all bins concatenated targets separated"]]
 
                     flattened_concat_no_sep = [x for sublist in concat_no_sep for x in sublist]
                     flattened_concat_no_sep = [x for sublist in flattened_concat_no_sep for x in sublist]
@@ -1844,13 +1845,13 @@ def get_mean_errors(
                     for target_idx in range(len(targets)):
                         fold_all_bins_concat_targets_sep_foldwise[target_idx][idx_bin] = (
                             fold_all_bins_concat_targets_sep_foldwise[target_idx][idx_bin]
-                            + return_dict["all bins concatenated targets seperated"][target_idx][idx_bin]
+                            + return_dict["all bins concatenated targets separated"][target_idx][idx_bin]
                         )
 
-                        if return_dict["all bins concatenated targets seperated"][target_idx][idx_bin] != []:
+                        if return_dict["all bins concatenated targets separated"][target_idx][idx_bin] != []:
                             combined = (
                                 fold_all_bins_concat_targets_sep_all[target_idx][idx_bin]
-                                + return_dict["all bins concatenated targets seperated"][target_idx][idx_bin][0]
+                                + return_dict["all bins concatenated targets separated"][target_idx][idx_bin][0]
                             )
                         else:
                             combined = fold_all_bins_concat_targets_sep_all[target_idx][idx_bin]
@@ -1870,12 +1871,12 @@ def get_mean_errors(
             all_concat_error_bins_target_nosep[model + " " + uncertainty_type] = fold_all_bins_concat_targets_nosep
 
             for target_idx in range(len(fold_all_bins_concat_targets_sep_foldwise)):
-                all_concat_error_bins_target_sep_foldwise[target_idx][
-                    model + " " + uncertainty_type
-                ] = fold_all_bins_concat_targets_sep_foldwise[target_idx]
-                all_concat_error_bins_target_sep_all[target_idx][
-                    model + " " + uncertainty_type
-                ] = fold_all_bins_concat_targets_sep_all[target_idx]
+                all_concat_error_bins_target_sep_foldwise[target_idx][model + " " + uncertainty_type] = (
+                    fold_all_bins_concat_targets_sep_foldwise[target_idx]
+                )
+                all_concat_error_bins_target_sep_all[target_idx][model + " " + uncertainty_type] = (
+                    fold_all_bins_concat_targets_sep_all[target_idx]
+                )
 
     return {
         "all_mean_error_bins_nosep": all_mean_error_bins,
@@ -1961,5 +1962,5 @@ def bin_wise_errors(fold_errors, fold_bins, num_bins, targets, uncertainty_key, 
         "mean all targets": mean_all_targets,
         "mean all bins": mean_all_bins,
         "all bins": all_qs_error,
-        "all bins concatenated targets seperated": all_qs_error_concat_targets_sep,
+        "all bins concatenated targets separated": all_qs_error_concat_targets_sep,
     }

--- a/tests/evaluate/test_uncertainty_metrics.py
+++ b/tests/evaluate/test_uncertainty_metrics.py
@@ -50,7 +50,7 @@ class TestEvaluateJaccard:
             dummy_test_preds[0], [["S-MHA", "S-MHA Error", "S-MHA Uncertainty"]], num_bins, [0, 1], num_folds=8
         )
         all_jaccard_data = jacc_dict["jaccard_all"]
-        all_jaccard_bins_targets_sep = jacc_dict["Jaccard targets seperated"]
+        all_jaccard_bins_targets_sep = jacc_dict["Jaccard targets separated"]
 
         assert list(all_jaccard_data.keys()) == ["U-NET S-MHA"]
         assert len(all_jaccard_data["U-NET S-MHA"]) == num_bins
@@ -59,7 +59,7 @@ class TestEvaluateJaccard:
         assert len(all_jaccard_bins_targets_sep["U-NET S-MHA"]) == num_bins
         assert (
             len(all_jaccard_bins_targets_sep["U-NET S-MHA"][0]) == 8 * 2
-        )  # because each landmark has 8 folds - they are seperate
+        )  # because each landmark has 8 folds - they are separate
 
     def test_one_fold(self, dummy_test_preds):
         jacc_dict = evaluate_jaccard(
@@ -67,7 +67,7 @@ class TestEvaluateJaccard:
         )
 
         all_jaccard_data = jacc_dict["jaccard_all"]
-        all_jaccard_bins_targets_sep = jacc_dict["Jaccard targets seperated"]
+        all_jaccard_bins_targets_sep = jacc_dict["Jaccard targets separated"]
 
         assert list(all_jaccard_data.keys()) == ["U-NET S-MHA"]
         assert len(all_jaccard_data["U-NET S-MHA"]) == 5
@@ -88,7 +88,7 @@ class TestEvaluateJaccard:
         )
 
         all_jaccard_data = jacc_dict["jaccard_all"]
-        all_jaccard_bins_targets_sep = jacc_dict["Jaccard targets seperated"]
+        all_jaccard_bins_targets_sep = jacc_dict["Jaccard targets separated"]
 
         assert list(all_jaccard_data.keys()) == ["U-NET S-MHA", "U-NET E-MHA"]
         assert len(all_jaccard_data["U-NET S-MHA"]) == len(all_jaccard_data["U-NET E-MHA"]) == 5
@@ -124,7 +124,7 @@ class TestEvaluateBounds:
         assert len(all_bound_percents_notargetsep["U-NET S-MHA"]) == num_bins
         assert (
             len(all_bound_percents_notargetsep["U-NET S-MHA"][0]) == 8 * 2
-        )  # because each landmark has 8 folds - they are seperate
+        )  # because each landmark has 8 folds - they are separate
 
     def test_one_fold(self, dummy_test_preds):
         bound_dict = evaluate_bounds(
@@ -503,7 +503,7 @@ class TestJaccardEvaluator:
 
         # Check that results match expected structure
         assert "jaccard_all" in results
-        assert "Jaccard targets seperated" in results
+        assert "Jaccard targets separated" in results
         assert "recall_all" in results
         assert "precision_all" in results
 


### PR DESCRIPTION
Fixes #551.

### Description
Corrects the misspelling "seperated" -> "separated" in the Quantile Binning uncertainty result keys. The typo appeared in the `ResultKeys` constants and in the corresponding result-dictionary keys produced and consumed across `kale/evaluate/uncertainty_metrics.py` (`bin_wise_bound_eval`, `bin_wise_errors`, `evaluate_bounds`, `get_mean_errors`, and the Jaccard evaluator), plus the assertions in `tests/evaluate/test_uncertainty_metrics.py`.

All producers and consumers are renamed together so the keys stay in sync. The remaining "seperate" comments in the test module are corrected as well, so no misspelling of the word is left in the repository. No `examples/` or `docs/` code references these keys.

**Note - breaking change:** the affected keys are part of the values returned by `evaluate_jaccard`, `evaluate_bounds`, and `get_mean_errors`. Downstream code reading the old misspelled keys (e.g. `results["Jaccard targets seperated"]`) must move to the corrected spelling.

### Status
Ready

### Types of changes
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] Source for documentation at `docs` manually updated for new API.