### PR TITLE
Default protonet_loss device to CUDA only when available

### DIFF
--- a/kale/evaluate/metrics.py
+++ b/kale/evaluate/metrics.py
@@ -9,6 +9,7 @@
 https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/models/losses.py
 """
 from enum import Enum
+from typing import Optional
 
 import torch
 import torch.nn as nn
@@ -324,10 +325,11 @@ class protonet_loss:
     Args:
         num_classes (int): Number of classes in a task. Default: 5
         num_query_samples (int): Number of samples per class in the query set. Default: 15
-        device (torch.device): The device in computation. Default: torch.device("cuda")
+        device (torch.device, optional): The device in computation. Defaults to CUDA when it is
+            available and CPU otherwise.
 
     Examples:
-        >>> loss_fn = protonet_loss(num_classes=5, num_query_samples=15, device=torch.device("cuda"))
+        >>> loss_fn = protonet_loss(num_classes=5, num_query_samples=15)
         >>> loss, acc = loss_fn(feature_support, feature_query)
 
     Reference:
@@ -335,11 +337,13 @@ class protonet_loss:
     """
 
     def __init__(
-        self, num_classes: int = 5, num_query_samples: int = 15, device: torch.device = torch.device("cuda")
+        self, num_classes: int = 5, num_query_samples: int = 15, device: Optional[torch.device] = None
     ) -> None:
         super().__init__()
         self.num_classes = num_classes
         self.num_query_samples = num_query_samples
+        if device is None:
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.device = device
 
     def __call__(self, feature_support: torch.Tensor, feature_query: torch.Tensor) -> tuple:

--- a/kale/evaluate/metrics.py
+++ b/kale/evaluate/metrics.py
@@ -9,7 +9,7 @@
 https://github.com/criteo-research/pytorch-ada/blob/master/adalib/ada/models/losses.py
 """
 from enum import Enum
-from typing import Optional
+from typing import Optional, Union
 
 import torch
 import torch.nn as nn
@@ -325,8 +325,8 @@ class protonet_loss:
     Args:
         num_classes (int): Number of classes in a task. Default: 5
         num_query_samples (int): Number of samples per class in the query set. Default: 15
-        device (torch.device, optional): The device in computation. Defaults to CUDA when it is
-            available and CPU otherwise.
+        device (str or torch.device, optional): The device in computation, accepted in either form
+            by ``Tensor.to``. Defaults to CUDA when it is available and CPU otherwise.
 
     Examples:
         >>> loss_fn = protonet_loss(num_classes=5, num_query_samples=15)
@@ -337,7 +337,7 @@ class protonet_loss:
     """
 
     def __init__(
-        self, num_classes: int = 5, num_query_samples: int = 15, device: Optional[torch.device] = None
+        self, num_classes: int = 5, num_query_samples: int = 15, device: Optional[Union[str, torch.device]] = None
     ) -> None:
         super().__init__()
         self.num_classes = num_classes

--- a/tests/evaluate/test_metrics.py
+++ b/tests/evaluate/test_metrics.py
@@ -88,6 +88,21 @@ def test_protonet_loss():
     assert dists.shape == (num_classes, num_classes * num_query_samples)
 
 
+def test_protonet_loss_default_device():
+    """The default device follows CUDA availability rather than assuming CUDA (issue #557)."""
+    expected = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    loss_fn = protonet_loss(num_classes=2, num_query_samples=3)
+
+    assert loss_fn.device.type == expected.type
+
+    # The default must run end to end on the host machine, CPU-only included.
+    feature_support = torch.rand(2, 4, 8)
+    feature_query = torch.rand(2 * 3, 8)
+    loss, acc = loss_fn(feature_support, feature_query)
+    assert isinstance(loss, torch.Tensor)
+    assert isinstance(acc, torch.Tensor)
+
+
 @pytest.fixture
 def x1():
     return torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.float)

--- a/tests/evaluate/test_metrics.py
+++ b/tests/evaluate/test_metrics.py
@@ -103,6 +103,20 @@ def test_protonet_loss_default_device():
     assert isinstance(acc, torch.Tensor)
 
 
+def test_protonet_loss_accepts_string_device():
+    """A device given as a string is accepted, which is how the trainer passes it.
+
+    ProtoNetTrainer holds ``devices`` as a plain string, so this is the form the class is
+    constructed with in practice.
+    """
+    loss_fn = protonet_loss(num_classes=2, num_query_samples=3, device="cpu")
+
+    loss, acc = loss_fn(torch.rand(2, 4, 8), torch.rand(2 * 3, 8))
+
+    assert isinstance(loss, torch.Tensor)
+    assert isinstance(acc, torch.Tensor)
+
+
 @pytest.fixture
 def x1():
     return torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.float)


### PR DESCRIPTION
Fixes #557.

### Description
`protonet_loss` defaulted to `torch.device("cuda")`, failing on CPU-only machines. The default is now resolved to CUDA when available and CPU otherwise, and the type/docstring accept a `str` device (as callers pass). Adds a test for the default path.

### Status
Ready

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [ ] Source for documentation at `docs` manually updated for new API.
