### PR TITLE
Correct empty-bin scoring and replace magic sentinel in bin_wise_bound_eval

### DIFF
--- a/kale/embed/uncertainty_fitting.py
+++ b/kale/embed/uncertainty_fitting.py
@@ -1,6 +1,6 @@
 """
-Module from the implementation of L. A. Schobs, A. J. Swift and H. Lu, 
-"Uncertainty Estimation for Heatmap-Based Landmark Localization," 
+Module from the implementation of L. A. Schobs, A. J. Swift and H. Lu,
+"Uncertainty Estimation for Heatmap-Based Landmark Localization,"
 in IEEE Transactions on Medical Imaging, vol. 42, no. 4, pp. 1021-1034, April 2023, doi: 10.1109/TMI.2022.3222730.
 
 Functions related to use the validation data to fit the uncertainty boundaries with error bounds. Also bins the test

--- a/kale/embed/uncertainty_fitting.py
+++ b/kale/embed/uncertainty_fitting.py
@@ -1,5 +1,7 @@
 """
-Module from the implementation of L. A. Schobs, A. J. Swift and H. Lu, "Uncertainty Estimation for Heatmap-Based Landmark Localization," in IEEE Transactions on Medical Imaging, vol. 42, no. 4, pp. 1021-1034, April 2023, doi: 10.1109/TMI.2022.3222730.
+Module from the implementation of L. A. Schobs, A. J. Swift and H. Lu, 
+"Uncertainty Estimation for Heatmap-Based Landmark Localization," 
+in IEEE Transactions on Medical Imaging, vol. 42, no. 4, pp. 1021-1034, April 2023, doi: 10.1109/TMI.2022.3222730.
 
 Functions related to use the validation data to fit the uncertainty boundaries with error bounds. Also bins the test
 data and saves the results.

--- a/kale/embed/uncertainty_fitting.py
+++ b/kale/embed/uncertainty_fitting.py
@@ -1,9 +1,8 @@
 """
-Module from the implementation of L. A. Schobs, A. J. Swift and H. Lu, "Uncertainty Estimation for Heatmap-Based Landmark Localization,"
-in IEEE Transactions on Medical Imaging, vol. 42, no. 4, pp. 1021-1034, April 2023, doi: 10.1109/TMI.2022.3222730.
+Module from the implementation of L. A. Schobs, A. J. Swift and H. Lu, "Uncertainty Estimation for Heatmap-Based Landmark Localization," in IEEE Transactions on Medical Imaging, vol. 42, no. 4, pp. 1021-1034, April 2023, doi: 10.1109/TMI.2022.3222730.
 
-Functions related to use the validation data to fit the uncertainty boundaries with error bounds.
-Also bins the test data and saves the results.
+Functions related to use the validation data to fit the uncertainty boundaries with error bounds. Also bins the test
+data and saves the results.
 """
 
 import logging

