### PR TITLE
Handle optimizers without a scheduler in WDGRLTrainer.configure_optimizers

### DIFF
--- a/kale/pipeline/domain_adapter.py
+++ b/kale/pipeline/domain_adapter.py
@@ -784,8 +784,9 @@ class WDGRLTrainer(BaseDANNLike):
     def configure_optimizers(self):
         """Configure the task/feature optimizer and, separately, the critic optimizer.
 
-        The critic is stepped manually in ``compute_loss``, so its optimizer and scheduler are
-        stored on the trainer rather than returned to PyTorch Lightning.
+        The critic is stepped manually in ``critic_update_steps`` (called from ``training_step``),
+        so its optimizer and scheduler are stored on the trainer rather than returned to PyTorch
+        Lightning.
 
         ``_configure_optimizer`` returns ``([optimizer], [scheduler])`` only for SGD with
         ``adapt_lr`` enabled, and ``[optimizer]`` otherwise; both shapes are handled here and the

--- a/kale/pipeline/domain_adapter.py
+++ b/kale/pipeline/domain_adapter.py
@@ -781,24 +781,31 @@ class WDGRLTrainer(BaseDANNLike):
 
         return loss  # required, for backward pass
 
-    def configure_optimizers(self):  # no usage?
+    def configure_optimizers(self):
+        """Configure the task/feature optimizer and, separately, the critic optimizer.
+
+        The critic is stepped manually in ``compute_loss``, so its optimizer and scheduler are
+        stored on the trainer rather than returned to PyTorch Lightning.
+
+        ``_configure_optimizer`` returns ``([optimizer], [scheduler])`` only for SGD with
+        ``adapt_lr`` enabled, and ``[optimizer]`` otherwise; both shapes are handled here and the
+        task/feature result is passed straight through to Lightning.
+        """
         nets = [self.feat, self.classifier]
         parameters = set()
         for net in nets:
             parameters |= set(net.parameters())
 
-        if self._adapt_lr:
-            task_feat_optimizer, task_feat_sched = self._configure_optimizer(parameters)
-            self.critic_opt, self.critic_sched = self._configure_optimizer(self.domain_classifier.parameters())
-            self.critic_opt = self.critic_opt[0]
-            self.critic_sched = self.critic_sched[0]
-            return task_feat_optimizer, task_feat_sched
+        critic_result = self._configure_optimizer(self.domain_classifier.parameters())
+        if isinstance(critic_result, tuple):
+            critic_optimizers, critic_schedulers = critic_result
+            self.critic_opt = critic_optimizers[0]
+            self.critic_sched = critic_schedulers[0]
         else:
-            task_feat_optimizer = self._configure_optimizer(parameters)
-            self.critic_opt = self._configure_optimizer(self.domain_classifier.parameters())
+            self.critic_opt = critic_result[0]
             self.critic_sched = None
-            self.critic_opt = self.critic_opt[0]
-        return task_feat_optimizer
+
+        return self._configure_optimizer(parameters)
 
 
 class WDGRLTrainerMod(WDGRLTrainer):

--- a/tests/pipeline/test_domain_adapter.py
+++ b/tests/pipeline/test_domain_adapter.py
@@ -69,6 +69,52 @@ def test_base_adapt_trainer_configure_optimizers_with_adamw():
     assert optimizers[0].defaults["weight_decay"] == 0.3
 
 
+def _wdgrl_trainer(optimizer, adapt_lr):
+    return domain_adapter.WDGRLTrainer(
+        dataset=_DummyDataset(),
+        feature_extractor=torch.nn.Linear(2, 3),
+        task_classifier=torch.nn.Linear(3, 2),
+        critic=torch.nn.Linear(3, 1),
+        nb_init_epochs=1,
+        nb_adapt_epochs=2,
+        init_lr=0.004,
+        adapt_lr=adapt_lr,
+        optimizer=optimizer,
+    )
+
+
+@pytest.mark.parametrize("optimizer_type", ["Adam", "AdamW"])
+def test_wdgrl_configure_optimizers_without_scheduler(optimizer_type):
+    """Optimizers that produce no scheduler are handled under adapt_lr (issue #548).
+
+    _configure_optimizer only builds a scheduler for SGD, so Adam/AdamW return a bare optimizer
+    list. configure_optimizers previously force-unpacked a (optimizers, schedulers) tuple and
+    raised ValueError for these.
+    """
+    model = _wdgrl_trainer({"type": optimizer_type, "optim_params": {}}, adapt_lr=True)
+
+    optimizers = model.configure_optimizers()
+
+    assert isinstance(optimizers, list)
+    assert len(optimizers) == 1
+    assert isinstance(optimizers[0], getattr(torch.optim, optimizer_type))
+    # The critic optimizer is stored for manual stepping; there is no scheduler for Adam/AdamW.
+    assert isinstance(model.critic_opt, getattr(torch.optim, optimizer_type))
+    assert model.critic_sched is None
+
+
+def test_wdgrl_configure_optimizers_with_scheduler():
+    """SGD with adapt_lr still returns the (optimizers, schedulers) pair and sets a critic scheduler."""
+    model = _wdgrl_trainer({"type": "SGD", "optim_params": {"momentum": 0.9}}, adapt_lr=True)
+
+    optimizers, schedulers = model.configure_optimizers()
+
+    assert isinstance(optimizers[0], torch.optim.SGD)
+    assert len(schedulers) == 1
+    assert isinstance(model.critic_opt, torch.optim.SGD)
+    assert model.critic_sched is not None
+
+
 @pytest.mark.parametrize("da_method", DA_METHODS)
 @pytest.mark.parametrize("n_fewshot", FEW_SHOT)
 def test_domain_adaptor(da_method, n_fewshot, download_path, testing_cfg):


### PR DESCRIPTION
Fixes #548.

### Description
`WDGRLTrainer.configure_optimizers` assumed `_configure_optimizer` always returned `(optimizers, schedulers)`, so the default Adam optimizer (which returns just `[optimizer]`) raised `ValueError`. It now handles both shapes and passes the task result straight through. Adds tests for the Adam/AdamW and SGD paths.

### Status
Ready

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [ ] Source for documentation at `docs` manually updated for new API.
