### PR TITLE
Replace eval() with getattr()/int() to prevent arbitrary code execution

### DIFF
--- a/kale/loaddata/video_datasets.py
+++ b/kale/loaddata/video_datasets.py
@@ -76,8 +76,9 @@ class BasicVideoDataset(VideoFrameDataset):
         i = 0
         input_file = pd.read_pickle(self.annotationfile_path)
         for line in input_file.values:
-            if 0 <= int(line[5]) < self.n_classes:
-                data.append((line[0], int(line[1]), int(line[2]), int(line[5])))
+            label = int(line[5])
+            if 0 <= label < self.n_classes:
+                data.append((line[0], int(line[1]), int(line[2]), label))
                 i = i + 1
         logging.info("Number of {:5} action segments: {}".format(self.dataset, i))
         return data

--- a/kale/loaddata/video_datasets.py
+++ b/kale/loaddata/video_datasets.py
@@ -76,8 +76,8 @@ class BasicVideoDataset(VideoFrameDataset):
         i = 0
         input_file = pd.read_pickle(self.annotationfile_path)
         for line in input_file.values:
-            if 0 <= eval(line[5]) < self.n_classes:
-                data.append((line[0], eval(line[1]), eval(line[2]), eval(line[5])))
+            if 0 <= int(line[5]) < self.n_classes:
+                data.append((line[0], int(line[1]), int(line[2]), int(line[5])))
                 i = i + 1
         logging.info("Number of {:5} action segments: {}".format(self.dataset, i))
         return data

--- a/kale/pipeline/fewshot_trainer.py
+++ b/kale/pipeline/fewshot_trainer.py
@@ -111,7 +111,7 @@ class ProtoNetTrainer(pl.LightningModule):
             loss (torch.Tensor): Loss value.
             return_dict (dict): Dictionary of loss and accuracy.
         """
-        loss, acc = eval(f"self.loss_{mode}")(feature_support, feature_query)
+        loss, acc = getattr(self, f"loss_{mode}")(feature_support, feature_query)
         return_dict = {"{}_loss".format(mode): loss.item(), "{}_acc".format(mode): acc}
         return loss, return_dict
 
@@ -146,5 +146,5 @@ class ProtoNetTrainer(pl.LightningModule):
         """
         Configure optimizer for training. Can be modified to support different optimizers from ``torch.optim``.
         """
-        optimizer = eval(f"torch.optim.{self.optimizer}")(self.model.parameters(), lr=self.lr)
+        optimizer = getattr(torch.optim, self.optimizer)(self.model.parameters(), lr=self.lr)
         return optimizer

--- a/kale/pipeline/fewshot_trainer.py
+++ b/kale/pipeline/fewshot_trainer.py
@@ -105,7 +105,8 @@ class ProtoNetTrainer(pl.LightningModule):
         Args:
             feature_support (torch.Tensor): Support features.
             feature_query (torch.Tensor): Query features.
-            mode (str): Mode of the trainer, "train", "val" or "test". Default: "train".
+            mode (str): Mode of the trainer, "train" or "val" (the loss used for validation is also
+                used for testing). Default: "train".
 
         Returns:
             loss (torch.Tensor): Loss value.

--- a/tests/loaddata/test_video_datasets.py
+++ b/tests/loaddata/test_video_datasets.py
@@ -1,0 +1,60 @@
+import pandas as pd
+import pytest
+
+from kale.loaddata.video_datasets import BasicVideoDataset
+
+
+def _make_annotation_file(tmp_path, rows):
+    """Write an annotation DataFrame to a pickle, mirroring the EPIC-Kitchen list format.
+
+    ``make_dataset`` reads columns 0 (video name), 1 (start frame), 2 (end frame) and 5 (label).
+    """
+    frame = pd.DataFrame(rows, columns=["video", "start", "end", "spare_a", "spare_b", "label"])
+    path = tmp_path / "annotations.pkl"
+    frame.to_pickle(path)
+    return path
+
+
+def _dataset_for(annotation_path, n_classes=8):
+    """Build a BasicVideoDataset without running __init__, which needs real image folders."""
+    dataset = object.__new__(BasicVideoDataset)
+    dataset.annotationfile_path = str(annotation_path)
+    dataset.n_classes = n_classes
+    dataset.dataset = "train"
+    return dataset
+
+
+class TestBasicVideoDatasetMakeDataset:
+    """Tests for ``BasicVideoDataset.make_dataset`` annotation parsing (issue #556)."""
+
+    def test_parses_annotation_fields_as_integers(self, tmp_path):
+        """Start frame, end frame and label are parsed to ints, and out-of-range labels are dropped."""
+        path = _make_annotation_file(
+            tmp_path,
+            [
+                ["video_1", "10", "20", "", "", "3"],
+                ["video_2", "30", "45", "", "", "0"],
+                ["video_3", "50", "60", "", "", "9"],  # label >= n_classes, excluded
+            ],
+        )
+
+        data = _dataset_for(path, n_classes=8).make_dataset()
+
+        assert data == [("video_1", 10, 20, 3), ("video_2", 30, 45, 0)]
+        for _, start, end, label in data:
+            assert isinstance(start, int) and isinstance(end, int) and isinstance(label, int)
+
+    def test_malicious_annotation_value_is_not_executed(self, tmp_path):
+        """A code-like annotation value is rejected rather than evaluated.
+
+        ``make_dataset`` previously ran ``eval`` on these fields, so a crafted pickle could execute
+        arbitrary code. Parsing with ``int`` must raise instead, and must leave no side effect.
+        """
+        marker = tmp_path / "marker.txt"
+        payload = f"__import__('pathlib').Path(r'{marker}').write_text('executed')"
+        path = _make_annotation_file(tmp_path, [["video_1", "10", "20", "", "", payload]])
+
+        with pytest.raises(ValueError):
+            _dataset_for(path).make_dataset()
+
+        assert not marker.exists(), "annotation value was executed instead of parsed"


### PR DESCRIPTION
Fixes #556.

### Description
Removes three `eval()` call sites used for dynamic dispatch and annotation parsing, replacing them with `getattr()` (loss/optimizer lookup) and `int()` (frame/label parsing). Equivalent for valid inputs, but malicious values can no longer execute. Adds tests for `make_dataset`, including rejection of a code-like value.

### Status
Ready

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] Source for documentation at `docs` manually updated for new API.