--- a/kale/evaluate/similarity_metrics.py
+++ b/kale/evaluate/similarity_metrics.py
@@ -83,8 +83,8 @@ def _quantile_thresholds(uncertainty_values: np.ndarray, num_bins: int, combine_
     Args:
         uncertainty_values (np.ndarray): Uncertainty values across all folds.
         num_bins (int): Number of quantile bins.
-        combine_middle_bins (bool): If True, keep only the outer thresholds, so the middle bins merge
-            into a single bin and only the two edge bins remain distinct.
+        combine_middle_bins (bool): If True, keep only the outer thresholds, so the middle bins merge into a single bin
+            and only the two edge bins remain distinct.
 
     Returns:
         list: The threshold values, ordered from lowest to highest uncertainty.
@@ -107,24 +107,24 @@ def evaluate_correlations(
     config: Optional[CorrelationConfig] = None,
 ) -> Dict[str, Dict[str, Dict[str, Any]]]:
     """
-    Calculate the correlation between error and uncertainty for each model and uncertainty type over all
-    testing folds, fitting a piece-wise linear regression between the quantile thresholds.
+    Calculate the correlation between error and uncertainty for each model and uncertainty type over all testing folds,
+    fitting a piece-wise linear regression between the quantile thresholds.
 
     Designed for use in Quantile Binning (/pykale/examples/landmark_uncertainty/main.py).
 
     Args:
         bin_predictions: A dictionary of Pandas DataFrames containing model predictions for each testing fold.
-        uncertainty_error_pairs: A list of tuples specifying the names of the uncertainty,
-            error, and uncertainty inversion keys for each pair.
+        uncertainty_error_pairs: A list of tuples specifying the names of the uncertainty, error, and uncertainty
+            inversion keys for each pair.
         confidence_invert_tuples: A list of tuples specifying whether to invert the uncertainty values for each method.
-                          First element is a string specifying the uncertainty method name and the second element is
-                          a boolean whether to invert e.g. [["E-MHA", True], ["E-CPV", False]]
+            First element is a string specifying the uncertainty method name and the second element is a boolean whether
+            to invert e.g. [["E-MHA", True], ["E-CPV", False]]
         config: Analysis, plotting and output settings. Defaults to :class:`CorrelationConfig`.
 
     Returns:
         The correlation statistics for each model and uncertainty type, as returned by
-        :func:`kale.interpret.uncertainty_utils.analyze_and_plot_uncertainty_correlation`:
-        ``{<model_name>: {<uncertainty_name>: {"spearman": [coefficient, p_value], "pearson": [coefficient, p_value]}}}``.
+        :func:`kale.interpret.uncertainty_utils.analyze_and_plot_uncertainty_correlation`: ``{<model_name>:
+        {<uncertainty_name>: {"spearman": [coefficient, p_value], "pearson": [coefficient, p_value]}}}``.
     """
     config = config or CorrelationConfig()
 

--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -1584,6 +1584,41 @@ def evaluate_jaccard(bin_predictions, uncertainty_pairs, num_bins, targets, num_
     return evaluator.evaluate(bin_predictions, uncertainty_pairs, targets)
 
 
+def _bin_error_bounds(q: int, num_bins: int, fold_bounds: list) -> Tuple[float, float]:
+    """Return the ``(lower, upper]`` error bounds for quantile bin ``q``.
+
+    The first bin starts at 0 and the last bin is open above (``inf``); the intermediate bins
+    take their bounds from consecutive entries of ``fold_bounds``.
+
+    Args:
+        q (int): Index of the quantile bin.
+        num_bins (int): Total number of quantile bins.
+        fold_bounds (list): Estimated error bounds for this target, one per bin edge.
+
+    Returns:
+        tuple: The ``(lower, upper)`` bounds, where membership is ``lower < error <= upper``.
+    """
+    if q == 0:
+        return 0, fold_bounds[q]
+    if q < num_bins - 1:
+        return fold_bounds[q - 1], fold_bounds[q]
+    return fold_bounds[q - 1], float("inf")
+
+
+def _count_within_bounds(errors: list, lower: float, upper: float) -> int:
+    """Count how many ``errors`` fall in the half-open interval ``(lower, upper]``.
+
+    Args:
+        errors (list): Error values in a single bin.
+        lower (float): Exclusive lower bound.
+        upper (float): Inclusive upper bound (``inf`` for the open-ended last bin).
+
+    Returns:
+        int: The number of errors within the bounds.
+    """
+    return sum(1 for error in errors if lower < error <= upper)
+
+
 def bin_wise_bound_eval(
     fold_bounds_all_targets: list,
     fold_errors: pd.DataFrame,
@@ -1659,33 +1694,10 @@ def bin_wise_bound_eval(
         bins_acc = []
         bins_sizes = []
         for q in range((num_bins)):
-            inner_bin_correct = 0
-
             inbin_errors = pred_bins_errors[q]
 
-            for error in inbin_errors:
-                if q == 0:
-                    lower = 0
-                    upper = fold_bounds[q]
-
-                    if error <= upper and error > lower:
-                        inner_bin_correct += 1
-
-                elif q < (num_bins) - 1:
-                    lower = fold_bounds[q - 1]
-                    upper = fold_bounds[q]
-
-                    if error <= upper and error > lower:
-                        inner_bin_correct += 1
-
-                else:
-                    lower = fold_bounds[q - 1]
-                    upper = float("inf")
-
-                    # ``upper`` is unbounded for the last bin, so ``error <= upper`` is always true;
-                    # writing the condition the same way as the other bins keeps them consistent.
-                    if error <= upper and error > lower:
-                        inner_bin_correct += 1
+            lower, upper = _bin_error_bounds(q, num_bins, fold_bounds)
+            inner_bin_correct = _count_within_bounds(inbin_errors, lower, upper)
 
             if len(inbin_errors) == 0:
                 accuracy_bin = 1.0

--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -1682,7 +1682,9 @@ def bin_wise_bound_eval(
                     lower = fold_bounds[q - 1]
                     upper = float("inf")
 
-                    if error > lower:
+                    # ``upper`` is unbounded for the last bin, so ``error <= upper`` is always true;
+                    # writing the condition the same way as the other bins keeps them consistent.
+                    if error <= upper and error > lower:
                         inner_bin_correct += 1
 
             if len(inbin_errors) == 0:

--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -1680,15 +1680,15 @@ def bin_wise_bound_eval(
 
                 else:
                     lower = fold_bounds[q - 1]
-                    upper = 999999999999999999999999999999
+                    upper = float("inf")
 
                     if error > lower:
                         inner_bin_correct += 1
 
-            if inner_bin_correct == 0:
-                accuracy_bin = 0.0
-            elif len(inbin_errors) == 0:
+            if len(inbin_errors) == 0:
                 accuracy_bin = 1.0
+            elif inner_bin_correct == 0:
+                accuracy_bin = 0.0
             else:
                 accuracy_bin = inner_bin_correct / len(inbin_errors)
             bins_sizes.append(len(inbin_errors))

--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -1619,6 +1619,66 @@ def _count_within_bounds(errors: list, lower: float, upper: float) -> int:
     return sum(1 for error in errors if lower < error <= upper)
 
 
+def _bin_accuracy(inbin_errors: list, lower: float, upper: float) -> float:
+    """Score a single quantile bin: the fraction of its errors within ``(lower, upper]``.
+
+    An empty bin scores ``1.0`` (issue #549): there is no prediction to be wrong about.
+
+    Args:
+        inbin_errors (list): Errors of the samples assigned to this bin.
+        lower (float): Exclusive lower bound.
+        upper (float): Inclusive upper bound (``inf`` for the open-ended last bin).
+
+    Returns:
+        float: ``1.0`` for an empty bin, otherwise the proportion of errors within the bounds.
+    """
+    if len(inbin_errors) == 0:
+        return 1.0
+    return _count_within_bounds(inbin_errors, lower, upper) / len(inbin_errors)
+
+
+def _group_target_errors_by_bin(pred_bins_ti: dict, true_errors_ti: dict, num_bins: int) -> List[List[float]]:
+    """Group a target's errors by the predicted quantile bin of each sample.
+
+    Bin membership and uid matching use string comparison, mirroring the legacy call site so that
+    numeric and string keys (e.g. ``1`` vs ``"1"``) are treated as equal.
+
+    Args:
+        pred_bins_ti (dict): Maps each sample uid to its predicted quantile bin.
+        true_errors_ti (dict): Maps each sample uid to its true error.
+        num_bins (int): Total number of quantile bins.
+
+    Returns:
+        list: ``num_bins`` lists, each holding the errors whose samples fall in that bin, in the
+        order the samples appear in ``pred_bins_ti``.
+    """
+    errors_by_uid = {str(uid): error for uid, error in true_errors_ti.items()}
+    binned_errors: List[List[float]] = [[] for _ in range(num_bins)]
+    for uid, bin_val in pred_bins_ti.items():
+        bin_str = str(bin_val)
+        for i in range(num_bins):
+            if str(i) == bin_str:
+                binned_errors[i].append(errors_by_uid[str(uid)])
+                break
+    return binned_errors
+
+
+def _weighted_average(values: list, weights: list) -> float:
+    """Return the ``weights``-weighted mean of ``values``, or ``0.0`` if the weights sum to zero.
+
+    Args:
+        values (list): Per-item values (e.g. per-bin accuracies).
+        weights (list): Non-negative weights aligned with ``values`` (e.g. per-bin sample counts).
+
+    Returns:
+        float: The size-weighted mean, or ``0.0`` when all weights are zero.
+    """
+    total_weight = sum(weights)
+    if total_weight == 0:
+        return 0.0
+    return sum(value * weight for value, weight in zip(values, weights)) / total_weight
+
+
 def bin_wise_bound_eval(
     fold_bounds_all_targets: list,
     fold_errors: pd.DataFrame,
@@ -1678,18 +1738,8 @@ def bin_wise_bound_eval(
         # If bin=0 then lower bound = 0, if bin=Q then no upper bound
         # Keep track of #samples in each bin for weighted mean.
 
-        # turn dictionary of predicted bins into [[num_bins]] array
-        pred_bins_keys = []
-        pred_bins_errors = []
-        for i in range(num_bins):
-            inner_list_bin = list([key for key, val in pred_bins_ti.items() if str(i) == str(val)])
-            inner_list_errors = []
-
-            for id_ in inner_list_bin:
-                inner_list_errors.append(list([val for key, val in true_errors_ti.items() if str(key) == str(id_)])[0])
-
-            pred_bins_errors.append(inner_list_errors)
-            pred_bins_keys.append(inner_list_bin)
+        # turn dictionary of predicted bins into [[num_bins]] array of errors
+        pred_bins_errors = _group_target_errors_by_bin(pred_bins_ti, true_errors_ti, num_bins)
 
         bins_acc = []
         bins_sizes = []
@@ -1697,14 +1747,7 @@ def bin_wise_bound_eval(
             inbin_errors = pred_bins_errors[q]
 
             lower, upper = _bin_error_bounds(q, num_bins, fold_bounds)
-            inner_bin_correct = _count_within_bounds(inbin_errors, lower, upper)
-
-            if len(inbin_errors) == 0:
-                accuracy_bin = 1.0
-            elif inner_bin_correct == 0:
-                accuracy_bin = 0.0
-            else:
-                accuracy_bin = inner_bin_correct / len(inbin_errors)
+            accuracy_bin = _bin_accuracy(inbin_errors, lower, upper)
             bins_sizes.append(len(inbin_errors))
             bins_acc.append(accuracy_bin)
 
@@ -1713,36 +1756,12 @@ def bin_wise_bound_eval(
             all_qs_errorbound_concat_targets_sep[i_ti][q].append(accuracy_bin)
 
         # Weighted average over all bins
-        weighted_mean_ti = 0.0
-        total_weights = 0.0
-        for l_idx in range(len(bins_sizes)):
-            bin_acc = bins_acc[l_idx]
-            bin_size = bins_sizes[l_idx]
-            weighted_mean_ti += bin_acc * bin_size
-            total_weights += bin_size
-        weighted_ave = weighted_mean_ti / total_weights
-        all_target_perc.append(weighted_ave)
+        all_target_perc.append(_weighted_average(bins_acc, bins_sizes))
 
     # Weighted average for each of the quantile bins.
     weighted_ave_binwise = []
     for binidx in range(len(all_qs_perc)):
-        bin_accs = all_qs_perc[binidx]
-        bin_asizes = all_qs_size[binidx]
-
-        weighted_mean_bin = 0.0
-        total_weights_bin = 0.0
-        for l_idx in range(len(bin_accs)):
-            b_acc = bin_accs[l_idx]
-            b_siz = bin_asizes[l_idx]
-            weighted_mean_bin += b_acc * b_siz
-            total_weights_bin += b_siz
-
-        # Avoid div by 0
-        if weighted_mean_bin == 0 or total_weights_bin == 0:
-            weighted_ave_bin = 0.0
-        else:
-            weighted_ave_bin = weighted_mean_bin / total_weights_bin
-        weighted_ave_binwise.append(weighted_ave_bin)
+        weighted_ave_binwise.append(_weighted_average(all_qs_perc[binidx], all_qs_size[binidx]))
 
     # No weighted average, just normal average
     normal_ave_bin_wise = []

--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -1790,8 +1790,10 @@ def bin_wise_errors(fold_errors, fold_bins, num_bins, targets, uncertainty_key, 
     Args:
         fold_errors (Pandas Dataframe): Pandas Dataframe of errors for this fold.
         fold_bins (Pandas Dataframe): Pandas Dataframe of predicted quantile bins for this fold.
-        num_bins (int): Number of quantile bins, targets (list) list of targets to measure uncertainty estimation,
-        uncertainty_key (string): Name of uncertainty type to calculate accuracy for,
+        num_bins (int): Number of quantile bins.
+        targets (list): list of targets to measure uncertainty estimation.
+        uncertainty_key (string): Name of uncertainty type to calculate accuracy for.
+        error_scaling_factor (float): Factor to scale the errors by.
 
 
     Returns:

--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -1664,18 +1664,18 @@ def _group_target_errors_by_bin(pred_bins_ti: dict, true_errors_ti: dict, num_bi
 
 
 def _weighted_average(values: list, weights: list) -> float:
-    """Return the ``weights``-weighted mean of ``values``, or ``0.0`` if the weights sum to zero.
+    """Return the ``weights``-weighted mean of ``values``, or ``nan`` if the weights sum to zero.
 
     Args:
         values (list): Per-item values (e.g. per-bin accuracies).
         weights (list): Non-negative weights aligned with ``values`` (e.g. per-bin sample counts).
 
     Returns:
-        float: The size-weighted mean, or ``0.0`` when all weights are zero.
+        float: The size-weighted mean, or ``nan`` when all weights are zero.
     """
     total_weight = sum(weights)
     if total_weight == 0:
-        return 0.0
+        return float("nan")
     return sum(value * weight for value, weight in zip(values, weights)) / total_weight
 
 
@@ -1702,7 +1702,8 @@ def bin_wise_bound_eval(
     Returns:
         dict: A dictionary containing the following error bound accuracy statistics:
               - 'mean all targets': The mean accuracy over all targets and quantile bins.
-              - 'mean all bins': A list of mean accuracy values for each quantile bin (all targets included).
+              - 'mean all bins': A list of mean accuracy values for each quantile bin (all targets included),
+               weighted by bin size; ``nan`` for a bin that is empty for every target.
               - 'mean all': A list of accuracy values for each quantile bin and target, weighted by # targets in each bin.
               - 'all bins concatenated targets separated': A list of accuracy values for each quantile bin, concatenated
                for each target separately.

--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -86,26 +86,21 @@ class EvaluationConfig:
     """
     Configuration parameters for uncertainty quantification evaluation.
 
-    This dataclass defines the settings and parameters used throughout the
-    evaluation process for uncertainty quantification metrics. It provides
-    default values for common evaluation scenarios while allowing customization
-    for specific research needs.
+    This dataclass defines the settings and parameters used throughout the evaluation process for uncertainty
+    quantification metrics. It provides default values for common evaluation scenarios while allowing customization for
+    specific research needs.
 
     Attributes:
-        num_folds (int): Number of cross-validation folds for evaluation.
-            Defaults to 8. Higher values provide more robust statistical
-            estimates but increase computational cost.
-        original_num_bins (int): Number of quantile bins for uncertainty
-            evaluation. Defaults to 10. Controls the granularity of
-            uncertainty analysis.
-        error_scaling_factor (float): Scaling factor applied to prediction
-            errors during evaluation. Defaults to 1.0 (no scaling).
-        combine_middle_bins (bool): Whether to combine middle uncertainty
-            bins for simplified analysis. Defaults to False. When True,
-            reduces evaluation complexity by merging intermediate quantiles.
-        combined_num_bins (int): Number of bins when middle bins are combined.
-            Defaults to 3 (low, medium, high uncertainty). Only used when
-            combine_middle_bins is True.
+        num_folds (int): Number of cross-validation folds for evaluation. Defaults to 8. Higher values provide more
+            robust statistical estimates but increase computational cost.
+        original_num_bins (int): Number of quantile bins for uncertainty evaluation. Defaults to 10. Controls the
+            granularity of uncertainty analysis.
+        error_scaling_factor (float): Scaling factor applied to prediction errors during evaluation. Defaults to 1.0 (no
+            scaling).
+        combine_middle_bins (bool): Whether to combine middle uncertainty bins for simplified analysis. Defaults to
+            False. When True, reduces evaluation complexity by merging intermediate quantiles.
+        combined_num_bins (int): Number of bins when middle bins are combined. Defaults to 3 (low, medium, high
+            uncertainty). Only used when combine_middle_bins is True.
 
     Example:
 
@@ -131,17 +126,16 @@ class FoldData:
     """
     Container for evaluation data from a single cross-validation fold.
 
-    This dataclass organizes the data required for evaluating a single fold
-    in cross-validation, including prediction errors, uncertainty bins, and
-    optional error bounds information.
+    This dataclass organizes the data required for evaluating a single fold in cross-validation, including prediction
+    errors, uncertainty bins, and optional error bounds information.
 
     Attributes:
-        errors (pd.DataFrame): DataFrame containing prediction errors for the fold.
-            Expected columns include UID, target_idx, and model-specific error columns.
-        bins (pd.DataFrame): DataFrame containing uncertainty bin assignments.
-            Expected columns include UID, target_idx, and uncertainty bin columns.
-        bounds (Optional[List]): Optional list containing error bound information
-            for bound-based evaluation methods. Defaults to None.
+        errors (pd.DataFrame): DataFrame containing prediction errors for the fold. Expected columns include UID,
+            target_idx, and model-specific error columns.
+        bins (pd.DataFrame): DataFrame containing uncertainty bin assignments. Expected columns include UID, target_idx,
+            and uncertainty bin columns.
+        bounds (Optional[List]): Optional list containing error bound information for bound-based evaluation methods.
+            Defaults to None.
 
     Example:
 
@@ -164,23 +158,17 @@ class BinResults:
     """
     Base container for evaluation results from a single fold.
 
-    This dataclass stores the fundamental evaluation metrics computed for a single
-    cross-validation fold, organized by targets and bins. Serves as the base class
-    for specialized result containers like JaccardBinResults.
+    This dataclass stores the fundamental evaluation metrics computed for a single cross-validation fold, organized by
+    targets and bins. Serves as the base class for specialized result containers like JaccardBinResults.
 
     Attributes:
         mean_all_targets (float): Mean evaluation metric across all targets in the fold.
-        mean_all_bins (List[float]): Mean evaluation metric for each bin across targets.
-            Length equals the number of bins.
-        all_bins (List[List[float]]): Raw evaluation metrics for each bin and target.
-            Outer list represents bins, inner lists contain values for each target.
-        all_bins_concat_targets_sep (List[List[List[float]]]): Evaluation metrics
-            organized for target-separated analysis. Structure: [target][bin][values].
-
-    Note:
-        This base class provides the common structure for fold-level results.
-        Subclasses can extend it with additional metrics specific to their
-        evaluation type (e.g., precision and recall for Jaccard evaluation).
+        mean_all_bins (List[float]): Mean evaluation metric for each bin across targets. Length equals the number of
+            bins.
+        all_bins (List[List[float]]): Raw evaluation metrics for each bin and target. Outer list represents bins, inner
+            lists contain values for each target.
+        all_bins_concat_targets_sep (List[List[List[float]]]): Evaluation metrics organized for target-separated
+            analysis. Structure: [target][bin][values].
     """
 
     mean_all_targets: float
@@ -194,9 +182,9 @@ class JaccardBinResults(BinResults):
     """
     Extended results container for Jaccard similarity evaluation with precision and recall.
 
-    This specialized container extends BinResults to include additional metrics
-    specific to Jaccard similarity evaluation: precision and recall. These metrics
-    provide comprehensive assessment of uncertainty quantification quality.
+    This specialized container extends BinResults to include additional metrics specific to Jaccard similarity
+    evaluation: precision and recall. These metrics provide comprehensive assessment of uncertainty quantification
+        quality.
 
     Attributes:
         Inherits from BinResults:
@@ -205,19 +193,13 @@ class JaccardBinResults(BinResults):
             - all_bins: Raw Jaccard similarities for each bin and target
             - all_bins_concat_targets_sep: Target-separated Jaccard similarities
 
-        Additional Jaccard-specific attributes:
-            mean_all_targets_recall (float): Mean recall across all targets in the fold.
-            mean_all_bins_recall (List[float]): Mean recall for each bin across targets.
-            all_bins_recall (List[List[float]]): Raw recall values for each bin and target.
-            mean_all_targets_precision (float): Mean precision across all targets.
-            mean_all_bins_precision (List[float]): Mean precision for each bin.
-            all_bins_precision (List[List[float]]): Raw precision values for each bin and target.
-
-    Note:
-        Precision measures the accuracy of positive predictions within each bin,
-        while recall measures the coverage of actual positive cases. Combined with
-        Jaccard similarity, these metrics provide a complete picture of uncertainty
-        quantification performance.
+        Additional Jaccard-specific attributes: 
+        mean_all_targets_recall (float): Mean recall across all targets in the fold. 
+        mean_all_bins_recall (List[float]): Mean recall for each bin across targets. 
+        all_bins_recall (List[List[float]]): Raw recall values for each bin and target.
+        mean_all_targets_precision (float): Mean precision across all targets. 
+        mean_all_bins_precision (List[float]): Mean precision for each bin.
+        all_bins_precision (List[List[float]]): Raw precision values for each bin and target.
     """
 
     mean_all_targets_recall: float = 0.0
@@ -232,13 +214,11 @@ class ResultsContainer:
     """
     Container for organizing and managing complex nested evaluation results.
 
-    This class provides a structured way to organize evaluation results across
-    different dimensions: models, uncertainty types, bins, targets, and folds.
-    It handles both main aggregated results and target-separated detailed results.
+    This class provides a structured way to organize evaluation results across different dimensions: models, uncertainty
+    types, bins, targets, and folds. It handles both main aggregated results and target-separated detailed results.
 
-    The container supports multiple evaluation metrics and provides methods for
-    adding results in an organized manner. It's designed to work with the
-    Template Method pattern in BaseEvaluator.
+    The container supports multiple evaluation metrics and provides methods for adding results in an organized manner.
+    It's designed to work with the Template Method pattern in BaseEvaluator.
 
     Attributes:
         num_bins (int): Number of uncertainty bins in the evaluation.
@@ -249,11 +229,9 @@ class ResultsContainer:
         target_sep_all (List[Dict]): Target-separated results aggregated across folds.
         additional_containers (Dict): Container for evaluation-specific results.
 
-    Jaccard-specific attributes:
-        recall_results (Dict): Recall metrics for all model-uncertainty combinations.
-        recall_target_separated (Dict): Target-separated recall results.
-        precision_results (Dict): Precision metrics for all combinations.
-        precision_target_separated (Dict): Target-separated precision results.
+    Jaccard-specific attributes: recall_results (Dict): Recall metrics for all model-uncertainty combinations.
+    recall_target_separated (Dict): Target-separated recall results. precision_results (Dict): Precision metrics for all
+        combinations. precision_target_separated (Dict): Target-separated precision results.
 
     Example:
 
@@ -280,9 +258,8 @@ class ResultsContainer:
         """
         Initialize all result containers with empty data structures.
 
-        Sets up the internal data structures needed to organize evaluation results
-        across different dimensions (main results, target-separated results,
-        fold-wise results, and evaluation-specific containers).
+        Sets up the internal data structures needed to organize evaluation results across different dimensions (main
+        results, target-separated results, fold-wise results, and evaluation-specific containers).
         """
         # Main results
         self.main_results = {}
@@ -314,12 +291,11 @@ class DataProcessor:
     """
     Utility class for data processing operations in uncertainty evaluation.
 
-    This class provides static methods for extracting and filtering data from
-    DataFrames for evaluation purposes. It handles fold-specific data extraction,
-    target filtering, and data structure preparation for evaluation workflows.
+    This class provides static methods for extracting and filtering data from DataFrames for evaluation purposes. It
+    handles fold-specific data extraction, target filtering, and data structure preparation for evaluation workflows.
 
-    The class is designed as a collection of utility methods that can be used
-    across different evaluator implementations without maintaining state.
+    The class is designed as a collection of utility methods that can be used across different evaluator implementations
+    without maintaining state.
 
     Key Operations:
         - Extract data for specific cross-validation folds
@@ -341,26 +317,19 @@ class DataProcessor:
         """
         Extract data for a specific cross-validation fold and uncertainty type.
 
-        Filters the input DataFrame to extract only the data belonging to the specified
-        fold and prepares separate DataFrames for errors and uncertainty bins.
+        Filters the input DataFrame to extract only the data belonging to the specified fold and prepares separate
+        DataFrames for errors and uncertainty bins.
 
         Args:
-            data_structs (pd.DataFrame): Complete dataset containing all folds and data.
-                Must include columns for fold identification, UIDs, target indices,
-                errors, and uncertainty bins.
+            data_structs (pd.DataFrame): Complete dataset containing all folds and data. Must include columns for fold
+                identification, UIDs, target indices, errors, and uncertainty bins.
             fold (int): The specific fold number to extract (0-based indexing).
-            uncertainty_type (str): Type of uncertainty to extract (e.g., "epistemic", "aleatoric").
-                Used to construct column names for error and bin data.
+            uncertainty_type (str): Type of uncertainty to extract (e.g., "epistemic", "aleatoric"). Used to construct
+                column names for error and bin data.
 
         Returns:
-            FoldData: Container with filtered errors and bins DataFrames for the specified
-                fold and uncertainty type. Contains UIDs, target indices, and corresponding
-                error and bin values.
-
-        Note:
-            The method expects specific column naming conventions:
-            - Error columns: "{uncertainty_type} Error"
-            - Bin columns: "{uncertainty_type} Uncertainty bins"
+            FoldData: Container with filtered errors and bins DataFrames for the specified fold and uncertainty type.
+                Contains UIDs, target indices, and corresponding error and bin values.
         """
         fold_mask = data_structs[ColumnNames.TESTING_FOLD] == fold
 
@@ -379,15 +348,14 @@ class DataProcessor:
         """
         Group prediction data by their assigned uncertainty bins.
 
-        Organizes prediction keys and errors into bin-wise groups based on their
-        uncertainty bin assignments. This enables bin-wise evaluation of prediction
-        quality and uncertainty calibration.
+        Organizes prediction keys and errors into bin-wise groups based on their uncertainty bin assignments. This
+        enables bin-wise evaluation of prediction quality and uncertainty calibration.
 
         Args:
-            errors_dict (Dict): Dictionary mapping prediction keys to error values.
-                Keys should correspond to unique prediction identifiers.
-            bins_dict (Dict): Dictionary mapping prediction keys to bin assignments.
-                Values should be bin indices (0 to num_bins-1).
+            errors_dict (Dict): Dictionary mapping prediction keys to error values. Keys should correspond to unique
+                prediction identifiers.
+            bins_dict (Dict): Dictionary mapping prediction keys to bin assignments. Values should be bin indices (0 to
+                num_bins-1).
             num_bins (int): Total number of uncertainty bins used in the evaluation.
 
         Returns:
@@ -424,13 +392,11 @@ class QuantileCalculator:
     """
     Utility class for calculating quantile-based error distributions and thresholds.
 
-    This class provides methods for computing quantile boundaries and grouping
-    prediction errors into quantile-based bins. It supports both standard
-    quantile binning and combined middle bin configurations for simplified analysis.
+    This class provides methods for computing quantile boundaries and grouping prediction errors into quantile-based
+    bins. It supports both standard quantile binning and combined middle bin configurations for simplified analysis.
 
-    The quantile approach enables analysis of prediction quality across different
-    uncertainty levels by creating bins that contain equal numbers of predictions
-    but varying error characteristics.
+    The quantile approach enables analysis of prediction quality across different uncertainty levels by creating bins
+    that contain equal numbers of predictions but varying error characteristics.
 
     Key Features:
         - Automatic quantile threshold calculation
@@ -456,17 +422,15 @@ class QuantileCalculator:
         """
         Calculate quantile thresholds and group errors into quantile-based bins.
 
-        Computes quantile boundaries based on the error distribution and groups
-        errors and their corresponding keys into bins. Supports combining middle
-        bins for simplified three-bin analysis (low, medium, high error).
+        Computes quantile boundaries based on the error distribution and groups errors and their corresponding keys into
+        bins. Supports combining middle bins for simplified three-bin analysis (low, medium, high error).
 
         Args:
-            errors_dict (Dict): Dictionary mapping prediction keys to error values.
-                Used to compute quantile boundaries from the error distribution.
-            num_bins (int): Number of quantile bins to create. Determines the
-                granularity of the quantile analysis.
-            combine_middle_bins (bool): Whether to combine middle quantiles into
-                a single bin. When True, creates 3 bins regardless of num_bins.
+            errors_dict (Dict): Dictionary mapping prediction keys to error values. Used to compute quantile boundaries
+                from the error distribution.
+            num_bins (int): Number of quantile bins to create. Determines the granularity of the quantile analysis.
+            combine_middle_bins (bool): Whether to combine middle quantiles into a single bin. When True, creates 3 bins
+                regardless of num_bins.
 
         Returns:
             Tuple[List[float], List[List], List[List]]: A tuple containing:
@@ -475,8 +439,8 @@ class QuantileCalculator:
                 - key_groups: List of prediction key lists for each bin (worst to best)
 
         Note:
-            Results are ordered from worst to best performance (B5 to B1 convention)
-            to match the expected evaluation output format.
+            Results are ordered from worst to best performance (B5 to B1 convention) to match the expected evaluation
+            output format.
 
         Example:
 
@@ -506,13 +470,12 @@ class QuantileCalculator:
         """
         Group errors and keys by quantile thresholds.
 
-        Helper method that partitions prediction errors and their corresponding keys
-        into groups based on quantile threshold boundaries.
+        Helper method that partitions prediction errors and their corresponding keys into groups based on quantile
+        threshold boundaries.
 
         Args:
             errors_dict (Dict): Dictionary mapping prediction keys to error values.
-            thresholds (List[float]): List of quantile threshold values that define
-                the boundaries between groups.
+            thresholds (List[float]): List of quantile threshold values that define the boundaries between groups.
 
         Returns:
             Tuple[List[List], List[List]]: A tuple containing:
@@ -541,8 +504,8 @@ class QuantileCalculator:
         """
         Check if error falls within the specified quantile range.
 
-        Helper method that determines whether a given error value belongs to
-        the specified quantile group based on threshold boundaries.
+        Helper method that determines whether a given error value belongs to the specified quantile group based on
+        threshold boundaries.
 
         Args:
             error (float): The error value to classify.
@@ -550,8 +513,7 @@ class QuantileCalculator:
             thresholds (List[float]): List of quantile threshold values.
 
         Returns:
-            bool: True if the error falls within the specified quantile range,
-                False otherwise.
+            bool: True if the error falls within the specified quantile range, False otherwise.
         """
         if quantile_idx == 0:
             return error <= thresholds[0]
@@ -565,10 +527,9 @@ class MetricsCalculator:
     """
     Utility class for calculating evaluation metrics in uncertainty quantification.
 
-    This class provides static methods for computing various metrics used to assess
-    the quality of uncertainty quantification, including Jaccard similarity, precision,
-    recall, and bound accuracy. The methods are designed to work with different
-    evaluation strategies and provide consistent metric calculations.
+    This class provides static methods for computing various metrics used to assess the quality of uncertainty
+    quantification, including Jaccard similarity, precision, recall, and bound accuracy. The methods are designed to
+    work with different evaluation strategies and provide consistent metric calculations.
 
     Key Metrics:
         - Jaccard Similarity: Measures overlap between predicted and ground truth sets
@@ -576,8 +537,8 @@ class MetricsCalculator:
         - Recall: Coverage of actual positive cases by predictions
         - Bound Accuracy: Whether errors fall within expected confidence bounds
 
-    The class supports both binary classification metrics (for set-based evaluation)
-    and regression-style bound checking for error prediction accuracy.
+    The class supports both binary classification metrics (for set-based evaluation) and regression-style bound checking
+    for error prediction accuracy.
 
     Example:
 
@@ -595,15 +556,14 @@ class MetricsCalculator:
         """
         Calculate Jaccard similarity, recall, and precision for set-based evaluation.
 
-        Computes three key metrics for assessing the overlap between predicted and
-        ground truth sets of prediction keys. These metrics provide comprehensive
-        evaluation of uncertainty quantification quality within bins.
+        Computes three key metrics for assessing the overlap between predicted and ground truth sets of prediction keys.
+        These metrics provide comprehensive evaluation of uncertainty quantification quality within bins.
 
         Args:
-            predicted_keys (List): List of prediction keys identified by the model
-                as belonging to a specific uncertainty or error bin.
-            ground_truth_keys (List): List of prediction keys that actually belong
-                to the target bin based on true error characteristics.
+            predicted_keys (List): List of prediction keys identified by the model as belonging to a specific
+                uncertainty or error bin.
+            ground_truth_keys (List): List of prediction keys that actually belong to the target bin based on true error
+                characteristics.
 
         Returns:
             Tuple[float, float, float]: A tuple containing:
@@ -657,19 +617,16 @@ class MetricsCalculator:
         """
         Check if error falls within expected bounds for the bin.
 
-        Determines whether a prediction error falls within the expected error bounds
-        for a specific uncertainty bin. This method is used to assess the accuracy
-        of uncertainty-based error predictions.
+        Determines whether a prediction error falls within the expected error bounds for a specific uncertainty bin.
+        This method is used to assess the accuracy of uncertainty-based error predictions.
 
         Args:
             error (float): The prediction error value to check.
             bin_idx (int): Index of the uncertainty bin (0-based).
-            bounds (List[float]): List of error boundary values that define
-                the expected error ranges for each bin.
+            bounds (List[float]): List of error boundary values that define the expected error ranges for each bin.
 
         Returns:
-            bool: True if the error falls within the expected bounds for the
-                specified bin, False otherwise.
+            bool: True if the error falls within the expected bounds for the specified bin, False otherwise.
 
         Note:
             Bin ranges follow the pattern (lower_bound, upper_bound], where:
@@ -689,14 +646,12 @@ class BaseEvaluator(ABC):
     """
     Abstract base class for uncertainty quantification evaluation strategies.
 
-    This class implements the Template Method pattern to provide a consistent evaluation
-    framework while allowing specialized implementations for different metrics (Jaccard,
-    error bounds, etc.). It manages the evaluation workflow across multiple folds,
-    models, and uncertainty types.
+    This class implements the Template Method pattern to provide a consistent evaluation framework while allowing
+    specialized implementations for different metrics (Jaccard, error bounds, etc.). It manages the evaluation workflow
+    across multiple folds, models, and uncertainty types.
 
-    Design Pattern:
-        Uses Template Method pattern where the main evaluation flow is defined in the
-        base class, while specific evaluation logic is implemented by subclasses.
+    Design Pattern: Uses Template Method pattern where the main evaluation flow is defined in the base class, while
+    specific evaluation logic is implemented by subclasses.
 
     Key Features:
         - Cross-validation fold processing
@@ -723,8 +678,8 @@ class BaseEvaluator(ABC):
         Initialize BaseEvaluator with evaluation configuration.
 
         Args:
-            config (EvaluationConfig): Configuration object containing evaluation
-                parameters such as number of folds, bins, and processing options.
+            config (EvaluationConfig): Configuration object containing evaluation parameters such as number of folds,
+                bins, and processing options.
         """
         self.config_ = config
         # Instance variables to reduce parameter passing
@@ -737,22 +692,22 @@ class BaseEvaluator(ABC):
         """
         Main evaluation method implementing the template method pattern.
 
-        Orchestrates the complete evaluation process across all models, uncertainty types,
-        and cross-validation folds. This method defines the evaluation workflow while
-        delegating specific evaluation logic to subclass implementations.
+        Orchestrates the complete evaluation process across all models, uncertainty types, and cross-validation folds.
+        This method defines the evaluation workflow while delegating specific evaluation logic to subclass
+        implementations.
 
         Args:
-            bin_predictions (Dict[str, pd.DataFrame]): Dictionary mapping model names to
-                DataFrames containing bin predictions and evaluation data. Each DataFrame
-                should contain columns for UIDs, target indices, errors, and uncertainty bins.
-            uncertainty_pairs (List): List of uncertainty type pairs to evaluate.
-                Each pair contains uncertainty type names (e.g., ['epistemic'], ['aleatoric']).
-            targets (List[int]): List of target indices to include in the evaluation.
-                Used to filter data and organize results by target.
+            bin_predictions (Dict[str, pd.DataFrame]): Dictionary mapping model names to DataFrames containing bin
+                predictions and evaluation data. Each DataFrame should contain columns for UIDs, target indices, errors,
+                and uncertainty bins.
+            uncertainty_pairs (List): List of uncertainty type pairs to evaluate. Each pair contains uncertainty type
+                names (e.g., ['epistemic'], ['aleatoric']).
+            targets (List[int]): List of target indices to include in the evaluation. Used to filter data and organize
+                results by target.
 
         Returns:
-            Dict: Comprehensive evaluation results dictionary. Structure depends on the
-                specific evaluator implementation but typically includes:
+            Dict: Comprehensive evaluation results dictionary. Structure depends on the specific evaluator
+                implementation but typically includes:
                 - Main results across all folds and targets
                 - Target-separated results for detailed analysis
                 - Additional metrics specific to the evaluation type
@@ -788,22 +743,16 @@ class BaseEvaluator(ABC):
         """
         Process evaluation for a single cross-validation fold.
 
-        This abstract method must be implemented by subclasses to define how
-        evaluation metrics are calculated for data from a single fold.
+        This abstract method must be implemented by subclasses to define how evaluation metrics are calculated for data
+        from a single fold.
 
         Args:
-            fold_data (FoldData): Container with errors and bins data for one fold.
-                Contains filtered DataFrames for the current fold, uncertainty type,
-                and any additional data needed for evaluation.
+            fold_data (FoldData): Container with errors and bins data for one fold. Contains filtered DataFrames for the
+                current fold, uncertainty type, and any additional data needed for evaluation.
 
         Returns:
-            BinResults: Results structure containing evaluation metrics for this fold.
-                The specific subclass of BinResults depends on the evaluation type
-                (e.g., JaccardBinResults for Jaccard evaluation).
-
-        Note:
-            Subclasses should implement their specific evaluation logic here,
-            such as calculating Jaccard similarity, error bounds, or other metrics.
+            BinResults: Results structure containing evaluation metrics for this fold. The specific subclass of
+                BinResults depends on the evaluation type (e.g., JaccardBinResults for Jaccard evaluation).
         """
         pass
 
@@ -812,18 +761,14 @@ class BaseEvaluator(ABC):
         """
         Aggregate results across all folds for a model-uncertainty combination.
 
-        This abstract method defines how fold-level results are combined and
-        stored in the results container for final output formatting.
+        This abstract method defines how fold-level results are combined and stored in the results container for final
+        output formatting.
 
         Args:
-            model_key (str): Identifier for the current model-uncertainty combination
-                (format: "model_name uncertainty_type").
-            fold_results (List[BinResults]): List of evaluation results from all folds
-                for the current model-uncertainty combination.
-
-        Note:
-            Subclasses should implement aggregation logic specific to their evaluation
-            type, including proper handling of target separation and result formatting.
+            model_key (str): Identifier for the current model-uncertainty combination (format: "model_name
+                uncertainty_type").
+            fold_results (List[BinResults]): List of evaluation results from all folds for the current model-uncertainty
+                combination.
         """
         pass
 
@@ -832,17 +777,12 @@ class BaseEvaluator(ABC):
         """
         Convert results container into final output format.
 
-        This abstract method handles the final formatting of evaluation results
-        to match the expected API output format.
+        This abstract method handles the final formatting of evaluation results to match the expected API output format.
 
         Returns:
-            Dict: Final results dictionary with keys matching the expected API format.
-                Structure depends on the evaluation type but typically includes
-                main results, target-separated results, and evaluation-specific metrics.
-
-        Note:
-            Subclasses should map container data to appropriate result keys
-            defined in ResultKeys class.
+            Dict: Final results dictionary with keys matching the expected API format. Structure depends on the
+                evaluation type but typically includes main results, target-separated results, and evaluation-specific
+                metrics.
         """
         pass
 
@@ -850,26 +790,18 @@ class BaseEvaluator(ABC):
         """
         Process all cross-validation folds for a given model and uncertainty type.
 
-        Iterates through all configured cross-validation folds, extracting data for each
-        fold and applying the subclass-specific evaluation logic to compute fold-level
-        results. This method coordinates the fold-wise evaluation process within the
-        Template Method pattern.
+        Iterates through all configured cross-validation folds, extracting data for each fold and applying the
+        subclass-specific evaluation logic to compute fold-level results. This method coordinates the fold-wise
+        evaluation process within the Template Method pattern.
 
         Args:
-            data_structs (pd.DataFrame): Complete dataset containing all folds and evaluation
-                data for the current model. Must include columns for fold identification,
-                UIDs, target indices, errors, and uncertainty bins.
+            data_structs (pd.DataFrame): Complete dataset containing all folds and evaluation data for the current
+                model. Must include columns for fold identification, UIDs, target indices, errors, and uncertainty bins.
 
         Returns:
-            List[BinResults]: List of evaluation results from all folds, where each element
-                contains the evaluation metrics (e.g., Jaccard similarity, error bounds)
-                computed for one fold. The specific type of BinResults depends on the
-                evaluator implementation (e.g., JaccardBinResults for Jaccard evaluation).
-
-        Note:
-            This method uses the current instance variables (current_uncertainty_type_,
-            config_.num_folds) to determine which data to extract and how many folds
-            to process. It delegates the actual evaluation logic to _process_single_fold.
+            List[BinResults]: List of evaluation results from all folds, where each element contains the evaluation
+            metrics (e.g., Jaccard similarity, error bounds) computed for one fold. The specific type of BinResults
+            depends on the evaluator implementation (e.g., JaccardBinResults for Jaccard evaluation).
         """
         fold_results = []
 
@@ -885,23 +817,20 @@ class JaccardEvaluator(BaseEvaluator):
     """
     Evaluator for calculating Jaccard similarity metrics for uncertainty quantification.
 
-    This evaluator computes Jaccard similarity between prediction confidence bins
-    and error bins to assess the quality of uncertainty quantification. It measures
-    how well the model's confidence aligns with actual prediction accuracy.
+    This evaluator computes Jaccard similarity between prediction confidence bins and error bins to assess the quality
+    of uncertainty quantification. It measures how well the model's confidence aligns with actual prediction accuracy.
 
-    The Jaccard similarity is calculated as:
-        J(A, B) = |A ∩ B| / |A ∪ B|
+    The Jaccard similarity is calculated as: J(A, B) = |A ∩ B| / |A ∪ B|
 
-    Where A represents the high-confidence predictions and B represents
-    the correct predictions within each bin.
+    Where A represents the high-confidence predictions and B represents the correct predictions within each bin.
 
     Attributes:
-        config_ (EvaluationConfig): Configuration object containing evaluation parameters
-            including bin counts, confidence thresholds, and target separation settings.
+        config_ (EvaluationConfig): Configuration object containing evaluation parameters including bin counts,
+            confidence thresholds, and target separation settings.
         data_processor (DataProcessor): Handles data filtering and preprocessing operations.
         quantile_calculator (QuantileCalculator): Computes quantile-based bin boundaries.
-        metrics_calculator (MetricsCalculator): Calculates evaluation metrics including
-            Jaccard similarity and statistical measures.
+        metrics_calculator (MetricsCalculator): Calculates evaluation metrics including Jaccard similarity and
+            statistical measures.
 
     Example:
 
@@ -937,23 +866,19 @@ class JaccardEvaluator(BaseEvaluator):
         """
         Create a JaccardEvaluator instance with simplified parameters.
 
-        Convenience factory method for creating a JaccardEvaluator with commonly
-        used configuration parameters without requiring full EvaluationConfig setup.
+        Convenience factory method for creating a JaccardEvaluator with commonly used configuration parameters without
+        requiring full EvaluationConfig setup.
 
         Args:
-            original_num_bins (int): Number of quantile bins for uncertainty evaluation.
-                Typical values range from 5 to 20 depending on dataset size and
-                desired granularity.
-            num_folds (int, optional): Number of cross-validation folds for evaluation.
-                Defaults to 8. Higher values provide more robust estimates but
-                increase computation time.
-            combine_middle_bins (bool, optional): Whether to combine middle uncertainty
-                bins for simplified analysis. Defaults to False. When True, reduces
-                the number of bins by merging middle quantiles.
+            original_num_bins (int): Number of quantile bins for uncertainty evaluation. Typical values range from 5 to
+                20 depending on dataset size and desired granularity.
+            num_folds (int, optional): Number of cross-validation folds for evaluation. Defaults to 8. Higher values
+                provide more robust estimates but increase computation time.
+            combine_middle_bins (bool, optional): Whether to combine middle uncertainty bins for simplified analysis.
+                Defaults to False. When True, reduces the number of bins by merging middle quantiles.
 
         Returns:
-            JaccardEvaluator: Configured evaluator instance ready for uncertainty
-                quantification assessment.
+            JaccardEvaluator: Configured evaluator instance ready for uncertainty quantification assessment.
 
         Example:
 
@@ -980,13 +905,12 @@ class JaccardEvaluator(BaseEvaluator):
         """
         Create a JaccardEvaluator instance with default configuration parameters.
 
-        Factory method that creates an evaluator using the default EvaluationConfig
-        settings, providing a quick way to instantiate the evaluator for standard
-        uncertainty quantification evaluation tasks.
+        Factory method that creates an evaluator using the default EvaluationConfig settings, providing a quick way to
+        instantiate the evaluator for standard uncertainty quantification evaluation tasks.
 
         Returns:
-            JaccardEvaluator: Evaluator instance configured with default parameters
-                including standard bin counts, fold numbers, and evaluation settings.
+            JaccardEvaluator: Evaluator instance configured with default parameters including standard bin counts, fold
+                numbers, and evaluation settings.
 
         Example:
 
@@ -1027,14 +951,12 @@ class JaccardEvaluator(BaseEvaluator):
         """
         Process Jaccard evaluation metrics for a single cross-validation fold.
 
-        Computes Jaccard similarity, precision, and recall metrics for each bin
-        and target within a single fold. This method implements the core evaluation
-        logic for assessing uncertainty quantification quality.
+        Computes Jaccard similarity, precision, and recall metrics for each bin and target within a single fold. This
+        method implements the core evaluation logic for assessing uncertainty quantification quality.
 
         Args:
-            fold_data (FoldData): Container with errors and bins data for the current fold.
-                Contains filtered DataFrames with prediction errors and uncertainty bins
-                for evaluation.
+            fold_data (FoldData): Container with errors and bins data for the current fold. Contains filtered DataFrames
+                with prediction errors and uncertainty bins for evaluation.
 
         Returns:
             JaccardBinResults: Results container with computed metrics including:
@@ -1086,14 +1008,12 @@ class JaccardEvaluator(BaseEvaluator):
         """
         Process Jaccard similarity metrics for a specific target within a fold.
 
-        Computes bin-wise Jaccard similarity, precision, and recall for predictions
-        associated with a particular target index. This enables target-specific
-        evaluation of uncertainty quantification quality.
+        Computes bin-wise Jaccard similarity, precision, and recall for predictions associated with a particular target
+        index. This enables target-specific evaluation of uncertainty quantification quality.
 
         Args:
             fold_data (FoldData): Container with errors and bins data for the current fold.
-            target_idx (int): Index of the target to process. Used to filter data
-                for target-specific evaluation.
+            target_idx (int): Index of the target to process. Used to filter data for target-specific evaluation.
 
         Returns:
             Dict: Dictionary containing computed metrics with keys:
@@ -1204,20 +1124,14 @@ class JaccardEvaluator(BaseEvaluator):
         """
         Aggregate Jaccard evaluation results across all cross-validation folds.
 
-        Combines fold-level Jaccard similarity, precision, and recall results into
-        aggregated statistics for a specific model-uncertainty combination. Handles
-        both main results and target-separated results based on configuration.
+        Combines fold-level Jaccard similarity, precision, and recall results into aggregated statistics for a specific
+        model-uncertainty combination. Handles both main results and target-separated results based on configuration.
 
         Args:
-            model_key (str): Identifier for the current model-uncertainty combination
-                (format: "model_name uncertainty_type").
-            fold_results (List[BinResults]): List of JaccardBinResults from all folds
-                for the current model-uncertainty combination.
-
-        Note:
-            This method aggregates results by computing means and standard deviations
-            across folds for both bin-wise and target-wise metrics. Results are
-            stored in the container for final formatting.
+            model_key (str): Identifier for the current model-uncertainty combination (format: "model_name
+                uncertainty_type").
+            fold_results (List[BinResults]): List of JaccardBinResults from all folds for the current model-uncertainty
+                combination.
         """
         # Cast to JaccardBinResults since we know that's what JaccardEvaluator produces
         jaccard_results = cast(List[JaccardBinResults], fold_results)
@@ -1359,9 +1273,8 @@ class JaccardEvaluator(BaseEvaluator):
         """
         Convert aggregated results container into final Jaccard evaluation output format.
 
-        Transforms the results container into the expected API output format with
-        properly organized Jaccard similarity, precision, and recall results for
-        all evaluation categories.
+        Transforms the results container into the expected API output format with properly organized Jaccard similarity,
+        precision, and recall results for all evaluation categories.
 
         Returns:
             Dict: Final results dictionary with keys defined in ResultKeys class:
@@ -1399,26 +1312,25 @@ def evaluate_bounds(
     """
     Evaluate error bound accuracy for uncertainty quantification models.
 
-    This function assesses how well predicted error bounds capture actual prediction
-    errors across different uncertainty bins. It provides a comprehensive evaluation
-    of bound reliability for uncertainty quantification in machine learning models.
+    This function assesses how well predicted error bounds capture actual prediction errors across different uncertainty
+    bins. It provides a comprehensive evaluation of bound reliability for uncertainty quantification in machine learning
+    models.
 
     Args:
-        estimated_bounds (Dict[str, pd.DataFrame]): Dictionary mapping model names to
-            DataFrames containing estimated error bounds for each prediction.
-        bin_predictions (Dict[str, pd.DataFrame]): Dictionary mapping model names to
-            DataFrames containing bin predictions and evaluation data with columns
-            for UIDs, target indices, errors, and uncertainty bins.
-        uncertainty_pairs (List): List of uncertainty type pairs to evaluate.
-            Each element should be a list/tuple containing uncertainty type names.
-        num_bins (int): Number of uncertainty bins for evaluation. Controls the
-            granularity of the bound accuracy assessment.
-        targets (List[int]): List of target indices to include in the evaluation.
-            Used to filter data and organize results by target.
-        num_folds (int, optional): Number of cross-validation folds for evaluation.
-            Defaults to 8. Higher values provide more robust estimates.
-        combine_middle_bins (bool, optional): Whether to combine middle uncertainty
-            bins for simplified three-bin analysis. Defaults to False.
+        estimated_bounds (Dict[str, pd.DataFrame]): Dictionary mapping model names to DataFrames containing estimated
+            error bounds for each prediction.
+        bin_predictions (Dict[str, pd.DataFrame]): Dictionary mapping model names to DataFrames containing bin
+            predictions and evaluation data with columns for UIDs, target indices, errors, and uncertainty bins.
+        uncertainty_pairs (List): List of uncertainty type pairs to evaluate. Each element should be a list/tuple
+            containing uncertainty type names.
+        num_bins (int): Number of uncertainty bins for evaluation. Controls the granularity of the bound accuracy
+            assessment.
+        targets (List[int]): List of target indices to include in the evaluation. Used to filter data and organize
+            results by target.
+        num_folds (int, optional): Number of cross-validation folds for evaluation. Defaults to 8. Higher values provide
+            more robust estimates.
+        combine_middle_bins (bool, optional): Whether to combine middle uncertainty bins for simplified three-bin
+            analysis. Defaults to False.
 
     Returns:
         Dict: Comprehensive evaluation results dictionary containing:
@@ -1530,8 +1442,8 @@ def evaluate_jaccard(bin_predictions, uncertainty_pairs, num_bins, targets, num_
     """
     Evaluate uncertainty estimation's ability to predict true error quantiles using Jaccard metrics.
 
-    This is a convenience function that uses the new JaccardEvaluator class
-    while maintaining backward compatibility with the original function signature.
+    This is a convenience function that uses the new JaccardEvaluator class while maintaining backward compatibility
+    with the original function signature.
 
     Args:
         bin_predictions: Dictionary of DataFrames containing bin predictions for each model
@@ -1737,14 +1649,14 @@ def get_mean_errors(
     combine_middle_bins: bool = False,
 ) -> Dict:
     """
-    Evaluate uncertainty estimation's mean error of each bin.
-    For each bin, we calculate the mean localization error for each target and for all targets.
-    We calculate the mean error for each dictionary in the bin_predictions dict. For each bin, we calculate: a) the mean
-    and std over all folds and all targets b) the mean and std for each target over all folds.
+    Evaluate uncertainty estimation's mean error of each bin. For each bin, we calculate the mean localization error for
+    each target and for all targets. We calculate the mean error for each dictionary in the bin_predictions dict. For
+    each bin, we calculate: a) the mean and std over all folds and all targets b) the mean and std for each target over
+    all folds.
 
     Args:
         bin_predictions (Dict): Dict of Pandas DataFrames where each DataFrame has errors, predicted bins for all
-        uncertainty measures for a model.
+            uncertainty measures for a model.
         uncertainty_pairs (List[Tuple[str, str]]): List of tuples describing the different uncertainty combinations to test.
         num_bins (int): Number of quantile bins.
         targets (List[str]): List of targets to measure uncertainty estimation.
@@ -1876,8 +1788,7 @@ def bin_wise_errors(fold_errors, fold_bins, num_bins, targets, uncertainty_key, 
     Args:
         fold_errors (Pandas Dataframe): Pandas Dataframe of errors for this fold.
         fold_bins (Pandas Dataframe): Pandas Dataframe of predicted quantile bins for this fold.
-        num_bins (int): Number of quantile bins,
-        targets (list) list of targets to measure uncertainty estimation,
+        num_bins (int): Number of quantile bins, targets (list) list of targets to measure uncertainty estimation,
         uncertainty_key (string): Name of uncertainty type to calculate accuracy for,
 
 

--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -1596,7 +1596,7 @@ def _bin_error_bounds(q: int, num_bins: int, fold_bounds: list) -> Tuple[float, 
         fold_bounds (list): Estimated error bounds for this target, one per bin edge.
 
     Returns:
-        tuple: The ``(lower, upper)`` bounds, where membership is ``lower < error <= upper``.
+        tuple: The ``(lower, upper)`` bounds.
     """
     if q == 0:
         return 0, fold_bounds[q]
@@ -1622,8 +1622,6 @@ def _count_within_bounds(errors: list, lower: float, upper: float) -> int:
 def _bin_accuracy(inbin_errors: list, lower: float, upper: float) -> float:
     """Score a single quantile bin: the fraction of its errors within ``(lower, upper]``.
 
-    An empty bin scores ``1.0`` (issue #549): there is no prediction to be wrong about.
-
     Args:
         inbin_errors (list): Errors of the samples assigned to this bin.
         lower (float): Exclusive lower bound.
@@ -1640,8 +1638,8 @@ def _bin_accuracy(inbin_errors: list, lower: float, upper: float) -> float:
 def _group_target_errors_by_bin(pred_bins_ti: dict, true_errors_ti: dict, num_bins: int) -> List[List[float]]:
     """Group a target's errors by the predicted quantile bin of each sample.
 
-    Bin membership and uid matching use string comparison, mirroring the legacy call site so that
-    numeric and string keys (e.g. ``1`` vs ``"1"``) are treated as equal.
+    Bin values and uids are compared as strings, so numeric and string keys (e.g. ``1`` and ``"1"``)
+    are treated as equal.
 
     Args:
         pred_bins_ti (dict): Maps each sample uid to its predicted quantile bin.

--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -716,10 +716,6 @@ class BaseEvaluator(ABC):
         current_num_bins_ (int): Number of bins for current evaluation (may differ from original)
         current_targets_ (List[int]): Target indices for current evaluation
         current_uncertainty_type_ (str): Current uncertainty type being processed
-
-    Note:
-        This is an abstract base class. Use concrete implementations like JaccardEvaluator
-        for actual evaluations.
     """
 
     def __init__(self, config: EvaluationConfig):
@@ -767,10 +763,6 @@ class BaseEvaluator(ABC):
                a. Process all cross-validation folds
                b. Aggregate fold results
             3. Finalize and format results for output
-
-        Note:
-            This method coordinates the evaluation process but delegates the actual
-            evaluation logic to abstract methods implemented by subclasses.
         """
         # Set instance variables to reduce parameter passing
         self.current_targets_ = targets
@@ -923,28 +915,18 @@ class JaccardEvaluator(BaseEvaluator):
             ...     targets=[0, 1],
             ... )
             >>> print(results["jaccard_all"]["model1 epistemic"])
-
-    Note:
-        This evaluator implements the Template Method pattern defined in BaseEvaluator,
-        providing specific implementations for Jaccard similarity calculation and
-        bin-wise evaluation of uncertainty quantification quality.
     """
 
     def __init__(self, config: Optional[EvaluationConfig] = None):
         """
         Initialize JaccardEvaluator with configuration and required components.
 
-        Sets up the evaluator with configuration parameters and calls the parent
-        class constructor to initialize the evaluation framework.
+        Sets up the evaluator with configuration parameters and calls the parent class constructor to initialize the
+        evaluation framework.
 
         Args:
-            config (Optional[EvaluationConfig]): Configuration object containing
-                evaluation parameters such as bin counts, thresholds, and settings
-                for target separation. If None, uses default EvaluationConfig values.
-
-        Note:
-            Inherits utility components (data_processor, quantile_calculator,
-            metrics_calculator) from BaseEvaluator initialization.
+            config (Optional[EvaluationConfig]): Configuration object containing evaluation parameters such as bin
+                counts, thresholds, and settings for target separation. If None, uses default EvaluationConfig values.
         """
         super().__init__(config or EvaluationConfig())
 
@@ -1061,11 +1043,6 @@ class JaccardEvaluator(BaseEvaluator):
                 - bin_precision: List of precision values for each bin
                 - target_metrics: Target-specific evaluation results
                 - bins_targets_separated: Bin results separated by target
-
-        Note:
-            This method processes each target individually and aggregates results
-            across all targets for comprehensive evaluation. Handles both combined
-            and target-separated result generation based on configuration.
         """
         all_target_jaccard = []
         all_target_recall = []
@@ -1126,11 +1103,6 @@ class JaccardEvaluator(BaseEvaluator):
                 - 'bin_jaccard': List of Jaccard values for each bin
                 - 'bin_recall': List of recall values for each bin
                 - 'bin_precision': List of precision values for each bin
-
-        Note:
-            This method processes data specific to one target, enabling detailed
-            analysis of uncertainty quantification performance across different
-            prediction targets or classes.
         """
         # Extract and prepare target-specific data
         errors_dict, bins_dict = self._extract_target_data(fold_data, target_idx)
@@ -1401,10 +1373,6 @@ class JaccardEvaluator(BaseEvaluator):
                 - PRECISION_TARGETS_SEPARATED: Target-separated precision results
                 - ALL_JACC_CONCAT_BINS_TARGET_SEP_FOLDWISE: Fold-wise target separation
                 - ALL_JACC_CONCAT_BINS_TARGET_SEP_ALL: Overall target separation
-
-        Note:
-            This method maps the container's organized data structure to the specific
-            result keys expected by the Jaccard evaluation API.
         """
         assert self.container_ is not None, "Results container is not initialized"
         return {
@@ -1471,10 +1439,6 @@ def evaluate_bounds(
             ...     num_bins=5, targets=[0, 1, 2]
             ... )
             >>> print(results['error_bounds_all']['model1_epistemic'])
-
-    Note:
-        This function complements Jaccard-based evaluation by focusing on the
-        accuracy of predicted confidence intervals rather than bin overlap.
     """
 
     if combine_middle_bins:
@@ -1589,9 +1553,6 @@ def evaluate_jaccard(bin_predictions, uncertainty_pairs, num_bins, targets, num_
 def _bin_error_bounds(q: int, num_bins: int, fold_bounds: list) -> Tuple[float, float]:
     """Return the ``(lower, upper]`` error bounds for quantile bin ``q``.
 
-    The first bin starts at 0 and the last bin is open above (``inf``); the intermediate bins
-    take their bounds from consecutive entries of ``fold_bounds``.
-
     Args:
         q (int): Index of the quantile bin.
         num_bins (int): Total number of quantile bins.
@@ -1613,7 +1574,7 @@ def _count_within_bounds(errors: list, lower: float, upper: float) -> int:
     Args:
         errors (list): Error values in a single bin.
         lower (float): Exclusive lower bound.
-        upper (float): Inclusive upper bound (``inf`` for the open-ended last bin).
+        upper (float): Inclusive upper bound.
 
     Returns:
         int: The number of errors within the bounds.
@@ -1622,15 +1583,15 @@ def _count_within_bounds(errors: list, lower: float, upper: float) -> int:
 
 
 def _bin_accuracy(inbin_errors: list, lower: float, upper: float) -> float:
-    """Score a single quantile bin: the fraction of its errors within ``(lower, upper]``.
+    """Return the fraction of ``inbin_errors`` within ``(lower, upper]``, or ``1.0`` if the bin is empty.
 
     Args:
         inbin_errors (list): Errors of the samples assigned to this bin.
         lower (float): Exclusive lower bound.
-        upper (float): Inclusive upper bound (``inf`` for the open-ended last bin).
+        upper (float): Inclusive upper bound.
 
     Returns:
-        float: ``1.0`` for an empty bin, otherwise the proportion of errors within the bounds.
+        float: The proportion of errors within the bounds; ``1.0`` when the bin is empty.
     """
     if len(inbin_errors) == 0:
         return 1.0
@@ -1640,8 +1601,7 @@ def _bin_accuracy(inbin_errors: list, lower: float, upper: float) -> float:
 def _group_target_errors_by_bin(pred_bins_ti: dict, true_errors_ti: dict, num_bins: int) -> List[List[float]]:
     """Group a target's errors by the predicted quantile bin of each sample.
 
-    Bin values and uids are compared as strings, so numeric and string keys (e.g. ``1`` and ``"1"``)
-    are treated as equal.
+    Bin values and uids are compared as strings, so ``1`` and ``"1"`` are treated as equal.
 
     Args:
         pred_bins_ti (dict): Maps each sample uid to its predicted quantile bin.
@@ -1649,8 +1609,7 @@ def _group_target_errors_by_bin(pred_bins_ti: dict, true_errors_ti: dict, num_bi
         num_bins (int): Total number of quantile bins.
 
     Returns:
-        list: ``num_bins`` lists, each holding the errors whose samples fall in that bin, in the
-        order the samples appear in ``pred_bins_ti``.
+        list: ``num_bins`` lists, each holding the errors of the samples in that bin.
     """
     errors_by_uid = {str(uid): error for uid, error in true_errors_ti.items()}
     binned_errors: List[List[float]] = [[] for _ in range(num_bins)]
@@ -1715,7 +1674,7 @@ def bin_wise_bound_eval(
             >>> bin_wise_bound_eval(fold_bounds_all_targets, fold_errors, fold_bins, [0,1], 'S-MHA', num_bins=5)
     """
     all_target_perc = []
-    all_qs_perc: List[List[float]] = [[] for x in range(num_bins)]  #
+    all_qs_perc: List[List[float]] = [[] for x in range(num_bins)]
     all_qs_size: List[List[float]] = [[] for x in range(num_bins)]
 
     all_qs_errorbound_concat_targets_sep: List[List[List[float]]] = [
@@ -1728,18 +1687,12 @@ def bin_wise_bound_eval(
             ["uid", uncertainty_type + " Uncertainty bins"]
         ]
 
-        # Zip to dictionary
         true_errors_ti = dict(zip(true_errors_ti.uid, true_errors_ti[uncertainty_type + " Error"]))
         pred_bins_ti = dict(zip(pred_bins_ti.uid, pred_bins_ti[uncertainty_type + " Uncertainty bins"]))
 
         # The error bounds are from B1 -> B5 i.e. best quantile of predictions to worst quantile of predictions
         fold_bounds = fold_bounds_all_targets[i_ti]
 
-        # For each bin, see what % of targets are between the error bounds.
-        # If bin=0 then lower bound = 0, if bin=Q then no upper bound
-        # Keep track of #samples in each bin for weighted mean.
-
-        # turn dictionary of predicted bins into [[num_bins]] array of errors
         pred_bins_errors = _group_target_errors_by_bin(pred_bins_ti, true_errors_ti, num_bins)
 
         bins_acc = []
@@ -1756,23 +1709,15 @@ def bin_wise_bound_eval(
             all_qs_size[q].append(len(inbin_errors))
             all_qs_errorbound_concat_targets_sep[i_ti][q].append(accuracy_bin)
 
-        # Weighted average over all bins
         if sum(bins_sizes) == 0:
             raise ValueError(
                 f"Target {target_idx} has no samples in this fold for uncertainty type {uncertainty_type}."
             )
         all_target_perc.append(_weighted_average(bins_acc, bins_sizes))
 
-    # Weighted average for each of the quantile bins.
     weighted_ave_binwise = []
     for binidx in range(len(all_qs_perc)):
         weighted_ave_binwise.append(_weighted_average(all_qs_perc[binidx], all_qs_size[binidx]))
-
-    # No weighted average, just normal average
-    normal_ave_bin_wise = []
-    for binidx in range(len(all_qs_perc)):
-        bin_accs = all_qs_perc[binidx]
-        normal_ave_bin_wise.append(np.mean(bin_accs))
 
     return {
         "mean all targets": np.mean(all_target_perc),

--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -2,9 +2,9 @@
 # Author: Lawrence Schobs, lawrenceschobs@gmail.com
 #         Zhongwei Ji, jizhongwei1999@outlook.com
 # =============================================================================
+
 """
-Module from the implementation of L. A. Schobs, A. J. Swift and H. Lu, "Uncertainty Estimation for Heatmap-Based Landmark Localization,"
-in IEEE Transactions on Medical Imaging, vol. 42, no. 4, pp. 1021-1034, April 2023, doi: 10.1109/TMI.2022.3222730.
+Module from the implementation of L. A. Schobs, A. J. Swift and H. Lu, "Uncertainty Estimation for Heatmap-Based Landmark Localization," in IEEE Transactions on Medical Imaging, vol. 42, no. 4, pp. 1021-1034, April 2023, doi: 10.1109/TMI.2022.3222730.
 
 Key Evaluation Approaches:
     A) Jaccard Similarity Analysis: Measures overlap between predicted uncertainty bins
@@ -23,6 +23,7 @@ Main Classes:
     - QuantileCalculator: Quantile-based error distribution analysis
     - MetricsCalculator: Statistical metrics computation
 """
+
 import copy
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field

--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -1664,18 +1664,18 @@ def _group_target_errors_by_bin(pred_bins_ti: dict, true_errors_ti: dict, num_bi
 
 
 def _weighted_average(values: list, weights: list) -> float:
-    """Return the ``weights``-weighted mean of ``values``, or ``nan`` if the weights sum to zero.
+    """Return the ``weights``-weighted mean of ``values``, or ``0.0`` if the weights sum to zero.
 
     Args:
-        values (list): Per-item values (e.g. per-bin accuracies).
-        weights (list): Non-negative weights aligned with ``values`` (e.g. per-bin sample counts).
+        values (list): Per-item values.
+        weights (list): Non-negative weights aligned with ``values``.
 
     Returns:
-        float: The size-weighted mean, or ``nan`` when all weights are zero.
+        float: The weighted mean, or ``0.0`` when all weights are zero.
     """
     total_weight = sum(weights)
     if total_weight == 0:
-        return float("nan")
+        return 0.0
     return sum(value * weight for value, weight in zip(values, weights)) / total_weight
 
 
@@ -1703,7 +1703,7 @@ def bin_wise_bound_eval(
         dict: A dictionary containing the following error bound accuracy statistics:
               - 'mean all targets': The mean accuracy over all targets and quantile bins.
               - 'mean all bins': A list of mean accuracy values for each quantile bin (all targets included),
-               weighted by bin size; ``nan`` for a bin that is empty for every target.
+               weighted by bin size; ``0.0`` for a bin that is empty for every target.
               - 'mean all': A list of accuracy values for each quantile bin and target, weighted by # targets in each bin.
               - 'all bins concatenated targets separated': A list of accuracy values for each quantile bin, concatenated
                for each target separately.

--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -1,6 +1,7 @@
 # =============================================================================
 # Author: Lawrence Schobs, lawrenceschobs@gmail.com
 #         Zhongwei Ji, jizhongwei1999@outlook.com
+#         Charles Anjah, cmanjahart@gmail.com
 # =============================================================================
 
 """

--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -5,7 +5,9 @@
 # =============================================================================
 
 """
-Module from the implementation of L. A. Schobs, A. J. Swift and H. Lu, "Uncertainty Estimation for Heatmap-Based Landmark Localization," in IEEE Transactions on Medical Imaging, vol. 42, no. 4, pp. 1021-1034, April 2023, doi: 10.1109/TMI.2022.3222730.
+Module from the implementation of L. A. Schobs, A. J. Swift and H. Lu, 
+"Uncertainty Estimation for Heatmap-Based Landmark Localization," 
+in IEEE Transactions on Medical Imaging, vol. 42, no. 4, pp. 1021-1034, April 2023, doi: 10.1109/TMI.2022.3222730.
 
 Key Evaluation Approaches:
     A) Jaccard Similarity Analysis: Measures overlap between predicted uncertainty bins

--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -1757,6 +1757,10 @@ def bin_wise_bound_eval(
             all_qs_errorbound_concat_targets_sep[i_ti][q].append(accuracy_bin)
 
         # Weighted average over all bins
+        if sum(bins_sizes) == 0:
+            raise ValueError(
+                f"Target {target_idx} has no samples in this fold for uncertainty type {uncertainty_type}."
+            )
         all_target_perc.append(_weighted_average(bins_acc, bins_sizes))
 
     # Weighted average for each of the quantile bins.

--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -5,8 +5,8 @@
 # =============================================================================
 
 """
-Module from the implementation of L. A. Schobs, A. J. Swift and H. Lu, 
-"Uncertainty Estimation for Heatmap-Based Landmark Localization," 
+Module from the implementation of L. A. Schobs, A. J. Swift and H. Lu,
+"Uncertainty Estimation for Heatmap-Based Landmark Localization,"
 in IEEE Transactions on Medical Imaging, vol. 42, no. 4, pp. 1021-1034, April 2023, doi: 10.1109/TMI.2022.3222730.
 
 Key Evaluation Approaches:
@@ -195,11 +195,11 @@ class JaccardBinResults(BinResults):
             - all_bins: Raw Jaccard similarities for each bin and target
             - all_bins_concat_targets_sep: Target-separated Jaccard similarities
 
-        Additional Jaccard-specific attributes: 
-        mean_all_targets_recall (float): Mean recall across all targets in the fold. 
-        mean_all_bins_recall (List[float]): Mean recall for each bin across targets. 
+        Additional Jaccard-specific attributes:
+        mean_all_targets_recall (float): Mean recall across all targets in the fold.
+        mean_all_bins_recall (List[float]): Mean recall for each bin across targets.
         all_bins_recall (List[List[float]]): Raw recall values for each bin and target.
-        mean_all_targets_precision (float): Mean precision across all targets. 
+        mean_all_targets_precision (float): Mean precision across all targets.
         mean_all_bins_precision (List[float]): Mean precision for each bin.
         all_bins_precision (List[List[float]]): Raw precision values for each bin and target.
     """

--- a/kale/interpret/uncertainty_quantiles.py
+++ b/kale/interpret/uncertainty_quantiles.py
@@ -6,9 +6,9 @@
 # =============================================================================
 
 """
-This module implements the uncertainty quantification method from L. A. Schobs, A. J. Swift and H. Lu, "Uncertainty
-Estimation for Heatmap-Based Landmark Localization," in IEEE Transactions on Medical Imaging, vol. 42, no. 4, pp.
-1021-1034, April 2023, doi: 10.1109/TMI.2022.3222730.
+This module implements the uncertainty quantification method from L. A. Schobs, A. J. Swift and H. Lu, 
+"Uncertainty Estimation for Heatmap-Based Landmark Localization," 
+in IEEE Transactions on Medical Imaging, vol. 42, no. 4, pp. 1021-1034, April 2023, doi: 10.1109/TMI.2022.3222730.
 
 Core Classes:
    - QuantileBinningAnalyzer: Main analysis class encapsulating uncertainty quantile analysis
@@ -260,9 +260,7 @@ class MetricDefinition:
     to_log: bool = False  # If True, apply logarithmic scaling to y-axis
     convert_to_percent: bool = False  # If True, multiply values by 100 and show as percentages
     y_lim_top_attr: str = "percent_y_lim_standard"  # Attribute name in config to use for y_lim_top
-    show_sample_info: Optional[
-        str
-    ] = None  # Display mode for sample sizes: None (no display), 'text', 'legend', or 'detailed'
+    show_sample_info: Optional[str] = None # Display mode: None (no display), 'text', 'legend', or 'detailed'  
     show_individual_dots: bool = False  # If True, overlay individual data points as dots on boxplots
     individual_data_key: Optional[str] = None  # Dictionary key for target-separated data; None if not applicable
 
@@ -986,8 +984,8 @@ class QuantileBinningAnalyzer:
             sep_target_data (List[Any]): Data separated by target. Structure varies by plotting mode:
                 - For individual bin comparison: List of target data dictionaries
                 - For comparing Q: List of Q-value data with target indices
-            individual_targets_to_show (List[int]): List of target indices to plot individually. Use [-1] to plot all
-                targets.
+            individual_targets_to_show (List[int]): List of target indices to plot individually. 
+                Use [-1] to plot all targets.
             uncertainty_categories (List[List[str]]): List of uncertainty-error pair combinations.
             models (List[str]): List of model names to analyze.
             category_labels (List[str]): Labels for x-axis categories.
@@ -1063,8 +1061,8 @@ class QuantileBinningAnalyzer:
                 - For individual bin comparison: Single dictionary or list with one dictionary
                 - For comparing Q plots: List of dictionaries (one per Q value)
             models (List[str]): List of model names to analyze.
-            uncertainty_categories (List[List[str]]): List of uncertainty-error pair combinations. Each inner list
-                contains [uncertainty_type, error_type].
+            uncertainty_categories (List[List[str]]): List of uncertainty-error pair combinations. 
+                Each inner list contains [uncertainty_type, error_type].
             category_labels (List[str]): Labels for x-axis categories (bins, Q values, etc.).
             show_sample_info (str): Mode for displaying sample size information ("None", "text", "legend").
             x_label (str): Label for the x-axis (e.g., "Uncertainty Thresholded Bin", "Q (# Bins)").

--- a/kale/interpret/uncertainty_quantiles.py
+++ b/kale/interpret/uncertainty_quantiles.py
@@ -6,9 +6,9 @@
 # =============================================================================
 
 """
-This module implements the uncertainty quantification method from L. A. Schobs, A. J. Swift and H. Lu,
-"Uncertainty Estimation for Heatmap-Based Landmark Localization," in IEEE Transactions on Medical Imaging,
-vol. 42, no. 4, pp. 1021-1034, April 2023, doi: 10.1109/TMI.2022.3222730.
+This module implements the uncertainty quantification method from L. A. Schobs, A. J. Swift and H. Lu, "Uncertainty
+Estimation for Heatmap-Based Landmark Localization," in IEEE Transactions on Medical Imaging, vol. 42, no. 4, pp.
+1021-1034, April 2023, doi: 10.1109/TMI.2022.3222730.
 
 Core Classes:
    - QuantileBinningAnalyzer: Main analysis class encapsulating uncertainty quantile analysis
@@ -371,12 +371,10 @@ class QuantileBinningAnalyzer:
                 - save_file_preamble (str): Prefix string for saved file names to ensure unique identification.
                 - save_figures (bool): If True, save plots to disk; if False, display plots interactively.
                 - interpret (bool): If True, execute analysis and visualization; if False, skip processing.
-            display_settings (Dict[str, bool]): Keys include 'errors', 'error_bounds', 'jaccard',
-                'correlation', 'cumulative_error' to control which plots are generated.
-            figure_format (str): File extension for figure outputs (e.g., 'pdf', 'png', 'svg').
-                Defaults to 'pdf'.
-            data_format (str): File extension for data outputs (e.g., 'xlsx', 'csv').
-                Defaults to 'xlsx'.
+            display_settings (Dict[str, bool]): Keys include 'errors', 'error_bounds', 'jaccard', 'correlation',
+                'cumulative_error' to control which plots are generated.
+            figure_format (str): File extension for figure outputs (e.g., 'pdf', 'png', 'svg'). Defaults to 'pdf'.
+            data_format (str): File extension for data outputs (e.g., 'xlsx', 'csv'). Defaults to 'xlsx'.
         """
         self.logger = logging.getLogger("qbin")
 
@@ -511,10 +509,9 @@ class QuantileBinningAnalyzer:
         """
         Compare models and uncertainty types across uncertainty bins at a fixed number of bins.
 
-        Loads the binned predictions, computes the evaluation metrics, and then generates whichever of the
-        following plots are enabled in ``display_settings``: uncertainty-error correlation, cumulative error
-        distribution, and boxplots of error, error bound accuracy and Jaccard index per bin. Does nothing if
-        ``interpret`` is False.
+        Loads the binned predictions, computes the evaluation metrics, and then generates whichever of the following
+        plots are enabled in ``display_settings``: uncertainty-error correlation, cumulative error distribution, and
+        boxplots of error, error bound accuracy and Jaccard index per bin. Does nothing if ``interpret`` is False.
 
         Args:
             config (QuantileBinningConfig): The models, uncertainty types, targets, bin count and output settings.
@@ -631,9 +628,9 @@ class QuantileBinningAnalyzer:
         """
         Compare the effect of different bin counts (Q values) on one model and uncertainty type.
 
-        Loads the binned predictions and computes the evaluation metrics for each Q value, then generates
-        whichever of the error, error bound accuracy and Jaccard index boxplots are enabled in
-        ``display_settings``, with one category per Q value. Does nothing if ``interpret`` is False.
+        Loads the binned predictions and computes the evaluation metrics for each Q value, then generates whichever of
+        the error, error bound accuracy and Jaccard index boxplots are enabled in ``display_settings``, with one
+        category per Q value. Does nothing if ``interpret`` is False.
 
         Args:
             config (ComparingBinsConfig): The model, uncertainty type, targets, Q values, data paths and
@@ -790,12 +787,11 @@ class QuantileBinningAnalyzer:
 
         Args:
             suffix (str): Descriptive suffix for the filename (e.g., "error_all_targets", "jaccard_target_1").
-            show_individual_dots (bool): Whether individual data points are shown as dots on the plot.
-                This affects the filename to distinguish between dotted and undotted variants.
+            show_individual_dots (bool): Whether individual data points are shown as dots on the plot. This affects the
+                filename to distinguish between dotted and undotted variants.
 
         Returns:
-            Optional[str]: Complete file path with .pdf extension if saving is enabled,
-                          None if save_figures is False.
+            Optional[str]: Complete file path with .pdf extension if saving is enabled, None if save_figures is False.
         """
         if not self.save_figures:
             return None
@@ -990,8 +986,8 @@ class QuantileBinningAnalyzer:
             sep_target_data (List[Any]): Data separated by target. Structure varies by plotting mode:
                 - For individual bin comparison: List of target data dictionaries
                 - For comparing Q: List of Q-value data with target indices
-            individual_targets_to_show (List[int]): List of target indices to plot individually.
-                Use [-1] to plot all targets.
+            individual_targets_to_show (List[int]): List of target indices to plot individually. Use [-1] to plot all
+                targets.
             uncertainty_categories (List[List[str]]): List of uncertainty-error pair combinations.
             models (List[str]): List of model names to analyze.
             category_labels (List[str]): Labels for x-axis categories.
@@ -1134,9 +1130,9 @@ class QuantileBinningAnalyzer:
         Create a MetricPlotConfig from the provided parameters.
 
         Args:
-            eval_data (Dict[str, Any]): Comprehensive evaluation data dictionary containing computed metrics.
-                Structure: {'errors': {...}, 'bounds': {...}, 'jaccard': {...}, 'bins': {...}}.
-                Each metric category contains aggregated and separated data for all models and targets.
+            eval_data (Dict[str, Any]): Comprehensive evaluation data dictionary containing computed metrics. Structure:
+                {'errors': {...}, 'bounds': {...}, 'jaccard': {...}, 'bins': {...}}. Each metric category contains
+                aggregated and separated data for all models and targets.
             models (List[str]): List of model names to include in the plots (e.g., ['ResNet50', 'VGG16']).
             uncertainty_categories (List[List[str]]): List of uncertainty-error pair combinations for plotting.
                 Each inner list contains [uncertainty_type, error_type] (e.g., [['epistemic', 'localization']]).
@@ -1157,8 +1153,8 @@ class QuantileBinningAnalyzer:
                 Required when plotting individual targets to maintain proper indexing. Defaults to None.
             percent_y_lim_standard (int, optional): Standard upper limit for percentage-based y-axis (0-100 scale).
                 Used for Jaccard Index plots. Defaults to 70.
-            percent_y_lim_extended (int, optional): Extended upper limit for percentage-based y-axis.
-                Used for error bounds and recall/precision plots where values may exceed 100%. Defaults to 120.
+            percent_y_lim_extended (int, optional): Extended upper limit for percentage-based y-axis. Used for error
+                bounds and recall/precision plots where values may exceed 100%. Defaults to 120.
             **kwargs (Any): Additional keyword arguments passed to the plotting functions. Common kwargs include:
                 - x_label (str): Custom x-axis label
                 - y_label (str): Custom y-axis label

--- a/kale/interpret/uncertainty_quantiles.py
+++ b/kale/interpret/uncertainty_quantiles.py
@@ -6,8 +6,8 @@
 # =============================================================================
 
 """
-This module implements the uncertainty quantification method from L. A. Schobs, A. J. Swift and H. Lu, 
-"Uncertainty Estimation for Heatmap-Based Landmark Localization," 
+This module implements the uncertainty quantification method from L. A. Schobs, A. J. Swift and H. Lu,
+"Uncertainty Estimation for Heatmap-Based Landmark Localization,"
 in IEEE Transactions on Medical Imaging, vol. 42, no. 4, pp. 1021-1034, April 2023, doi: 10.1109/TMI.2022.3222730.
 
 Core Classes:
@@ -260,7 +260,7 @@ class MetricDefinition:
     to_log: bool = False  # If True, apply logarithmic scaling to y-axis
     convert_to_percent: bool = False  # If True, multiply values by 100 and show as percentages
     y_lim_top_attr: str = "percent_y_lim_standard"  # Attribute name in config to use for y_lim_top
-    show_sample_info: Optional[str] = None # Display mode: None (no display), 'text', 'legend', or 'detailed'  
+    show_sample_info: Optional[str] = None  # Display mode: None (no display), 'text', 'legend', or 'detailed'
     show_individual_dots: bool = False  # If True, overlay individual data points as dots on boxplots
     individual_data_key: Optional[str] = None  # Dictionary key for target-separated data; None if not applicable
 
@@ -984,7 +984,7 @@ class QuantileBinningAnalyzer:
             sep_target_data (List[Any]): Data separated by target. Structure varies by plotting mode:
                 - For individual bin comparison: List of target data dictionaries
                 - For comparing Q: List of Q-value data with target indices
-            individual_targets_to_show (List[int]): List of target indices to plot individually. 
+            individual_targets_to_show (List[int]): List of target indices to plot individually.
                 Use [-1] to plot all targets.
             uncertainty_categories (List[List[str]]): List of uncertainty-error pair combinations.
             models (List[str]): List of model names to analyze.
@@ -1061,7 +1061,7 @@ class QuantileBinningAnalyzer:
                 - For individual bin comparison: Single dictionary or list with one dictionary
                 - For comparing Q plots: List of dictionaries (one per Q value)
             models (List[str]): List of model names to analyze.
-            uncertainty_categories (List[List[str]]): List of uncertainty-error pair combinations. 
+            uncertainty_categories (List[List[str]]): List of uncertainty-error pair combinations.
                 Each inner list contains [uncertainty_type, error_type].
             category_labels (List[str]): Labels for x-axis categories (bins, Q values, etc.).
             show_sample_info (str): Mode for displaying sample size information ("None", "text", "legend").

--- a/kale/interpret/uncertainty_utils.py
+++ b/kale/interpret/uncertainty_utils.py
@@ -446,26 +446,20 @@ def plot_cumulative(
     """
     Generate cumulative error distribution plots for uncertainty quantification analysis.
 
-    Creates cumulative distribution plots showing the percentage of images with errors below certain
-    thresholds, which is useful for understanding the overall error distribution across uncertainty
-    bins and for comparing model performance.
+    Creates cumulative distribution plots showing the percentage of images with errors below certain thresholds, which
+    is useful for understanding the overall error distribution across uncertainty bins and for comparing model
+    performance.
 
     Args:
-        data_struct (Dict[str, pd.DataFrame]): Dictionary containing dataframes for each model.
-            Keys are model names, values are DataFrames with uncertainty and error columns.
+        data_struct (Dict[str, pd.DataFrame]): Dictionary containing dataframes for each model. Keys are model names,
+            values are DataFrames with uncertainty and error columns.
         models (List[str]): List of model names to compare. These should be keys in data_struct.
         uncertainty_types (List[Tuple[str, str]]): List of tuples describing uncertainty-error combinations to analyze.
             Each tuple contains (uncertainty_type, error_type).
-        bins (Union[int, List[int], np.ndarray]): Bin indices to include in the analysis.
-            Can be a single value, list, or numpy array.
-        config (CumulativePlotConfig, optional): Presentation, output and styling settings.
-            Defaults to :class:`CumulativePlotConfig`.
-
-    Note:
-        - The plot uses logarithmic scaling on the x-axis for better visualization of error distributions
-        - A vertical reference line is drawn at ``config.reference_line_x``
-        - Different line styles distinguish between models and uncertainty types
-        - The y-axis shows cumulative percentage (0-100%)
+        bins (Union[int, List[int], np.ndarray]): Bin indices to include in the analysis. Can be a single value, list,
+            or numpy array.
+        config (CumulativePlotConfig, optional): Presentation, output and styling settings. Defaults to
+            :class:`CumulativePlotConfig`.
     """
     config = config or CumulativePlotConfig()
 

--- a/kale/interpret/uncertainty_utils.py
+++ b/kale/interpret/uncertainty_utils.py
@@ -47,35 +47,25 @@ def analyze_and_plot_uncertainty_correlation(
     Run the uncertainty-error correlation analysis and plot the result.
 
     Args:
-        errors (np.ndarray): Array of prediction errors. Must have same length
-            as uncertainties array.
-        uncertainties (np.ndarray): Array of uncertainty estimates corresponding
-            to each prediction.
-        quantile_thresholds (List[float]): List of quantile threshold values that
-            define breakpoints for piecewise linear modeling. These determine
-            how the uncertainty range is segmented for analysis.
-        colormap (str, optional): Matplotlib colormap name for coloring different
-            quantile segments. Defaults to "Set1".
-        to_log (bool, optional): Whether to apply logarithmic scaling to both
-            axes of the plot. Useful for data spanning multiple orders of magnitude.
-            Defaults to False.
-        error_scaling_factor (float, optional): Multiplicative factor to scale
-            error values (e.g., for unit conversion from pixels to mm).
-            Defaults to 1.0.
-        save_path (Optional[str], optional): File path to save the generated plot.
-            If None, displays the plot interactively. Supports common formats
-            like PNG, PDF, SVG. Defaults to None.
-        n_bootstrap (int, optional): Number of bootstrap iterations for confidence
-            interval estimation. Higher values provide more robust estimates but
-            increase computation time. Defaults to 1000.
-        sample_ratio (float, optional): Fraction of data to sample in each bootstrap
-            iteration. Must be between 0 and 1. Lower values increase diversity
-            but may reduce stability. Defaults to 0.6.
-        font_size (int, optional): Font size for all text elements in the plot
-            including axis labels, correlation text, and quantile labels.
-            Defaults to 25.
-        show (bool, optional): Whether to display the plot interactively. Defaults to False.
-        **fig_kwargs: Additional keyword arguments for figure creation and styling:
+        errors (np.ndarray): Array of prediction errors. Must have same length as uncertainties array.
+        uncertainties (np.ndarray): Array of uncertainty estimates corresponding to each prediction.
+        quantile_thresholds (List[float]): List of quantile threshold values that define breakpoints for piecewise
+            linear modeling. These determine how the uncertainty range is segmented for analysis.
+        colormap (str, optional): Matplotlib colormap name for coloring different quantile segments. Defaults to "Set1".
+        to_log (bool, optional): Whether to apply logarithmic scaling to both axes of the plot. Useful for data spanning
+            multiple orders of magnitude. Defaults to False.
+        error_scaling_factor (float, optional): Multiplicative factor to scale error values (e.g., for unit conversion
+            from pixels to mm). Defaults to 1.0.
+        save_path (Optional[str], optional): File path to save the generated plot. If None, displays the plot
+            interactively. Supports common formats like PNG, PDF, SVG. Defaults to None.
+        n_bootstrap (int, optional): Number of bootstrap iterations for confidence interval estimation. Higher values
+            provide more robust estimates but increase computation time. Defaults to 1000.
+        sample_ratio (float, optional): Fraction of data to sample in each bootstrap iteration. Must be between 0 and 1.
+            Lower values increase diversity but may reduce stability. Defaults to 0.6.
+        font_size (int, optional): Font size for all text elements in the plot including axis labels, correlation text,
+            and quantile labels. Defaults to 25.
+        show (bool, optional): Whether to display the plot interactively. Defaults to False. **fig_kwargs: Additional
+            keyword arguments for figure creation and styling:
             - figsize (tuple): Figure size in inches (default: (16, 8))
             - save_dpi (int): Resolution in dots per inch for the saved figure (default: 600)
             - show_dpi (int): Resolution in dots per inch for the shown figure (default: 100)
@@ -127,14 +117,13 @@ def analyze_uncertainty_correlation(
     Args:
         errors (np.ndarray): Array of prediction errors
         uncertainties (np.ndarray): Array of uncertainty estimates
-        quantile_thresholds (List[float]): List of quantile threshold values
-            that define breakpoints for piecewise linear modeling
-        error_scaling_factor (float, optional): Multiplicative factor to scale
-            errors (e.g., for unit conversion). Defaults to 1.0.
-        n_bootstrap (int, optional): Number of bootstrap samples for confidence
-            interval estimation. Defaults to 1000.
-        sample_ratio (float, optional): Fraction of data to sample in each
-            bootstrap iteration. Must be between 0 and 1. Defaults to 0.6.
+        quantile_thresholds (List[float]): List of quantile threshold values that define breakpoints for piecewise
+            linear modeling
+        error_scaling_factor (float, optional): Multiplicative factor to scale errors (e.g., for unit conversion).
+            Defaults to 1.0.
+        n_bootstrap (int, optional): Number of bootstrap samples for confidence interval estimation. Defaults to 1000.
+        sample_ratio (float, optional): Fraction of data to sample in each bootstrap iteration. Must be between 0 and 1.
+            Defaults to 0.6.
 
     Returns:
         Dict[str, Any]: Dictionary containing analysis results with keys:
@@ -200,14 +189,12 @@ def plot_uncertainty_correlation(
         uncertainties (np.ndarray): Array of uncertainty estimates
         analysis_results (Dict[str, Any]): Results from analyze_uncertainty_correlation
         quantile_thresholds (List[float]): Quantile threshold values for segmentation
-        colormap (str, optional): Matplotlib colormap name for segment coloring.
-            Defaults to "Set1".
-        to_log (bool, optional): Whether to use logarithmic scale for both axes.
-            Defaults to False.
+        colormap (str, optional): Matplotlib colormap name for segment coloring. Defaults to "Set1".
+        to_log (bool, optional): Whether to use logarithmic scale for both axes. Defaults to False.
         save_path (Optional[str], optional): File path to save the plot. Defaults to None.
         show (bool, optional): Whether to show the figure. Defaults to False.
-        font_size (int, optional): Font size for all text elements. Defaults to 25.
-        **fig_kwargs: Additional keyword arguments for figure creation and styling:
+        font_size (int, optional): Font size for all text elements. Defaults to 25. **fig_kwargs: Additional keyword
+            arguments for figure creation and styling:
             - figsize (tuple): Figure size in inches (default: (16, 8))
             - save_dpi (int): Dots per inch for resolution (default: 600)
             - show_dpi (int): Dots per inch for the shown figure (default: 100)
@@ -527,8 +514,8 @@ def _fit_piecewise_model(
     Args:
         uncertainties (np.ndarray): Array of uncertainty values (independent variable)
         scaled_errors (np.ndarray): Array of scaled error values (dependent variable)
-        quantile_thresholds (List[float]): List of quantile threshold values that serve
-            as breakpoints for the piecewise linear model
+        quantile_thresholds (List[float]): List of quantile threshold values that serve as breakpoints for the piecewise
+            linear model
 
     Returns:
         pwlf.PiecewiseLinFit: The fitted piecewise linear model.
@@ -553,12 +540,12 @@ def _generate_bootstrap_models(
         scaled_errors (np.ndarray): Array of scaled error values
         quantile_thresholds (List[float]): Quantile threshold breakpoints for piecewise fitting
         n_bootstrap (int, optional): Number of bootstrap samples to generate. Defaults to 1000.
-        sample_ratio (float, optional): Fraction of data to sample for each bootstrap.
-            Must be between 0 and 1. Defaults to 0.6.
+        sample_ratio (float, optional): Fraction of data to sample for each bootstrap. Must be between 0 and 1. Defaults
+            to 0.6.
 
     Returns:
-        List[pwlf.PiecewiseLinFit]: One fitted model per bootstrap sample. Each sample has
-            ``int(len(data) * sample_ratio)`` points drawn with replacement.
+        List[pwlf.PiecewiseLinFit]: One fitted model per bootstrap sample. Each sample has ``int(len(data) *
+        sample_ratio)`` points drawn with replacement.
     """
     bootstrap_models = []
 
@@ -579,16 +566,14 @@ def _get_quantile_bounds(quantile_thresholds: List[float], uncertainties: np.nda
     Get the minimum and maximum bounds of a quantile segment.
 
     Args:
-        quantile_thresholds (List[float]): List of quantile threshold values that
-            define segment boundaries
-        uncertainties (np.ndarray): Array of uncertainty values used to determine
-            global min/max bounds
+        quantile_thresholds (List[float]): List of quantile threshold values that define segment boundaries
+        uncertainties (np.ndarray): Array of uncertainty values used to determine global min/max bounds
         idx (int): Index of the quantile segment (0-based)
 
     Returns:
         tuple[float, float]: The ``(min_value, max_value)`` of the segment. The first segment starts at
-            ``min(uncertainties)``, the last ends at ``max(uncertainties)``, and the others are bounded by
-            consecutive thresholds.
+            ``min(uncertainties)``, the last ends at ``max(uncertainties)``, and the others are bounded by consecutive
+            thresholds.
     """
     if idx == 0:
         min_val = min(uncertainties)
@@ -631,8 +616,7 @@ def _plot_bootstrap_confidence_bands(
         ax: Matplotlib axes object to plot on
         bootstrap_models (List[pwlf.PiecewiseLinFit]): List of fitted bootstrap models
         uncertainties (np.ndarray): Array of uncertainty values for determining plot range
-        num_pred_points (int, optional): Number of prediction points for smooth curves.
-            Defaults to 10000.
+        num_pred_points (int, optional): Number of prediction points for smooth curves. Defaults to 10000.
 
     Returns:
         None: Plots directly on the provided axes.
@@ -677,8 +661,7 @@ def _plot_piecewise_segments(
         uncertainties (np.ndarray): Array of uncertainty values for range determination
         quantile_thresholds (List[float]): Quantile thresholds defining segment boundaries
         colors (List[str]): List of colors for different segments (cycles if needed)
-        num_pred_points (int, optional): Number of prediction points for smooth curves.
-            Defaults to 20000.
+        num_pred_points (int, optional): Number of prediction points for smooth curves. Defaults to 20000.
 
     Returns:
         None: Plots directly on the provided axes.
@@ -713,13 +696,13 @@ def _setup_plot_formatting(
         ax: Matplotlib axes object to format
         bin_label_locs (List[float]): X-axis positions for quantile bin labels
         quantile_thresholds (List[float]): Quantile thresholds for determining label count
-        correlation_dict (Dict[str, List[float]]): Dictionary containing correlation results
-            with 'spearman' key containing [correlation, p_value]
+        correlation_dict (Dict[str, List[float]]): Dictionary containing correlation results with 'spearman' key
+            containing [correlation, p_value]
         font_size (int, optional): Font size for labels and text. Defaults to 25.
 
     Returns:
-        None: Modifies the provided axes in place. Tick labels are ``Q_1 … Q_n``; the Spearman
-            coefficient and p-value (rounded to three decimals, floored at 0.001) are written on the plot.
+        None: Modifies the provided axes in place. Tick labels are ``Q_1 … Q_n``; the Spearman coefficient and p-value
+            (rounded to three decimals, floored at 0.001) are written on the plot.
     """
     # Set x-axis ticks and labels
     ax.set_xticks(bin_label_locs)

--- a/kale/interpret/uncertainty_utils.py
+++ b/kale/interpret/uncertainty_utils.py
@@ -193,8 +193,8 @@ def plot_uncertainty_correlation(
         to_log (bool, optional): Whether to use logarithmic scale for both axes. Defaults to False.
         save_path (Optional[str], optional): File path to save the plot. Defaults to None.
         show (bool, optional): Whether to show the figure. Defaults to False.
-        font_size (int, optional): Font size for all text elements. Defaults to 25. 
-        
+        font_size (int, optional): Font size for all text elements. Defaults to 25.
+
         **fig_kwargs: Additional keyword
             arguments for figure creation and styling:
             - figsize (tuple): Figure size in inches (default: (16, 8))
@@ -447,7 +447,7 @@ def plot_cumulative(
             Each tuple contains (uncertainty_type, error_type).
         bins (Union[int, List[int], np.ndarray]): Bin indices to include in the analysis. Can be a single value, list,
             or numpy array.
-        config (CumulativePlotConfig, optional): Presentation, output and styling settings. 
+        config (CumulativePlotConfig, optional): Presentation, output and styling settings.
             Defaults to :class:`CumulativePlotConfig`.
     """
     config = config or CumulativePlotConfig()
@@ -542,11 +542,11 @@ def _generate_bootstrap_models(
         scaled_errors (np.ndarray): Array of scaled error values
         quantile_thresholds (List[float]): Quantile threshold breakpoints for piecewise fitting
         n_bootstrap (int, optional): Number of bootstrap samples to generate. Defaults to 1000.
-        sample_ratio (float, optional): Fraction of data to sample for each bootstrap. Must be between 0 and 1. 
+        sample_ratio (float, optional): Fraction of data to sample for each bootstrap. Must be between 0 and 1.
             Defaults to 0.6.
 
     Returns:
-        List[pwlf.PiecewiseLinFit]: One fitted model per bootstrap sample. Each sample has 
+        List[pwlf.PiecewiseLinFit]: One fitted model per bootstrap sample. Each sample has
         ``int(len(data) * sample_ratio)`` points drawn with replacement.
     """
     bootstrap_models = []

--- a/kale/interpret/uncertainty_utils.py
+++ b/kale/interpret/uncertainty_utils.py
@@ -64,8 +64,9 @@ def analyze_and_plot_uncertainty_correlation(
             Lower values increase diversity but may reduce stability. Defaults to 0.6.
         font_size (int, optional): Font size for all text elements in the plot including axis labels, correlation text,
             and quantile labels. Defaults to 25.
-        show (bool, optional): Whether to display the plot interactively. Defaults to False. **fig_kwargs: Additional
-            keyword arguments for figure creation and styling:
+        show (bool, optional): Whether to display the plot interactively. Defaults to False.
+
+        **fig_kwargs: Additional keyword arguments for figure creation and styling:
             - figsize (tuple): Figure size in inches (default: (16, 8))
             - save_dpi (int): Resolution in dots per inch for the saved figure (default: 600)
             - show_dpi (int): Resolution in dots per inch for the shown figure (default: 100)
@@ -195,8 +196,7 @@ def plot_uncertainty_correlation(
         show (bool, optional): Whether to show the figure. Defaults to False.
         font_size (int, optional): Font size for all text elements. Defaults to 25.
 
-        **fig_kwargs: Additional keyword
-            arguments for figure creation and styling:
+        **fig_kwargs: Additional keyword arguments for figure creation and styling:
             - figsize (tuple): Figure size in inches (default: (16, 8))
             - save_dpi (int): Dots per inch for resolution (default: 600)
             - show_dpi (int): Dots per inch for the shown figure (default: 100)

--- a/kale/interpret/uncertainty_utils.py
+++ b/kale/interpret/uncertainty_utils.py
@@ -193,7 +193,9 @@ def plot_uncertainty_correlation(
         to_log (bool, optional): Whether to use logarithmic scale for both axes. Defaults to False.
         save_path (Optional[str], optional): File path to save the plot. Defaults to None.
         show (bool, optional): Whether to show the figure. Defaults to False.
-        font_size (int, optional): Font size for all text elements. Defaults to 25. **fig_kwargs: Additional keyword
+        font_size (int, optional): Font size for all text elements. Defaults to 25. 
+        
+        **fig_kwargs: Additional keyword
             arguments for figure creation and styling:
             - figsize (tuple): Figure size in inches (default: (16, 8))
             - save_dpi (int): Dots per inch for resolution (default: 600)
@@ -445,8 +447,8 @@ def plot_cumulative(
             Each tuple contains (uncertainty_type, error_type).
         bins (Union[int, List[int], np.ndarray]): Bin indices to include in the analysis. Can be a single value, list,
             or numpy array.
-        config (CumulativePlotConfig, optional): Presentation, output and styling settings. Defaults to
-            :class:`CumulativePlotConfig`.
+        config (CumulativePlotConfig, optional): Presentation, output and styling settings. 
+            Defaults to :class:`CumulativePlotConfig`.
     """
     config = config or CumulativePlotConfig()
 
@@ -540,12 +542,12 @@ def _generate_bootstrap_models(
         scaled_errors (np.ndarray): Array of scaled error values
         quantile_thresholds (List[float]): Quantile threshold breakpoints for piecewise fitting
         n_bootstrap (int, optional): Number of bootstrap samples to generate. Defaults to 1000.
-        sample_ratio (float, optional): Fraction of data to sample for each bootstrap. Must be between 0 and 1. Defaults
-            to 0.6.
+        sample_ratio (float, optional): Fraction of data to sample for each bootstrap. Must be between 0 and 1. 
+            Defaults to 0.6.
 
     Returns:
-        List[pwlf.PiecewiseLinFit]: One fitted model per bootstrap sample. Each sample has ``int(len(data) *
-        sample_ratio)`` points drawn with replacement.
+        List[pwlf.PiecewiseLinFit]: One fitted model per bootstrap sample. Each sample has 
+        ``int(len(data) * sample_ratio)`` points drawn with replacement.
     """
     bootstrap_models = []
 

--- a/kale/prepdata/tabular_transform.py
+++ b/kale/prepdata/tabular_transform.py
@@ -127,19 +127,19 @@ def generate_struct_for_qbin(
         dataset: String of what dataset you're measuring.
 
     Returns:
-        data_structs: Dictionary where keys are model names and values are pandas dataframes containing
-                      all prediction data across targets for that model.
+        data_structs: Dictionary where keys are model names and values are pandas dataframes containing all prediction
+            data across targets for that model.
 
         data_struct_sep: Dictionary where keys are a combination of model names and target indices (e.g., "model1 T1"),
-                         and values are pandas dataframes containing prediction data for the corresponding model and target.
+            and values are pandas dataframes containing prediction data for the corresponding model and target.
 
-        data_struct_bounds: Dictionary where keys are a combination of model names and the string " Error Bounds"
-                            (e.g., "model1 Error Bounds"), and values are pandas dataframes containing all estimated
-                            error bounds across targets for that model.
+        data_struct_bounds: Dictionary where keys are a combination of model names and the string " Error Bounds" (e.g.,
+            "model1 Error Bounds"), and values are pandas dataframes containing all estimated error bounds across
+            targets for that model.
 
         data_struct_bounds_sep: Dictionary where keys are a combination of model names, target indices and the string
-                                "Error Bounds" (e.g., "model1 Error Bounds L1"), and values are pandas dataframes containing
-                                estimated error bounds for the corresponding model and target.
+            "Error Bounds" (e.g., "model1 Error Bounds L1"), and values are pandas dataframes containing estimated error
+            bounds for the corresponding model and target.
     """
     data_structs = {}
     data_struct_sep = {}  #

--- a/tests/evaluate/test_uncertainty_metrics.py
+++ b/tests/evaluate/test_uncertainty_metrics.py
@@ -177,6 +177,10 @@ class TestEvaluateBounds:
             == 8 * 2
         )  # because each landmark has 8 folds - they are sep
 
+
+class TestBinWiseBoundEvalScoring:
+    """Scoring behaviour of ``bin_wise_bound_eval`` for empty and open-ended bins (#549, #550)."""
+
     UNCERTAINTY = "S-MHA"
 
     @classmethod

--- a/tests/evaluate/test_uncertainty_metrics.py
+++ b/tests/evaluate/test_uncertainty_metrics.py
@@ -701,3 +701,42 @@ class TestCrossDataFrameIndexAlignment:
         assert aligned["mean all targets"] == pytest.approx(1.0)
         assert misaligned["mean all targets"] == pytest.approx(aligned["mean all targets"])
         assert misaligned["mean all bins"] == pytest.approx(aligned["mean all bins"])
+
+class TestBoundEvalEmptyBinsAndOpenUpperBound:
+    """Tests for issues #549 and #550 in ``bin_wise_bound_eval``."""
+
+    @staticmethod
+    def _frames(bins):
+        errors_df = pd.DataFrame({"uid": ["u0", "u1"], "Target Index": [0, 0], "S-MHA Error": [1.0, 3.0]})
+        bins_df = pd.DataFrame({"uid": ["u0", "u1"], "Target Index": [0, 0], "S-MHA Uncertainty bins": bins})
+        return errors_df, bins_df
+
+    def test_empty_bin_scores_one(self):
+        """An empty quantile bin is scored 1.0, not 0.0 (issue #549).
+
+        Both samples are placed in bin 0, leaving bin 1 empty. The empty bin must take the
+        dedicated empty-bin score. Because an empty bin has size 0, it must not affect the
+        size-weighted means.
+        """
+        errors_df, bins_df = self._frames([0, 0])
+
+        result = bin_wise_bound_eval([[2.0]], errors_df, bins_df, targets=[0], uncertainty_type="S-MHA", num_bins=2)
+
+        # Bin 1 is empty and is scored 1.0.
+        assert result["mean all"][1] == [1.0]
+        # Bin 0 holds errors 1.0 (within bound 2.0) and 3.0 (outside) -> 0.5.
+        assert result["mean all"][0] == [0.5]
+        # Size-weighted means are unaffected by the empty bin (its weight is 0).
+        assert result["mean all targets"] == pytest.approx(0.5)
+        assert result["mean all bins"] == pytest.approx([0.5, 0.0])
+
+    def test_last_bin_has_no_upper_bound(self):
+        """The final bin is unbounded above, so an arbitrarily large error is still correct (#550)."""
+        errors_df = pd.DataFrame({"uid": ["u0", "u1"], "Target Index": [0, 0], "S-MHA Error": [1.0, 1e31]})
+        bins_df = pd.DataFrame({"uid": ["u0", "u1"], "Target Index": [0, 0], "S-MHA Uncertainty bins": [0, 1]})
+
+        result = bin_wise_bound_eval([[2.0]], errors_df, bins_df, targets=[0], uncertainty_type="S-MHA", num_bins=2)
+
+        # 1.0 falls inside bound 2.0; 1e31 exceeds the lower bound of the open-ended last bin.
+        assert result["mean all targets"] == pytest.approx(1.0)
+        assert result["mean all"][1] == [1.0]

--- a/tests/evaluate/test_uncertainty_metrics.py
+++ b/tests/evaluate/test_uncertainty_metrics.py
@@ -178,64 +178,6 @@ class TestEvaluateBounds:
         )  # because each landmark has 8 folds - they are sep
 
 
-class TestBinWiseBoundEvalScoring:
-    """Scoring behaviour of ``bin_wise_bound_eval`` for empty and open-ended bins (#549, #550)."""
-
-    UNCERTAINTY = "S-MHA"
-
-    @classmethod
-    def _frames(cls, errors, bins):
-        """Build matching error and bin frames for two predictions, using the column-name constants."""
-        errors_df = pd.DataFrame(
-            {
-                ColumnNames.UID: ["u0", "u1"],
-                ColumnNames.TARGET_IDX: [0, 0],
-                cls.UNCERTAINTY + ColumnNames.ERROR_SUFFIX: errors,
-            }
-        )
-        bins_df = pd.DataFrame(
-            {
-                ColumnNames.UID: ["u0", "u1"],
-                ColumnNames.TARGET_IDX: [0, 0],
-                cls.UNCERTAINTY + ColumnNames.UNCERTAINTY_BINS_SUFFIX: bins,
-            }
-        )
-        return errors_df, bins_df
-
-    def test_empty_bin_scores_one(self):
-        """An empty quantile bin is scored 1.0, not 0.0 (issue #549).
-
-        Both samples are placed in bin 0, leaving bin 1 empty. The empty bin must take the
-        dedicated empty-bin score. Because an empty bin has size 0, it must not affect the
-        size-weighted means.
-        """
-        errors_df, bins_df = self._frames(errors=[1.0, 3.0], bins=[0, 0])
-
-        result = bin_wise_bound_eval(
-            [[2.0]], errors_df, bins_df, targets=[0], uncertainty_type=self.UNCERTAINTY, num_bins=2
-        )
-
-        # Bin 1 is empty and is scored 1.0.
-        assert result["mean all"][1] == [1.0]
-        # Bin 0 holds errors 1.0 (within bound 2.0) and 3.0 (outside) -> 0.5.
-        assert result["mean all"][0] == [0.5]
-        # Size-weighted means are unaffected by the empty bin (its weight is 0).
-        assert result["mean all targets"] == pytest.approx(0.5)
-        assert result["mean all bins"] == pytest.approx([0.5, 0.0])
-
-    def test_last_bin_has_no_upper_bound(self):
-        """The final bin is unbounded above, so an arbitrarily large error is still correct (#550)."""
-        errors_df, bins_df = self._frames(errors=[1.0, 1e31], bins=[0, 1])
-
-        result = bin_wise_bound_eval(
-            [[2.0]], errors_df, bins_df, targets=[0], uncertainty_type=self.UNCERTAINTY, num_bins=2
-        )
-
-        # 1.0 falls inside bound 2.0; 1e31 exceeds the lower bound of the open-ended last bin.
-        assert result["mean all targets"] == pytest.approx(1.0)
-        assert result["mean all"][1] == [1.0]
-
-
 class TestEvaluationConfig:
     """Test EvaluationConfig dataclass."""
 

--- a/tests/evaluate/test_uncertainty_metrics.py
+++ b/tests/evaluate/test_uncertainty_metrics.py
@@ -702,13 +702,29 @@ class TestCrossDataFrameIndexAlignment:
         assert misaligned["mean all targets"] == pytest.approx(aligned["mean all targets"])
         assert misaligned["mean all bins"] == pytest.approx(aligned["mean all bins"])
 
+
 class TestBoundEvalEmptyBinsAndOpenUpperBound:
     """Tests for issues #549 and #550 in ``bin_wise_bound_eval``."""
 
-    @staticmethod
-    def _frames(bins):
-        errors_df = pd.DataFrame({"uid": ["u0", "u1"], "Target Index": [0, 0], "S-MHA Error": [1.0, 3.0]})
-        bins_df = pd.DataFrame({"uid": ["u0", "u1"], "Target Index": [0, 0], "S-MHA Uncertainty bins": bins})
+    UNCERTAINTY = "S-MHA"
+
+    @classmethod
+    def _frames(cls, errors, bins):
+        """Build matching error and bin frames for two predictions, using the column-name constants."""
+        errors_df = pd.DataFrame(
+            {
+                ColumnNames.UID: ["u0", "u1"],
+                ColumnNames.TARGET_IDX: [0, 0],
+                cls.UNCERTAINTY + ColumnNames.ERROR_SUFFIX: errors,
+            }
+        )
+        bins_df = pd.DataFrame(
+            {
+                ColumnNames.UID: ["u0", "u1"],
+                ColumnNames.TARGET_IDX: [0, 0],
+                cls.UNCERTAINTY + ColumnNames.UNCERTAINTY_BINS_SUFFIX: bins,
+            }
+        )
         return errors_df, bins_df
 
     def test_empty_bin_scores_one(self):
@@ -718,9 +734,11 @@ class TestBoundEvalEmptyBinsAndOpenUpperBound:
         dedicated empty-bin score. Because an empty bin has size 0, it must not affect the
         size-weighted means.
         """
-        errors_df, bins_df = self._frames([0, 0])
+        errors_df, bins_df = self._frames(errors=[1.0, 3.0], bins=[0, 0])
 
-        result = bin_wise_bound_eval([[2.0]], errors_df, bins_df, targets=[0], uncertainty_type="S-MHA", num_bins=2)
+        result = bin_wise_bound_eval(
+            [[2.0]], errors_df, bins_df, targets=[0], uncertainty_type=self.UNCERTAINTY, num_bins=2
+        )
 
         # Bin 1 is empty and is scored 1.0.
         assert result["mean all"][1] == [1.0]
@@ -732,10 +750,11 @@ class TestBoundEvalEmptyBinsAndOpenUpperBound:
 
     def test_last_bin_has_no_upper_bound(self):
         """The final bin is unbounded above, so an arbitrarily large error is still correct (#550)."""
-        errors_df = pd.DataFrame({"uid": ["u0", "u1"], "Target Index": [0, 0], "S-MHA Error": [1.0, 1e31]})
-        bins_df = pd.DataFrame({"uid": ["u0", "u1"], "Target Index": [0, 0], "S-MHA Uncertainty bins": [0, 1]})
+        errors_df, bins_df = self._frames(errors=[1.0, 1e31], bins=[0, 1])
 
-        result = bin_wise_bound_eval([[2.0]], errors_df, bins_df, targets=[0], uncertainty_type="S-MHA", num_bins=2)
+        result = bin_wise_bound_eval(
+            [[2.0]], errors_df, bins_df, targets=[0], uncertainty_type=self.UNCERTAINTY, num_bins=2
+        )
 
         # 1.0 falls inside bound 2.0; 1e31 exceeds the lower bound of the open-ended last bin.
         assert result["mean all targets"] == pytest.approx(1.0)

--- a/tests/evaluate/test_uncertainty_metrics.py
+++ b/tests/evaluate/test_uncertainty_metrics.py
@@ -177,6 +177,60 @@ class TestEvaluateBounds:
             == 8 * 2
         )  # because each landmark has 8 folds - they are sep
 
+    UNCERTAINTY = "S-MHA"
+
+    @classmethod
+    def _frames(cls, errors, bins):
+        """Build matching error and bin frames for two predictions, using the column-name constants."""
+        errors_df = pd.DataFrame(
+            {
+                ColumnNames.UID: ["u0", "u1"],
+                ColumnNames.TARGET_IDX: [0, 0],
+                cls.UNCERTAINTY + ColumnNames.ERROR_SUFFIX: errors,
+            }
+        )
+        bins_df = pd.DataFrame(
+            {
+                ColumnNames.UID: ["u0", "u1"],
+                ColumnNames.TARGET_IDX: [0, 0],
+                cls.UNCERTAINTY + ColumnNames.UNCERTAINTY_BINS_SUFFIX: bins,
+            }
+        )
+        return errors_df, bins_df
+
+    def test_empty_bin_scores_one(self):
+        """An empty quantile bin is scored 1.0, not 0.0 (issue #549).
+
+        Both samples are placed in bin 0, leaving bin 1 empty. The empty bin must take the
+        dedicated empty-bin score. Because an empty bin has size 0, it must not affect the
+        size-weighted means.
+        """
+        errors_df, bins_df = self._frames(errors=[1.0, 3.0], bins=[0, 0])
+
+        result = bin_wise_bound_eval(
+            [[2.0]], errors_df, bins_df, targets=[0], uncertainty_type=self.UNCERTAINTY, num_bins=2
+        )
+
+        # Bin 1 is empty and is scored 1.0.
+        assert result["mean all"][1] == [1.0]
+        # Bin 0 holds errors 1.0 (within bound 2.0) and 3.0 (outside) -> 0.5.
+        assert result["mean all"][0] == [0.5]
+        # Size-weighted means are unaffected by the empty bin (its weight is 0).
+        assert result["mean all targets"] == pytest.approx(0.5)
+        assert result["mean all bins"] == pytest.approx([0.5, 0.0])
+
+    def test_last_bin_has_no_upper_bound(self):
+        """The final bin is unbounded above, so an arbitrarily large error is still correct (#550)."""
+        errors_df, bins_df = self._frames(errors=[1.0, 1e31], bins=[0, 1])
+
+        result = bin_wise_bound_eval(
+            [[2.0]], errors_df, bins_df, targets=[0], uncertainty_type=self.UNCERTAINTY, num_bins=2
+        )
+
+        # 1.0 falls inside bound 2.0; 1e31 exceeds the lower bound of the open-ended last bin.
+        assert result["mean all targets"] == pytest.approx(1.0)
+        assert result["mean all"][1] == [1.0]
+
 
 class TestEvaluationConfig:
     """Test EvaluationConfig dataclass."""
@@ -701,61 +755,3 @@ class TestCrossDataFrameIndexAlignment:
         assert aligned["mean all targets"] == pytest.approx(1.0)
         assert misaligned["mean all targets"] == pytest.approx(aligned["mean all targets"])
         assert misaligned["mean all bins"] == pytest.approx(aligned["mean all bins"])
-
-
-class TestBoundEvalEmptyBinsAndOpenUpperBound:
-    """Tests for issues #549 and #550 in ``bin_wise_bound_eval``."""
-
-    UNCERTAINTY = "S-MHA"
-
-    @classmethod
-    def _frames(cls, errors, bins):
-        """Build matching error and bin frames for two predictions, using the column-name constants."""
-        errors_df = pd.DataFrame(
-            {
-                ColumnNames.UID: ["u0", "u1"],
-                ColumnNames.TARGET_IDX: [0, 0],
-                cls.UNCERTAINTY + ColumnNames.ERROR_SUFFIX: errors,
-            }
-        )
-        bins_df = pd.DataFrame(
-            {
-                ColumnNames.UID: ["u0", "u1"],
-                ColumnNames.TARGET_IDX: [0, 0],
-                cls.UNCERTAINTY + ColumnNames.UNCERTAINTY_BINS_SUFFIX: bins,
-            }
-        )
-        return errors_df, bins_df
-
-    def test_empty_bin_scores_one(self):
-        """An empty quantile bin is scored 1.0, not 0.0 (issue #549).
-
-        Both samples are placed in bin 0, leaving bin 1 empty. The empty bin must take the
-        dedicated empty-bin score. Because an empty bin has size 0, it must not affect the
-        size-weighted means.
-        """
-        errors_df, bins_df = self._frames(errors=[1.0, 3.0], bins=[0, 0])
-
-        result = bin_wise_bound_eval(
-            [[2.0]], errors_df, bins_df, targets=[0], uncertainty_type=self.UNCERTAINTY, num_bins=2
-        )
-
-        # Bin 1 is empty and is scored 1.0.
-        assert result["mean all"][1] == [1.0]
-        # Bin 0 holds errors 1.0 (within bound 2.0) and 3.0 (outside) -> 0.5.
-        assert result["mean all"][0] == [0.5]
-        # Size-weighted means are unaffected by the empty bin (its weight is 0).
-        assert result["mean all targets"] == pytest.approx(0.5)
-        assert result["mean all bins"] == pytest.approx([0.5, 0.0])
-
-    def test_last_bin_has_no_upper_bound(self):
-        """The final bin is unbounded above, so an arbitrarily large error is still correct (#550)."""
-        errors_df, bins_df = self._frames(errors=[1.0, 1e31], bins=[0, 1])
-
-        result = bin_wise_bound_eval(
-            [[2.0]], errors_df, bins_df, targets=[0], uncertainty_type=self.UNCERTAINTY, num_bins=2
-        )
-
-        # 1.0 falls inside bound 2.0; 1e31 exceeds the lower bound of the open-ended last bin.
-        assert result["mean all targets"] == pytest.approx(1.0)
-        assert result["mean all"][1] == [1.0]

--- a/tests/evaluate/test_uncertainty_metrics.py
+++ b/tests/evaluate/test_uncertainty_metrics.py
@@ -21,7 +21,6 @@ from kale.evaluate.uncertainty_metrics import (
 )
 from kale.prepdata.tabular_transform import generate_struct_for_qbin
 
-# from kale.utils.download import download_file_by_url
 from kale.utils.seed import set_seed
 
 # import os
@@ -624,14 +623,8 @@ class TestJaccardBinResults:
 
 
 class TestCrossDataFrameIndexAlignment:
-    """Regression tests for issue #553.
-
-    ``bin_wise_bound_eval`` and ``bin_wise_errors`` must group errors by ``uid`` using each
-    frame's own ``Target Index`` column, independently of how ``fold_errors`` and ``fold_bins``
-    are indexed. Before the fix, ``fold_bins`` was filtered with a boolean mask built from
-    ``fold_errors``, so a difference in row order/index between the two frames silently produced
-    the wrong grouping (or raised). These tests deliberately misalign the two frames.
-    """
+    """``bin_wise_bound_eval`` and ``bin_wise_errors`` group errors by ``uid`` regardless of
+    how ``fold_errors`` and ``fold_bins`` are indexed."""
 
     @staticmethod
     def _errors_df():

--- a/tests/evaluate/test_uncertainty_metrics.py
+++ b/tests/evaluate/test_uncertainty_metrics.py
@@ -20,10 +20,8 @@ from kale.evaluate.uncertainty_metrics import (
     ResultsContainer,
 )
 from kale.prepdata.tabular_transform import generate_struct_for_qbin
-
 from kale.utils.seed import set_seed
 
-# import os
 LOGGER = logging.getLogger(__name__)
 
 

--- a/tests/evaluate/test_uncertainty_metrics.py
+++ b/tests/evaluate/test_uncertainty_metrics.py
@@ -649,9 +649,8 @@ class TestCrossDataFrameIndexAlignment:
     def test_bin_wise_errors_misaligned_index(self):
         """Bins must be grouped by uid even when ``fold_bins`` rows are reordered/reindexed.
 
-        The reordered ``fold_bins`` holds the same per-uid data as the aligned frame; only its
-        row order and index differ. The result must match the aligned case and the hand-computed
-        expectation.
+        The reordered ``fold_bins`` holds the same per-uid data as the aligned frame; only its row order and index
+        differ. The result must match the aligned case and the hand-computed expectation.
         """
         errors_df = self._errors_df()
         bins_aligned = self._bins_df()

--- a/tests/evaluate/test_uncertainty_metrics_bounds.py
+++ b/tests/evaluate/test_uncertainty_metrics_bounds.py
@@ -1,0 +1,62 @@
+import pandas as pd
+import pytest
+
+from kale.evaluate.uncertainty_metrics import bin_wise_bound_eval, ColumnNames
+
+
+class TestBinWiseBoundEvalScoring:
+    """Scoring behaviour of ``bin_wise_bound_eval`` for empty and open-ended bins (#549, #550)."""
+
+    UNCERTAINTY = "S-MHA"
+
+    @classmethod
+    def _frames(cls, errors, bins):
+        """Build matching error and bin frames for two predictions, using the column-name constants."""
+        errors_df = pd.DataFrame(
+            {
+                ColumnNames.UID: ["u0", "u1"],
+                ColumnNames.TARGET_IDX: [0, 0],
+                cls.UNCERTAINTY + ColumnNames.ERROR_SUFFIX: errors,
+            }
+        )
+        bins_df = pd.DataFrame(
+            {
+                ColumnNames.UID: ["u0", "u1"],
+                ColumnNames.TARGET_IDX: [0, 0],
+                cls.UNCERTAINTY + ColumnNames.UNCERTAINTY_BINS_SUFFIX: bins,
+            }
+        )
+        return errors_df, bins_df
+
+    def test_empty_bin_scores_one(self):
+        """An empty quantile bin is scored 1.0, not 0.0 (issue #549).
+
+        Both samples are placed in bin 0, leaving bin 1 empty. The empty bin must take the
+        dedicated empty-bin score. Because an empty bin has size 0, it must not affect the
+        size-weighted means.
+        """
+        errors_df, bins_df = self._frames(errors=[1.0, 3.0], bins=[0, 0])
+
+        result = bin_wise_bound_eval(
+            [[2.0]], errors_df, bins_df, targets=[0], uncertainty_type=self.UNCERTAINTY, num_bins=2
+        )
+
+        # Bin 1 is empty and is scored 1.0.
+        assert result["mean all"][1] == [1.0]
+        # Bin 0 holds errors 1.0 (within bound 2.0) and 3.0 (outside) -> 0.5.
+        assert result["mean all"][0] == [0.5]
+        # Size-weighted means are unaffected by the empty bin (its weight is 0).
+        assert result["mean all targets"] == pytest.approx(0.5)
+        assert result["mean all bins"] == pytest.approx([0.5, 0.0])
+
+    def test_last_bin_has_no_upper_bound(self):
+        """The final bin is unbounded above, so an arbitrarily large error is still correct (#550)."""
+        errors_df, bins_df = self._frames(errors=[1.0, 1e31], bins=[0, 1])
+
+        result = bin_wise_bound_eval(
+            [[2.0]], errors_df, bins_df, targets=[0], uncertainty_type=self.UNCERTAINTY, num_bins=2
+        )
+
+        # 1.0 falls inside bound 2.0; 1e31 exceeds the lower bound of the open-ended last bin.
+        assert result["mean all targets"] == pytest.approx(1.0)
+        assert result["mean all"][1] == [1.0]

--- a/tests/evaluate/test_uncertainty_metrics_bounds.py
+++ b/tests/evaluate/test_uncertainty_metrics_bounds.py
@@ -64,3 +64,12 @@ class TestBinWiseBoundEvalScoring:
         # 1.0 falls inside bound 2.0; 1e31 exceeds the lower bound of the open-ended last bin.
         assert result["mean all targets"] == pytest.approx(1.0)
         assert result["mean all"][1] == [1.0]
+
+    def test_target_without_samples_raises(self):
+        """A target with no samples in the fold raises instead of being scored."""
+        errors_df, bins_df = self._frames(errors=[1.0, 3.0], bins=[0, 0])
+
+        with pytest.raises(ValueError, match="Target 1 has no samples"):
+            bin_wise_bound_eval(
+                [[2.0], [2.0]], errors_df, bins_df, targets=[0, 1], uncertainty_type=self.UNCERTAINTY, num_bins=2
+            )

--- a/tests/evaluate/test_uncertainty_metrics_bounds.py
+++ b/tests/evaluate/test_uncertainty_metrics_bounds.py
@@ -5,7 +5,7 @@ from kale.evaluate.uncertainty_metrics import bin_wise_bound_eval, ColumnNames
 
 
 class TestBinWiseBoundEvalScoring:
-    """Scoring behaviour of ``bin_wise_bound_eval`` for empty and open-ended bins (#549, #550)."""
+    """Scoring behaviour of ``bin_wise_bound_eval`` for empty and open-ended bins."""
 
     UNCERTAINTY = "S-MHA"
 
@@ -29,10 +29,7 @@ class TestBinWiseBoundEvalScoring:
         return errors_df, bins_df
 
     def test_empty_bin_scores_one(self):
-        """An empty quantile bin is scored 1.0 and carries no weight in the size-weighted means (#549).
-
-        Both samples are placed in bin 0, leaving bin 1 empty.
-        """
+        """An empty quantile bin is scored 1.0 and carries no weight in the size-weighted means."""
         errors_df, bins_df = self._frames(errors=[1.0, 3.0], bins=[0, 0])
 
         result = bin_wise_bound_eval(

--- a/tests/evaluate/test_uncertainty_metrics_bounds.py
+++ b/tests/evaluate/test_uncertainty_metrics_bounds.py
@@ -1,5 +1,3 @@
-import math
-
 import pandas as pd
 import pytest
 
@@ -48,11 +46,11 @@ class TestBinWiseBoundEvalScoring:
         # Size-weighted means are unaffected by the empty bin (its weight is 0).
         assert result["mean all targets"] == pytest.approx(0.5)
         assert result["mean all bins"][0] == pytest.approx(0.5)
-        # A bin that is empty for every target has no weighted mean.
-        assert math.isnan(result["mean all bins"][1])
+        # A bin that is empty for every target reports 0.0 in the size-weighted mean.
+        assert result["mean all bins"][1] == 0.0
 
     def test_last_bin_has_no_upper_bound(self):
-        """The final bin is unbounded above, so an arbitrarily large error is still correct (#550)."""
+        """The final bin is unbounded above, so an arbitrarily large error is still correct."""
         errors_df, bins_df = self._frames(errors=[1.0, 1e31], bins=[0, 1])
 
         result = bin_wise_bound_eval(

--- a/tests/evaluate/test_uncertainty_metrics_bounds.py
+++ b/tests/evaluate/test_uncertainty_metrics_bounds.py
@@ -31,11 +31,9 @@ class TestBinWiseBoundEvalScoring:
         return errors_df, bins_df
 
     def test_empty_bin_scores_one(self):
-        """An empty quantile bin is scored 1.0, not 0.0 (issue #549).
+        """An empty quantile bin is scored 1.0 and carries no weight in the size-weighted means (#549).
 
-        Both samples are placed in bin 0, leaving bin 1 empty. The empty bin must take the
-        dedicated empty-bin score. Because an empty bin has size 0, it must not affect the
-        size-weighted means.
+        Both samples are placed in bin 0, leaving bin 1 empty.
         """
         errors_df, bins_df = self._frames(errors=[1.0, 3.0], bins=[0, 0])
 

--- a/tests/evaluate/test_uncertainty_metrics_bounds.py
+++ b/tests/evaluate/test_uncertainty_metrics_bounds.py
@@ -1,3 +1,5 @@
+import math
+
 import pandas as pd
 import pytest
 
@@ -47,7 +49,9 @@ class TestBinWiseBoundEvalScoring:
         assert result["mean all"][0] == [0.5]
         # Size-weighted means are unaffected by the empty bin (its weight is 0).
         assert result["mean all targets"] == pytest.approx(0.5)
-        assert result["mean all bins"] == pytest.approx([0.5, 0.0])
+        assert result["mean all bins"][0] == pytest.approx(0.5)
+        # A bin that is empty for every target has no weighted mean.
+        assert math.isnan(result["mean all bins"][1])
 
     def test_last_bin_has_no_upper_bound(self):
         """The final bin is unbounded above, so an arbitrarily large error is still correct (#550)."""

--- a/tests/pipeline/test_uncertainty_qbin_pipeline.py
+++ b/tests/pipeline/test_uncertainty_qbin_pipeline.py
@@ -163,10 +163,10 @@ def _create_analyzer(config, display_settings):
     """Create and return a QuantileBinningAnalyzer instance.
 
     Args:
-        config: Configuration object (QuantileBinningConfig or ComparingBinsConfig) containing
-            analysis parameters like save folder, colormap, and display options.
-        display_settings (dict): Dictionary specifying which plots to generate (cumulative_error,
-            errors, jaccard, error_bounds, correlation, hatch).
+        config: Configuration object (QuantileBinningConfig or ComparingBinsConfig) containing analysis parameters like
+            save folder, colormap, and display options.
+        display_settings (dict): Dictionary specifying which plots to generate (cumulative_error, errors, jaccard,
+            error_bounds, correlation, hatch).
 
     Returns:
         QuantileBinningAnalyzer: Configured analyzer instance ready for analysis.
@@ -476,8 +476,7 @@ def helper_test_qbin_fit(
             pairs to use for testing.
         landmark_results_path_val (str): The path to the directory containing validation results for the
             specified landmark.
-        landmark_results_path_test (str): The path to the directory containing test results for the specified
-            landmark.
+        landmark_results_path_test (str): The path to the directory containing test results for the specified landmark.
         num_bins (int): The number of bins to use for quantile binning.
         cfg (Any): A configuration object containing various settings for the algorithm.
         gt_test_error_available (bool): Whether or not ground truth test errors are available.


### PR DESCRIPTION
Fixes #549.
Fixes #550.

### Description
Empty quantile bins in `bin_wise_bound_eval` were scored `0.0` because a preceding condition made the intended empty-bin branch unreachable; the conditions are reordered so an empty bin scores `1.0`. The hard-coded `999…` last-bin upper-bound sentinel is replaced with `float("inf")`. Also raises a `ValueError` when a target has no samples in a fold instead of silently dividing by zero. Size-weighted outputs are unchanged; adds tests for both cases.

### Status
Ready

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] Source for documentation at `docs` manually updated for new API.
