### PR TITLE
Use the model device instead of hard-coded .cuda() in SignalImageVAE

### DIFF
--- a/kale/embed/multimodal_encoder.py
+++ b/kale/embed/multimodal_encoder.py
@@ -58,23 +58,25 @@ class SignalImageVAE(nn.Module):
         self.n_latents = latent_dim
 
     @staticmethod
-    def prior_expert(size, use_cuda=False):
+    def prior_expert(size, use_cuda=False, device=None):
         """
         Creates a universal prior expert as a spherical Gaussian N(0, 1) with specified size.
 
         Args:
             size (tuple): Desired shape, typically (1, batch_size, latent_dim).
-            use_cuda (bool): Whether to move tensors to CUDA.
+            use_cuda (bool): Whether to place tensors on CUDA. Only used when ``device`` is None.
+            device (torch.device or str, optional): Device on which to create the tensors. Takes
+                precedence over ``use_cuda``. When None, falls back to the default CUDA device if
+                ``use_cuda`` is True and CPU otherwise.
 
         Returns:
             mean (Tensor): Zero-mean tensor.
             log_var (Tensor): Zero log-variance tensor.
         """
-        mean = torch.zeros(size)
-        log_var = torch.zeros(size)
-        if use_cuda:
-            mean = mean.cuda()
-            log_var = log_var.cuda()
+        if device is None:
+            device = "cuda" if use_cuda else "cpu"
+        mean = torch.zeros(size, device=device)
+        log_var = torch.zeros(size, device=device)
         return mean, log_var
 
     def reparametrize(self, mean, log_var):
@@ -123,8 +125,8 @@ class SignalImageVAE(nn.Module):
             log_var (Tensor): Log-variance vector of the fused latent distribution, shape (batch_size, latent_dim).
         """
         batch_size = image.size(0) if image is not None else signal.size(0)
-        use_cuda = next(self.parameters()).is_cuda
-        mean, log_var = self.prior_expert((1, batch_size, self.n_latents), use_cuda=use_cuda)
+        device = next(self.parameters()).device
+        mean, log_var = self.prior_expert((1, batch_size, self.n_latents), device=device)
         if image is not None:
             img_mu, img_log_var = self.image_encoder(image)
             mean = torch.cat((mean, img_mu.unsqueeze(0)), dim=0)

--- a/tests/embed/test_multimodal_encoder.py
+++ b/tests/embed/test_multimodal_encoder.py
@@ -29,7 +29,11 @@ def test_bimodal_vae_full_coverage():
         mu_cuda, log_var_cuda = model.prior_expert((1, batch_size, latent_dim), use_cuda=True)
         assert mu_cuda.shape == (1, batch_size, latent_dim)
         assert log_var_cuda.shape == (1, batch_size, latent_dim)
-        assert mock_zeros.call_args.kwargs["device"] == "cuda"
+        # Both the mean and log-variance tensors must be created on the cuda device, so check every
+        # call rather than only the last one - otherwise a regression that placed just one of them
+        # correctly would slip through.
+        assert mock_zeros.call_count == 2
+        assert all(call.kwargs["device"] == "cuda" for call in mock_zeros.call_args_list)
 
     # --- Test reparametrize, both training and eval mode ---
     dummy_mu = torch.zeros(batch_size, latent_dim)

--- a/tests/embed/test_multimodal_encoder.py
+++ b/tests/embed/test_multimodal_encoder.py
@@ -23,12 +23,13 @@ def test_bimodal_vae_full_coverage():
     assert mean.shape == (1, batch_size, latent_dim)
     assert torch.allclose(log_var, torch.zeros_like(log_var))
 
-    # --- Test prior_expert (mocked cuda branch, even on CPU) ---
-    with patch.object(torch.Tensor, "cuda", lambda x: x):
+    # --- Test prior_expert (cuda branch resolves to the cuda device, even on CPU-only hosts) ---
+    prior_stub = torch.zeros(1, batch_size, latent_dim)  # built before patching torch.zeros
+    with patch("kale.embed.multimodal_encoder.torch.zeros", return_value=prior_stub) as mock_zeros:
         mu_cuda, log_var_cuda = model.prior_expert((1, batch_size, latent_dim), use_cuda=True)
         assert mu_cuda.shape == (1, batch_size, latent_dim)
         assert log_var_cuda.shape == (1, batch_size, latent_dim)
-        # These are not .is_cuda (since we're faking), but they exist
+        assert mock_zeros.call_args.kwargs["device"] == "cuda"
 
     # --- Test reparametrize, both training and eval mode ---
     dummy_mu = torch.zeros(batch_size, latent_dim)
@@ -53,3 +54,55 @@ def test_bimodal_vae_full_coverage():
     assert mu_img.shape == (batch_size, latent_dim)
     mu_sig, log_var_sig = model.infer(signal=signal)
     assert mu_sig.shape == (batch_size, latent_dim)
+
+
+class TestPriorExpertDevice:
+    """Device placement of the prior expert (issue #542)."""
+
+    def test_explicit_device_is_honoured(self):
+        """An explicit device is applied regardless of the use_cuda flag."""
+        mean, log_var = SignalImageVAE.prior_expert((1, 2, 4), device="cpu")
+
+        assert mean.device.type == "cpu"
+        assert log_var.device.type == "cpu"
+
+    def test_use_cuda_false_stays_on_cpu(self):
+        """Backward compatibility: the use_cuda flag still selects CPU when False."""
+        mean, log_var = SignalImageVAE.prior_expert((1, 2, 4), use_cuda=False)
+
+        assert mean.device.type == "cpu"
+        assert log_var.device.type == "cpu"
+
+    def test_prior_matches_model_device(self):
+        """infer() places the prior on the same device as the model parameters.
+
+        Previously the prior was built from a boolean flag and always landed on the default CUDA
+        device, so a model on a non-default device received a prior on the wrong one.
+        """
+        model = SignalImageVAE(image_input_channels=1, signal_input_dim=64, latent_dim=4)
+        model.eval()
+        expected = next(model.parameters()).device
+
+        image = torch.rand(2, 1, 224, 224)
+        signal = torch.rand(2, 1, 64)
+        mean, log_var = model.infer(image=image, signal=signal)
+
+        assert mean.device == expected
+        assert log_var.device == expected
+
+    def test_infer_forwards_model_device_to_prior_expert(self):
+        """infer() forwards the model's actual device, not a boolean CUDA flag.
+
+        The flag collapsed every CUDA device to the default one, so a model on a non-default
+        device (e.g. cuda:1) or on MPS received its prior on the wrong device. Asserting the
+        forwarded argument is what makes that regression detectable on a CPU-only host.
+        """
+        model = SignalImageVAE(image_input_channels=1, signal_input_dim=64, latent_dim=4)
+        model.eval()
+        expected = next(model.parameters()).device
+        prior = (torch.zeros(1, 2, 4), torch.zeros(1, 2, 4))
+
+        with patch.object(SignalImageVAE, "prior_expert", return_value=prior) as spy:
+            model.infer(image=torch.rand(2, 1, 224, 224), signal=torch.rand(2, 1, 64))
+
+        assert spy.call_args.kwargs["device"] == expected


### PR DESCRIPTION
Fixes #542.

### Description
`SignalImageVAE.prior_expert` used `.cuda()`, which forces device 0 and ignores the model's actual device. `infer()` now derives the device from the model parameters and creates the prior there, so it works on non-default GPUs and MPS. Adds device-placement and forwarding tests.

### Status
Ready

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [ ] Source for documentation at `docs` manually updated for new API.
