### PR TITLE
Reduce parameter complexity in plot_cumulative and evaluate_correlations

### DIFF
--- a/kale/evaluate/similarity_metrics.py
+++ b/kale/evaluate/similarity_metrics.py
@@ -6,6 +6,7 @@ Functions related to similarity metrics including similarity measures and correl
 
 import logging
 import os
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
@@ -15,17 +16,99 @@ from kale.interpret.uncertainty_utils import analyze_and_plot_uncertainty_correl
 from kale.prepdata.tabular_transform import apply_confidence_inversion
 
 
+@dataclass
+class CorrelationConfig:
+    """
+    Configuration for :func:`evaluate_correlations`.
+
+    Groups the analysis, plotting and output settings so that callers pass one object instead of a long
+    parameter list, and so that the binning and file-naming constants are named rather than embedded in
+    the analysis code.
+    """
+
+    # Analysis settings
+    num_bins: int = 10  # Number of quantile bins used to derive the uncertainty thresholds
+    num_folds: int = 8  # Number of testing folds to include
+    error_scaling_factor: float = 1.0  # Multiplicative factor for error values (e.g. pixel to mm conversion)
+    combine_middle_bins: bool = False  # If True, keep only the outer thresholds so middle bins merge into one
+
+    # Plotting and output
+    colormap: str = "Set1"  # Matplotlib colormap name for the correlation plots
+    save_path: Optional[str] = None  # Directory to save plots into; if None, no figure is written
+    to_log: bool = False  # If True, use logarithmic scaling on the plot axes
+    file_name_template: str = "{model}_{uncertainty}_correlation_pwr_all_targets.pdf"  # Output file name pattern
+
+
+def _fold_rows(data_structs: pd.DataFrame, num_folds: int) -> pd.DataFrame:
+    """Select the rows belonging to the first ``num_folds`` testing folds.
+
+    Args:
+        data_structs (pd.DataFrame): Predictions for a single model.
+        num_folds (int): Number of testing folds to include.
+
+    Returns:
+        pd.DataFrame: The rows for those folds.
+    """
+    return data_structs[data_structs["Testing Fold"].isin(np.arange(num_folds))]
+
+
+def _fold_errors_and_uncertainties(
+    data_structs: pd.DataFrame,
+    uncertainty_pair: Tuple[str, str, str],
+    invert_uncertainty: bool,
+    num_folds: int,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Extract the errors and uncertainties for one uncertainty type across the testing folds.
+
+    Args:
+        data_structs (pd.DataFrame): Predictions for a single model.
+        uncertainty_pair (tuple): The (name, error key, uncertainty key) triple being analysed.
+        invert_uncertainty (bool): Whether the uncertainty values should be inverted.
+        num_folds (int): Number of testing folds to include.
+
+    Returns:
+        tuple: Flattened error values and (optionally inverted) uncertainty values.
+    """
+    uncertainty_type = uncertainty_pair[0]
+    rows = _fold_rows(data_structs, num_folds)
+
+    errors = np.array(rows[[uncertainty_type + " Error"]].values.tolist()).flatten()
+
+    uncertainties = rows[[uncertainty_type + " Uncertainty"]]
+    if invert_uncertainty:
+        uncertainties = apply_confidence_inversion(uncertainties, uncertainty_pair[2])
+
+    return errors, np.array(uncertainties.values.tolist()).flatten()
+
+
+def _quantile_thresholds(uncertainty_values: np.ndarray, num_bins: int, combine_middle_bins: bool) -> List[float]:
+    """Compute the uncertainty values that separate the quantile bins.
+
+    Args:
+        uncertainty_values (np.ndarray): Uncertainty values across all folds.
+        num_bins (int): Number of quantile bins.
+        combine_middle_bins (bool): If True, keep only the outer thresholds, so the middle bins merge
+            into a single bin and only the two edge bins remain distinct.
+
+    Returns:
+        list: The threshold values, ordered from lowest to highest uncertainty.
+    """
+    sorted_uncertainties = np.sort(uncertainty_values)
+
+    quantiles = np.arange(1 / num_bins, 1, 1 / num_bins)[: num_bins - 1]
+    thresholds = [np.quantile(sorted_uncertainties, quantile) for quantile in quantiles]
+
+    if combine_middle_bins:
+        thresholds = [thresholds[0], thresholds[-1]]
+
+    return thresholds
+
+
 def evaluate_correlations(
     bin_predictions: Dict[str, pd.DataFrame],
     uncertainty_error_pairs: List[Tuple[str, str, str]],
-    num_bins: int,
     confidence_invert_tuples: List[Tuple[str, bool]],
-    colormap: str = "Set1",
-    num_folds: int = 8,
-    error_scaling_factor: float = 1,
-    combine_middle_bins: bool = False,
-    save_path: Optional[str] = None,
-    to_log: bool = False,
+    config: Optional[CorrelationConfig] = None,
 ) -> Dict[str, Dict[str, Dict[str, Any]]]:
     """
     Calculates the correlation between error and uncertainty for each bin and for each target,
@@ -37,16 +120,11 @@ def evaluate_correlations(
         bin_predictions: A dictionary of Pandas DataFrames containing model predictions for each testing fold.
         uncertainty_error_pairs: A list of tuples specifying the names of the uncertainty,
             error, and uncertainty inversion keys for each pair.
-        num_bins: The number of quantile bins to divide the data into.
         confidence_invert_tuples: A list of tuples specifying whether to invert the uncertainty values for each method.
                           First element is a string specifying the uncertainty method name and the second element is
                           a boolean whether to invert e.g. [["E-MHA", True], ["E-CPV", False]]
-        colormap (str): Name of matplotlib colormap. Defaults to 'Set1'.
-        num_folds: The number of folds to use for cross-validation (default: 8).
-        error_scaling_factor: The scale factor to transform error by (default: 1).
-        combine_middle_bins: Whether to combine the middle bins into one bin (default: False).
-        save_path: The path to save the correlation plots (default: None).
-        to_log: Whether to use logarithmic scaling for the x and y axes of the plots (default: False).
+        config: Analysis, plotting and output settings. Defaults to :class:`CorrelationConfig`.
+
     Returns:
         A dictionary containing the correlation statistics for each model and uncertainty method.
         The dictionary has the following structure:
@@ -73,63 +151,47 @@ def evaluate_correlations(
         The "all_folds" key contains the correlation statistics for all testing folds combined.
         The "quantiles" key contains the correlation statistics for each quantile bin separately.
     """
+    config = config or CorrelationConfig()
 
     logger = logging.getLogger("qbin")
     # define dict to save correlations to.
     correlation_dict: Dict[str, Dict[str, Dict[str, Any]]] = {}
 
-    num_bins_quantiles = num_bins
-    # If we are combining the middle bins, we only have the 2 edge bins and the middle bins are combined into 1 bin.
-    if combine_middle_bins:
-        num_bins = 3
+    invert_by_type = dict(confidence_invert_tuples)
 
     # Loop over models (model) and uncertainty methods (uncert_pair)
-    for _, (model, data_structs) in enumerate(bin_predictions.items()):
+    for model, data_structs in bin_predictions.items():
         correlation_dict[model] = {}
         for uncert_pair in uncertainty_error_pairs:  # uncert_pair = [pair name, error name , uncertainty name]
             uncertainty_type = uncert_pair[0]
             logger.info("All folds correlation for Model: %s, Uncertainty type %s :", uncertainty_type, model)
-            fold_errors = np.array(
-                data_structs[(data_structs["Testing Fold"].isin(np.arange(num_folds)))][
-                    [uncertainty_type + " Error"]
-                ].values.tolist()
-            ).flatten()
 
-            fold_uncertainty_values = data_structs[(data_structs["Testing Fold"].isin(np.arange(num_folds)))][
-                [uncertainty_type + " Uncertainty"]
-            ]
-
-            invert_uncert = [x[1] for x in confidence_invert_tuples if x[0] == uncertainty_type][0]
-            if invert_uncert:
-                fold_uncertainty_values = apply_confidence_inversion(fold_uncertainty_values, uncert_pair[2])
-
-            fold_uncertainty_values = np.array(fold_uncertainty_values.values.tolist()).flatten()
+            fold_errors, fold_uncertainty_values = _fold_errors_and_uncertainties(
+                data_structs, uncert_pair, invert_by_type[uncertainty_type], config.num_folds
+            )
 
             # Get the quantiles of the data w.r.t to the uncertainty values.
-            # Get the true uncertianty quantiles
-            sorted_uncertainties = np.sort(fold_uncertainty_values)
-
-            quantiles = np.arange(1 / num_bins_quantiles, 1, 1 / num_bins_quantiles)[: num_bins_quantiles - 1]
-            quantile_thresholds = [np.quantile(sorted_uncertainties, q) for q in quantiles]
-
-            # If we are combining the middle bins, combine the middle lists into 1 list.
-            if combine_middle_bins:
-                quantile_thresholds = [quantile_thresholds[0], quantile_thresholds[-1]]
+            quantile_thresholds = _quantile_thresholds(
+                fold_uncertainty_values, config.num_bins, config.combine_middle_bins
+            )
 
             # fit a piece-wise linear regression line between quantiles, and return correlation values.
             save_path_fig = (
-                os.path.join(save_path, model + "_" + uncertainty_type + "_correlation_pwr_all_targets.pdf")
-                if save_path
+                os.path.join(
+                    config.save_path,
+                    config.file_name_template.format(model=model, uncertainty=uncertainty_type),
+                )
+                if config.save_path
                 else None
             )
             corr_dict = analyze_and_plot_uncertainty_correlation(
                 fold_errors,
                 fold_uncertainty_values,
                 quantile_thresholds,
-                colormap=colormap,
-                error_scaling_factor=error_scaling_factor,
+                colormap=config.colormap,
+                error_scaling_factor=config.error_scaling_factor,
                 save_path=save_path_fig,
-                to_log=to_log,
+                to_log=config.to_log,
             )
 
             correlation_dict[model][uncertainty_type] = corr_dict

--- a/kale/evaluate/similarity_metrics.py
+++ b/kale/evaluate/similarity_metrics.py
@@ -164,7 +164,7 @@ def evaluate_correlations(
         correlation_dict[model] = {}
         for uncert_pair in uncertainty_error_pairs:  # uncert_pair = [pair name, error name , uncertainty name]
             uncertainty_type = uncert_pair[0]
-            logger.info("All folds correlation for Model: %s, Uncertainty type %s :", uncertainty_type, model)
+            logger.info("All folds correlation for Model: %s, Uncertainty type %s :", model, uncertainty_type)
 
             fold_errors, fold_uncertainty_values = _fold_errors_and_uncertainties(
                 data_structs, uncert_pair, invert_by_type[uncertainty_type], config.num_folds

--- a/kale/evaluate/similarity_metrics.py
+++ b/kale/evaluate/similarity_metrics.py
@@ -1,7 +1,9 @@
-"""
-Authors: Lawrence Schobs, lawrenceschobs@gmail.com
+# =============================================================================
+# Author: Lawrence Schobs, lawrenceschobs@gmail.com
+#         Charles Anjah, cmanjahart@gmail.com
+# =============================================================================
 
-Functions related to similarity metrics including similarity measures and correlations.
+"""Functions related to similarity metrics including similarity measures and correlations.
 """
 
 import logging

--- a/kale/evaluate/similarity_metrics.py
+++ b/kale/evaluate/similarity_metrics.py
@@ -18,13 +18,7 @@ from kale.prepdata.tabular_transform import apply_confidence_inversion
 
 @dataclass
 class CorrelationConfig:
-    """
-    Configuration for :func:`evaluate_correlations`.
-
-    Groups the analysis, plotting and output settings so that callers pass one object instead of a long
-    parameter list, and so that the binning and file-naming constants are named rather than embedded in
-    the analysis code.
-    """
+    """Analysis, plotting and output settings for :func:`evaluate_correlations`."""
 
     # Analysis settings
     num_bins: int = 10  # Number of quantile bins used to derive the uncertainty thresholds
@@ -111,8 +105,8 @@ def evaluate_correlations(
     config: Optional[CorrelationConfig] = None,
 ) -> Dict[str, Dict[str, Dict[str, Any]]]:
     """
-    Calculates the correlation between error and uncertainty for each bin and for each target,
-    using a piece-wise linear regression model.
+    Calculate the correlation between error and uncertainty for each model and uncertainty type over all
+    testing folds, fitting a piece-wise linear regression between the quantile thresholds.
 
     Designed for use in Quantile Binning (/pykale/examples/landmark_uncertainty/main.py).
 
@@ -126,30 +120,9 @@ def evaluate_correlations(
         config: Analysis, plotting and output settings. Defaults to :class:`CorrelationConfig`.
 
     Returns:
-        A dictionary containing the correlation statistics for each model and uncertainty method.
-        The dictionary has the following structure:
-        {
-            <model_name>: {
-                <uncertainty_name>: {
-                    "all_folds": {
-                        "r": <correlation coefficient>,
-                        "p": <p-value>,
-                        "fit_params": <regression line parameters>,
-                        "ci": <confidence intervals for the regression line parameters>
-                    },
-                    "quantiles": {
-                        <quantile_index>: {
-                            "r": <correlation coefficient>,
-                            "p": <p-value>,
-                            "fit_params": <regression line parameters>,
-                            "ci": <confidence intervals for the regression line parameters>
-                        }
-                    }
-                }
-            }
-        }
-        The "all_folds" key contains the correlation statistics for all testing folds combined.
-        The "quantiles" key contains the correlation statistics for each quantile bin separately.
+        The correlation statistics for each model and uncertainty type, as returned by
+        :func:`kale.interpret.uncertainty_utils.analyze_and_plot_uncertainty_correlation`:
+        ``{<model_name>: {<uncertainty_name>: {"spearman": [coefficient, p_value], "pearson": [coefficient, p_value]}}}``.
     """
     config = config or CorrelationConfig()
 

--- a/kale/interpret/uncertainty_quantiles.py
+++ b/kale/interpret/uncertainty_quantiles.py
@@ -65,7 +65,7 @@ from typing import Any, Callable, cast, Dict, List, Optional, Tuple
 
 import numpy as np
 
-from kale.evaluate.similarity_metrics import evaluate_correlations
+from kale.evaluate.similarity_metrics import CorrelationConfig, evaluate_correlations
 from kale.evaluate.uncertainty_metrics import evaluate_bounds, evaluate_jaccard, get_mean_errors
 from kale.interpret.box_plot import (
     execute_boxplot,
@@ -73,7 +73,7 @@ from kale.interpret.box_plot import (
     plot_per_model_boxplot,
     plot_q_comparing_boxplot,
 )
-from kale.interpret.uncertainty_utils import plot_cumulative
+from kale.interpret.uncertainty_utils import CumulativePlotConfig, plot_cumulative
 from kale.prepdata.tabular_transform import generate_struct_for_qbin
 from kale.utils.save_xlsx import generate_summary_df
 
@@ -525,57 +525,67 @@ class QuantileBinningAnalyzer:
             evaluate_correlations(
                 eval_data["bins"],
                 uncertainty_error_model_triples,
-                config.num_bins,
                 config.confidence_invert,
-                num_folds=config.num_folds,
-                colormap=colormap,
-                error_scaling_factor=config.error_scaling_factor,
-                combine_middle_bins=config.combine_middle_bins,
-                save_path=self.save_folder if self.save_figures else None,
-                to_log=True,
+                CorrelationConfig(
+                    num_bins=config.num_bins,
+                    num_folds=config.num_folds,
+                    colormap=colormap,
+                    error_scaling_factor=config.error_scaling_factor,
+                    combine_middle_bins=config.combine_middle_bins,
+                    save_path=self.save_folder if self.save_figures else None,
+                    to_log=True,
+                ),
             )
 
         if self.display_settings.get("cumulative_error"):
-            colormap = self.boxplot_config.get("colormap", "Set1")
             # Extract just the base names (first element) for plot_cumulative
             extracted_uncertainty_error_pairs = [(name, name) for name, err, unc in config.uncertainty_error_pairs]
+
+            def cumulative_config(title: str, file_name: str, compare_to_all: bool = False) -> CumulativePlotConfig:
+                """Build a plot config, holding the settings shared by every cumulative plot."""
+                return CumulativePlotConfig(
+                    colormap=self.boxplot_config.get("colormap", "Set1"),
+                    title=title,
+                    compare_to_all=compare_to_all,
+                    save_path=self.save_folder if self.save_figures else None,
+                    file_name=self._build_filename(file_name),
+                    error_scaling_factor=config.error_scaling_factor,
+                )
+
             plot_cumulative(
-                colormap,
                 eval_data["bins"],
                 config.models,
                 extracted_uncertainty_error_pairs,
                 np.arange(config.num_bins),
-                CUMULATIVE_ERROR_TITLE_TEMPLATE.format(config.dataset),
-                save_path=self.save_folder if self.save_figures else None,
-                file_name=self._build_filename(FILE_NAME_ALL_PREDICTIONS_CUMULATIVE_ERROR),
-                error_scaling_factor=config.error_scaling_factor,
+                cumulative_config(
+                    CUMULATIVE_ERROR_TITLE_TEMPLATE.format(config.dataset),
+                    FILE_NAME_ALL_PREDICTIONS_CUMULATIVE_ERROR,
+                ),
             )
             # Plot cumulative error figure for B1 only predictions
             plot_cumulative(
-                colormap,
                 eval_data["bins"],
                 config.models,
                 extracted_uncertainty_error_pairs,
                 0,
-                CUMULATIVE_ERROR_B1_TITLE_TEMPLATE.format(config.dataset),
-                save_path=self.save_folder if self.save_figures else None,
-                file_name=self._build_filename(FILE_NAME_B1_PREDICTIONS_CUMULATIVE_ERROR),
-                error_scaling_factor=config.error_scaling_factor,
+                cumulative_config(
+                    CUMULATIVE_ERROR_B1_TITLE_TEMPLATE.format(config.dataset),
+                    FILE_NAME_B1_PREDICTIONS_CUMULATIVE_ERROR,
+                ),
             )
 
             # Plot cumulative error figure comparing B1 and ALL, for both models
             for model_type in config.models:
                 plot_cumulative(
-                    colormap,
                     eval_data["bins"],
                     [model_type],
                     extracted_uncertainty_error_pairs,
                     0,
-                    CUMULATIVE_ERROR_B1_VS_ALL_TITLE_TEMPLATE.format(model_type, config.dataset),
-                    compare_to_all=True,
-                    save_path=self.save_folder if self.save_figures else None,
-                    file_name=self._build_filename(FILE_NAME_B1_VS_ALL_CUMULATIVE_ERROR_TEMPLATE.format(model_type)),
-                    error_scaling_factor=config.error_scaling_factor,
+                    cumulative_config(
+                        CUMULATIVE_ERROR_B1_VS_ALL_TITLE_TEMPLATE.format(model_type, config.dataset),
+                        FILE_NAME_B1_VS_ALL_CUMULATIVE_ERROR_TEMPLATE.format(model_type),
+                        compare_to_all=True,
+                    ),
                 )
 
         if self.display_settings.get("errors"):

--- a/kale/interpret/uncertainty_quantiles.py
+++ b/kale/interpret/uncertainty_quantiles.py
@@ -441,6 +441,103 @@ class QuantileBinningAnalyzer:
         ext = self.figure_format if is_figure else self.data_format
         return f"{base_name}.{ext}"
 
+    def _plot_correlations(self, config: QuantileBinningConfig, eval_data: Dict[str, Any]) -> None:
+        """
+        Analyze and plot the correlation between uncertainty estimates and actual errors.
+
+        Args:
+            config (QuantileBinningConfig): Configuration for this analysis.
+            eval_data (Dict[str, Any]): Evaluation data, keyed by metric, as produced by the analysis.
+        """
+        evaluate_correlations(
+            eval_data["bins"],
+            config.uncertainty_error_pairs,
+            config.confidence_invert,
+            CorrelationConfig(
+                num_bins=config.num_bins,
+                num_folds=config.num_folds,
+                colormap=self.boxplot_config.get("colormap", "Set1"),
+                error_scaling_factor=config.error_scaling_factor,
+                combine_middle_bins=config.combine_middle_bins,
+                save_path=self.save_folder if self.save_figures else None,
+                to_log=True,
+            ),
+        )
+
+    def _cumulative_plot_config(
+        self, config: QuantileBinningConfig, title: str, file_name: str, compare_to_all: bool = False
+    ) -> CumulativePlotConfig:
+        """
+        Build a cumulative plot configuration, holding the settings shared by every cumulative plot.
+
+        Args:
+            config (QuantileBinningConfig): Configuration for this analysis.
+            title (str): Title for the plot.
+            file_name (str): File name stem, expanded by :meth:`_build_filename`.
+            compare_to_all (bool): Whether to overlay the full dataset alongside the selected bins.
+
+        Returns:
+            CumulativePlotConfig: The configuration to pass to :func:`plot_cumulative`.
+        """
+        return CumulativePlotConfig(
+            colormap=self.boxplot_config.get("colormap", "Set1"),
+            title=title,
+            compare_to_all=compare_to_all,
+            save_path=self.save_folder if self.save_figures else None,
+            file_name=self._build_filename(file_name),
+            error_scaling_factor=config.error_scaling_factor,
+        )
+
+    def _plot_cumulative_errors(self, config: QuantileBinningConfig, eval_data: Dict[str, Any]) -> None:
+        """
+        Plot cumulative error distributions for all predictions, for B1 only, and for B1 against all.
+
+        Args:
+            config (QuantileBinningConfig): Configuration for this analysis.
+            eval_data (Dict[str, Any]): Evaluation data, keyed by metric, as produced by the analysis.
+        """
+        # Extract just the base names (first element) for plot_cumulative
+        uncertainty_pairs = [(name, name) for name, err, unc in config.uncertainty_error_pairs]
+
+        plot_cumulative(
+            eval_data["bins"],
+            config.models,
+            uncertainty_pairs,
+            np.arange(config.num_bins),
+            self._cumulative_plot_config(
+                config,
+                CUMULATIVE_ERROR_TITLE_TEMPLATE.format(config.dataset),
+                FILE_NAME_ALL_PREDICTIONS_CUMULATIVE_ERROR,
+            ),
+        )
+        # Plot cumulative error figure for B1 only predictions
+        plot_cumulative(
+            eval_data["bins"],
+            config.models,
+            uncertainty_pairs,
+            0,
+            self._cumulative_plot_config(
+                config,
+                CUMULATIVE_ERROR_B1_TITLE_TEMPLATE.format(config.dataset),
+                FILE_NAME_B1_PREDICTIONS_CUMULATIVE_ERROR,
+            ),
+        )
+
+        # Plot cumulative error figure comparing B1 and ALL, for both models
+        for model_type in config.models:
+            plot_cumulative(
+                eval_data["bins"],
+                [model_type],
+                uncertainty_pairs,
+                0,
+                self._cumulative_plot_config(
+                    config,
+                    CUMULATIVE_ERROR_B1_VS_ALL_TITLE_TEMPLATE.format(model_type, config.dataset),
+                    FILE_NAME_B1_VS_ALL_CUMULATIVE_ERROR_TEMPLATE.format(model_type),
+                    compare_to_all=True,
+                ),
+            )
+
     def run_individual_bin_comparison(self, config: QuantileBinningConfig) -> None:
         """
         Execute comprehensive comparative analysis of different models and uncertainty types at fixed bin counts.
@@ -519,74 +616,10 @@ class QuantileBinningAnalyzer:
         category_labels = [rf"$B_{{{num_bins_display + 1 - (i + 1)}}}$" for i in range(num_bins_display + 1)]
         # --- Start plotting ---
         if self.display_settings.get("correlation"):
-            colormap = self.boxplot_config.get("colormap", "Set1")
-            uncertainty_error_model_triples = config.uncertainty_error_pairs
-            # confidence_invert is already properly typed as List[Tuple[str, bool]]
-            evaluate_correlations(
-                eval_data["bins"],
-                uncertainty_error_model_triples,
-                config.confidence_invert,
-                CorrelationConfig(
-                    num_bins=config.num_bins,
-                    num_folds=config.num_folds,
-                    colormap=colormap,
-                    error_scaling_factor=config.error_scaling_factor,
-                    combine_middle_bins=config.combine_middle_bins,
-                    save_path=self.save_folder if self.save_figures else None,
-                    to_log=True,
-                ),
-            )
+            self._plot_correlations(config, eval_data)
 
         if self.display_settings.get("cumulative_error"):
-            # Extract just the base names (first element) for plot_cumulative
-            extracted_uncertainty_error_pairs = [(name, name) for name, err, unc in config.uncertainty_error_pairs]
-
-            def cumulative_config(title: str, file_name: str, compare_to_all: bool = False) -> CumulativePlotConfig:
-                """Build a plot config, holding the settings shared by every cumulative plot."""
-                return CumulativePlotConfig(
-                    colormap=self.boxplot_config.get("colormap", "Set1"),
-                    title=title,
-                    compare_to_all=compare_to_all,
-                    save_path=self.save_folder if self.save_figures else None,
-                    file_name=self._build_filename(file_name),
-                    error_scaling_factor=config.error_scaling_factor,
-                )
-
-            plot_cumulative(
-                eval_data["bins"],
-                config.models,
-                extracted_uncertainty_error_pairs,
-                np.arange(config.num_bins),
-                cumulative_config(
-                    CUMULATIVE_ERROR_TITLE_TEMPLATE.format(config.dataset),
-                    FILE_NAME_ALL_PREDICTIONS_CUMULATIVE_ERROR,
-                ),
-            )
-            # Plot cumulative error figure for B1 only predictions
-            plot_cumulative(
-                eval_data["bins"],
-                config.models,
-                extracted_uncertainty_error_pairs,
-                0,
-                cumulative_config(
-                    CUMULATIVE_ERROR_B1_TITLE_TEMPLATE.format(config.dataset),
-                    FILE_NAME_B1_PREDICTIONS_CUMULATIVE_ERROR,
-                ),
-            )
-
-            # Plot cumulative error figure comparing B1 and ALL, for both models
-            for model_type in config.models:
-                plot_cumulative(
-                    eval_data["bins"],
-                    [model_type],
-                    extracted_uncertainty_error_pairs,
-                    0,
-                    cumulative_config(
-                        CUMULATIVE_ERROR_B1_VS_ALL_TITLE_TEMPLATE.format(model_type, config.dataset),
-                        FILE_NAME_B1_VS_ALL_CUMULATIVE_ERROR_TEMPLATE.format(model_type),
-                        compare_to_all=True,
-                    ),
-                )
+            self._plot_cumulative_errors(config, eval_data)
 
         if self.display_settings.get("errors"):
             uncertainty_categories = [[name, name] for name, err, unc in config.uncertainty_error_pairs]

--- a/kale/interpret/uncertainty_quantiles.py
+++ b/kale/interpret/uncertainty_quantiles.py
@@ -2,6 +2,7 @@
 # Author: Lawrence Schobs, lawrenceschobs@gmail.com
 #         Wenjie Zhao, mcsoft12138@outlook.com
 #         Zhongwei Ji, jizhongwei1999@outlook.com
+#         Charles Anjah, cmanjahart@gmail.com
 # =============================================================================
 
 """

--- a/kale/interpret/uncertainty_quantiles.py
+++ b/kale/interpret/uncertainty_quantiles.py
@@ -150,12 +150,7 @@ SUMMARY_MEAN_ERROR_TITLE = "Mean error"
 
 @dataclass
 class BaseAnalysisConfig:
-    """
-    Base configuration class with common analysis and visualization settings.
-
-    This base class consolidates shared fields across different analysis configurations to avoid duplication
-    and ensure consistency in plotting and analysis parameters.
-    """
+    """Analysis and visualization settings shared by the quantile binning configurations."""
 
     # Common analysis settings
     combine_middle_bins: bool = False  # If True, merge middle bins into one for simplified 3-bin analysis
@@ -183,24 +178,14 @@ class BaseAnalysisConfig:
     interpret: bool = True  # If True, execute analysis and plotting; if False, skip processing
 
     def __post_init__(self):
-        """
-        Initialize default values for mutable fields.
-
-        This method is automatically called after dataclass initialization to set up mutable default values that cannot
-        be safely defined in the field declarations.
-        """
+        """Set ``individual_targets_to_show`` to an empty list when not given."""
         if self.individual_targets_to_show is None:
             self.individual_targets_to_show = []
 
 
 @dataclass
 class QuantileBinningConfig(BaseAnalysisConfig):
-    """
-    Configuration class for quantile binning analysis.
-
-    This class replaces the tuple-based parameter passing with a more structured, type-safe approach for configuring
-    quantile binning uncertainty analysis. It inherits common analysis and visualization settings from BaseAnalysisConfig.
-    """
+    """Configuration for comparing models and uncertainty types at a fixed number of bins."""
 
     # Data configuration (specific to this analysis type)
     uncertainty_error_pairs: List[Tuple[str, str, str]] = field(
@@ -219,12 +204,7 @@ class QuantileBinningConfig(BaseAnalysisConfig):
 
 @dataclass
 class ComparingBinsConfig(BaseAnalysisConfig):
-    """
-    Configuration class for comparing different bin counts (Q values) analysis.
-
-    This class inherits common analysis and visualization settings from BaseAnalysisConfig, focusing on Q-value
-    optimization while reducing code duplication.
-    """
+    """Configuration for comparing different bin counts (Q values) for one model and uncertainty type."""
 
     # Data configuration (specific to this analysis type)
     uncertainty_error_pair: Tuple[str, str] = (
@@ -242,12 +222,7 @@ class ComparingBinsConfig(BaseAnalysisConfig):
 
 @dataclass
 class MetricPlotConfig:
-    """
-    Configuration class for metric plotting parameters.
-
-    This class consolidates plotting parameters to reduce function argument count
-    and improve maintainability of plotting methods.
-    """
+    """Plotting parameters for one metric, as consumed by :meth:`QuantileBinningAnalyzer._plot_metrics`."""
 
     # Core plotting parameters
     eval_data: Dict[str, Any]  # Dictionary containing computed metrics (errors, jaccard, bounds)
@@ -276,12 +251,7 @@ class MetricPlotConfig:
 
 @dataclass
 class MetricDefinition:
-    """
-    Definition of a specific metric's plotting characteristics.
-
-    This class encapsulates the specific parameters needed for each metric type,
-    enabling a unified plotting approach across different metrics.
-    """
+    """Plotting characteristics of a specific metric type (data keys, labels, scaling)."""
 
     metric_name: str  # Internal identifier for the metric (e.g., 'error', 'jaccard', 'errorbound')
     data_key: str  # Dictionary key to access metric data in eval_data
@@ -298,13 +268,11 @@ class MetricDefinition:
 
 class QuantileBinningAnalyzer:
     """
-    A class for performing and visualizing Quantile Binning uncertainty analysis.
+    Perform and visualize Quantile Binning uncertainty analysis.
 
-    This class encapsulates the functionality of the original generate_fig_individual_bin_comparison and
-    generate_fig_comparing_bins functions to reduce code duplication and improve maintainability. It provides two core
-    analysis modes:
-    1. Compare different models/uncertainty types at fixed bin counts (run_individual_bin_comparison).
-    2. Compare the impact of different bin counts (Q values) on model performance (run_comparing_bins_analysis).
+    Two analysis modes are provided:
+    1. Compare different models/uncertainty types at a fixed number of bins (run_individual_bin_comparison).
+    2. Compare the impact of different bin counts (Q values) on one model (run_comparing_bins_analysis).
     """
 
     # Metric definitions for unified plotting
@@ -540,36 +508,15 @@ class QuantileBinningAnalyzer:
 
     def run_individual_bin_comparison(self, config: QuantileBinningConfig) -> None:
         """
-        Execute comprehensive comparative analysis of different models and uncertainty types at fixed bin counts.
+        Compare models and uncertainty types across uncertainty bins at a fixed number of bins.
 
-        This method performs the core individual bin comparison analysis, comparing how different models and
-        uncertainty estimation methods perform across uncertainty-based bins. It generates multiple types of
-        visualizations and statistical analyses to evaluate uncertainty quantification effectiveness in medical imaging
-        applications.
-
-        The analysis workflow includes:
-        1. Data loading and evaluation metric computation for all model-uncertainty combinations
-        2. Correlation analysis between uncertainty estimates and actual errors (if enabled)
-        3. Cumulative error distribution analysis (if enabled)
-        4. Error boxplot generation comparing models across uncertainty bins
-        5. Error bounds accuracy assessment showing calibration quality
-        6. Jaccard similarity analysis evaluating bin overlap with ground truth
+        Loads the binned predictions, computes the evaluation metrics, and then generates whichever of the
+        following plots are enabled in ``display_settings``: uncertainty-error correlation, cumulative error
+        distribution, and boxplots of error, error bound accuracy and Jaccard index per bin. Does nothing if
+        ``interpret`` is False.
 
         Args:
-            config (QuantileBinningConfig): Comprehensive configuration object containing:
-                - uncertainty_error_pairs: List of (uncertainty_type, error_type) combinations to analyze
-                - models: List of model names to compare (e.g., ['ResNet50', 'VGG16', 'DenseNet'])
-                - dataset: Dataset identifier for labeling and file organization
-                - target_indices: List of anatomical landmark/target indices to analyze
-                - num_bins: Number of uncertainty quantile bins (typically 5-20)
-                - combine_middle_bins: Whether to merge middle bins for simplified 3-bin analysis
-                - confidence_invert: List of (uncertainty_type, should_invert) tuples for proper type-safe handling
-                - Display and visualization settings for plot generation
-                - File paths and saving configuration
-
-        Raises:
-            FileNotFoundError: If required data files are not found at specified paths.
-            ValueError: If configuration parameters are invalid or incompatible.
+            config (QuantileBinningConfig): The models, uncertainty types, targets, bin count and output settings.
 
         Example:
 
@@ -588,12 +535,6 @@ class QuantileBinningAnalyzer:
                 ...     individual_targets_to_show=[0, 1],
                 ... )
                 >>> analyzer.run_individual_bin_comparison(config)
-
-        Note:
-            - The method respects the analyzer's display_settings to control which plots are generated
-            - Individual target plots provide detailed per-landmark analysis when enabled
-            - Results are automatically saved to Excel summary files for further analysis
-            - All plots use consistent styling and colormaps for publication-ready figures
         """
         if not self.interpret:
             return
@@ -687,42 +628,15 @@ class QuantileBinningAnalyzer:
 
     def run_comparing_bins_analysis(self, config: ComparingBinsConfig) -> None:
         """
-        Execute comprehensive analysis comparing the impact of different bin counts (Q values) on model performance.
+        Compare the effect of different bin counts (Q values) on one model and uncertainty type.
 
-        This method performs Q-value optimization analysis to determine the optimal number of uncertainty bins for a
-        specific model and uncertainty type combination. It systematically evaluates how different binning strategies
-        (Q=5, Q=10, Q=15, etc.) affect uncertainty quantification performance and provides insights for hyperparameter
-        selection in medical imaging applications.
-
-        The analysis workflow includes:
-        1. Iterative data collection across all specified Q values
-        2. Metric computation (errors, Jaccard similarity, error bounds) for each Q configuration
-        3. Comparative visualization showing Q-value impact on performance metrics
-        4. Statistical analysis of optimal bin count selection
-        5. Individual target analysis (if enabled) for detailed per-landmark insights
-
-        This analysis is crucial for:
-        - Determining optimal binning strategies for specific datasets and models
-        - Understanding the trade-offs between granularity and statistical reliability
-        - Identifying Q values that maximize uncertainty-error correlation
-        - Validating binning approach generalizability across different anatomical targets
+        Loads the binned predictions and computes the evaluation metrics for each Q value, then generates
+        whichever of the error, error bound accuracy and Jaccard index boxplots are enabled in
+        ``display_settings``, with one category per Q value. Does nothing if ``interpret`` is False.
 
         Args:
-            config (ComparingBinsConfig): Comprehensive configuration object containing:
-                - uncertainty_error_pair: Single (uncertainty_type, error_type) tuple to analyze
-                - model: Single model name to evaluate across different Q values
-                - dataset: Dataset identifier for consistent labeling and organization
-                - targets: List of target indices for multi-target analysis
-                - q_values: List of Q values to compare (e.g., [5, 10, 15, 20, 25])
-                - fitted_save_paths: Corresponding list of data file paths for each Q value
-                - combine_middle_bins: Whether to use simplified 3-bin analysis for all Q values
-                - Display settings controlling which metrics to visualize
-                - Individual target plotting configuration for detailed analysis
-
-        Raises:
-            FileNotFoundError: If data files for any Q value are missing or inaccessible.
-            ValueError: If Q values and save paths lists have mismatched lengths.
-            IndexError: If specified target indices are not present in the data.
+            config (ComparingBinsConfig): The model, uncertainty type, targets, Q values, data paths and
+                output settings.
 
         Example:
 
@@ -744,13 +658,6 @@ class QuantileBinningAnalyzer:
                 ...     individual_targets_to_show=[0],
                 ... )
                 >>> analyzer.run_comparing_bins_analysis(config)
-
-        Note:
-            - Results typically show optimal Q values in the range of 10-20 bins for medical imaging
-            - Higher Q values provide finer granularity but may suffer from insufficient statistics
-            - Lower Q values are more robust but may miss important uncertainty patterns
-            - Individual target analysis can reveal target-specific optimal Q values
-            - Generated plots use consistent formatting for easy comparison across Q values
         """
         if not self.interpret:
             return
@@ -878,10 +785,7 @@ class QuantileBinningAnalyzer:
 
     def _get_save_location(self, suffix: str, show_individual_dots: bool) -> Optional[str]:
         """
-        Construct and return the save path for charts, or return None if not saving.
-
-        This method generates the complete file path for saving plots based on the analyzer's configuration and the
-        specific plot parameters.
+        Construct the save path for a chart, or return None if figures are not being saved.
 
         Args:
             suffix (str): Descriptive suffix for the filename (e.g., "error_all_targets", "jaccard_target_1").
@@ -911,7 +815,7 @@ class QuantileBinningAnalyzer:
         combine_middle_bins: bool,
     ) -> Dict[str, Any]:
         """
-        Load and compute all evaluation metrics for the given binning configuration.
+        Load the binned predictions, compute the evaluation metrics, and write the mean-error summary file.
 
         Args:
             models (List[str]): List of model names.
@@ -948,10 +852,7 @@ class QuantileBinningAnalyzer:
 
     def _plot_metrics(self, metric_type: str, config: MetricPlotConfig) -> None:
         """
-        Unified method for plotting different types of metrics.
-
-        This method replaces the three similar _plot_*_metrics methods with a single,
-        configurable approach that reduces code duplication.
+        Plot the boxplots for one metric type, for all targets and, if enabled, for individual targets.
 
         Args:
             metric_type (str): Type of metric ('error', 'error_bounds', 'jaccard')
@@ -1080,11 +981,7 @@ class QuantileBinningAnalyzer:
         **kwargs: Any,
     ):
         """
-        Generate individual target-specific plots for detailed analysis.
-
-        This method creates separate plots for each specified target to enable detailed analysis of model performance
-        on individual anatomical landmarks or regions. It handles different data structures depending on the plotting
-        mode.
+        Generate a separate plot for each of the specified targets.
 
         Args:
             metric_name (str): Name of the metric being plotted (e.g., "error", "jaccard", "errorbound").
@@ -1158,11 +1055,7 @@ class QuantileBinningAnalyzer:
         **kwargs: Any,
     ):
         """
-        Universal metric plotting function for drawing boxplots of various uncertainty quantification metrics.
-
-        This is the core plotting method that handles the creation of boxplots for different metrics including errors,
-        Jaccard index, and error bounds. It standardizes the plotting process across different metric types and
-        plotting modes.
+        Draw the boxplot of one metric (error, Jaccard index or error bounds) for all targets.
 
         Args:
             metric_name (str): The metric being plotted ('error', 'jaccard', 'errorbound', 'mean_error_folds',
@@ -1237,11 +1130,7 @@ class QuantileBinningAnalyzer:
         **kwargs: Any,
     ) -> MetricPlotConfig:
         """
-        Create a MetricPlotConfig object from the provided parameters.
-
-        This helper method reduces the number of arguments passed to plotting methods by encapsulating them in a
-        configuration object. It serves as a factory method to construct the MetricPlotConfig dataclass with
-        consistent parameter organization and default value handling.
+        Create a MetricPlotConfig from the provided parameters.
 
         Args:
             eval_data (Dict[str, Any]): Comprehensive evaluation data dictionary containing computed metrics.
@@ -1280,8 +1169,7 @@ class QuantileBinningAnalyzer:
                 - precision_y_label (str): Custom label for Jaccard precision plots
 
         Returns:
-            MetricPlotConfig: Configuration object encapsulating all plotting parameters in a structured format.
-                This object is passed to _plot_metrics() to generate the actual visualizations.
+            MetricPlotConfig: The configuration to pass to :meth:`_plot_metrics`.
         """
         return MetricPlotConfig(
             eval_data=eval_data,

--- a/kale/interpret/uncertainty_utils.py
+++ b/kale/interpret/uncertainty_utils.py
@@ -13,6 +13,7 @@ Functions related to uncertainty-error correlation analysis in terms of:
    C) Main analysis functions: analyze_and_plot_uncertainty_correlation
 """
 import os
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import matplotlib.pyplot as plt
@@ -330,51 +331,145 @@ def quantile_binning_and_estimate_errors(
     return uncertainty_boundaries, estimated_errors
 
 
+@dataclass
+class CumulativePlotConfig:
+    """
+    Configuration for :func:`plot_cumulative`.
+
+    Groups the presentation, output and styling settings so that callers pass one object instead of a
+    long parameter list, and so that the plot's constants are named and overridable rather than
+    embedded in the plotting code.
+    """
+
+    # Presentation
+    colormap: str = "Set1"  # Matplotlib colormap name for consistent colours across plots
+    title: str = ""  # Plot title, e.g. "Cumulative Error Distribution - Dataset Name"
+    compare_to_all: bool = False  # If True, overlay the full dataset alongside the selected bins
+
+    # Output
+    save_path: Optional[str] = None  # Directory to save into; if None, the plot is shown interactively
+    file_name: str = "cumulative_error.pdf"  # Output file name, joined with save_path
+    dpi: int = 100  # Resolution used when saving
+    figure_size: Tuple[float, float] = (16.0, 10.0)  # Figure size (inches) used when showing interactively
+
+    # Data scaling
+    error_scaling_factor: float = 1.0  # Multiplicative factor for error values (e.g. 1.0 for mm)
+
+    # Styling
+    font_size: int = 10  # Font size for ticks, axis labels and legend
+    x_label: str = "Error (mm)"  # X-axis label
+    y_label: str = "Number of images in %"  # Y-axis label
+    reference_line_x: float = 5.0  # X position of the vertical reference line (a 5mm error threshold)
+    x_ticks: List[int] = field(default_factory=lambda: [1, 2, 3, 4, 5, 10, 20, 30])  # Explicit log-scale x ticks
+    line_styles: List[str] = field(default_factory=lambda: [":", "-", "dotted", "-."])  # Per-model line styles
+
+
+def _cumulative_curve(errors: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    """Sort errors and compute the cumulative percentage of samples at or below each one.
+
+    Args:
+        errors (np.ndarray): Error values for one model and uncertainty type.
+
+    Returns:
+        tuple: Sorted errors and their cumulative percentages.
+    """
+    percentages = 100 * np.arange(len(errors)) / (len(errors) - 1)
+    return np.sort(errors), percentages
+
+
+def _model_errors(
+    dataframe: pd.DataFrame,
+    uncertainty: str,
+    bins: Optional[Union[List[int], np.ndarray]],
+    error_scaling_factor: float,
+) -> np.ndarray:
+    """Extract scaled errors for one uncertainty type, optionally restricted to given bins.
+
+    Args:
+        dataframe (pd.DataFrame): Predictions for a single model.
+        uncertainty (str): Uncertainty type whose error column is read.
+        bins (list or np.ndarray, optional): Bins to keep; when None, all rows are used.
+        error_scaling_factor (float): Multiplicative factor applied to the errors.
+
+    Returns:
+        np.ndarray: The scaled error values.
+    """
+    if bins is not None:
+        dataframe = dataframe[dataframe[uncertainty + " Uncertainty bins"].isin(bins)]
+    return dataframe[uncertainty + " Error"].values * error_scaling_factor
+
+
+def _style_cumulative_axes(ax, config: CumulativePlotConfig) -> None:
+    """Apply axis labels, fonts and the logarithmic x scale."""
+    plt.xticks(fontsize=config.font_size)
+    plt.yticks(fontsize=config.font_size)
+    ax.set_xlabel(config.x_label, fontsize=config.font_size)
+    ax.set_ylabel(config.y_label, fontsize=config.font_size)
+    plt.title(config.title)
+    ax.set_xscale("log")
+
+
+def _finalize_cumulative_axes(ax, reference_color, config: CumulativePlotConfig) -> None:
+    """Add the legend, reference line, tick formatting and colours."""
+    handles, labels = ax.get_legend_handles_labels()
+    ax.legend(handles, labels, prop={"size": config.font_size})
+    plt.axvline(x=config.reference_line_x, color=reference_color)
+
+    for axis in [ax.xaxis, ax.yaxis]:
+        axis.set_major_formatter(ScalarFormatter())
+
+    plt.xticks(config.x_ticks)
+
+    ax.xaxis.label.set_color("black")
+    ax.yaxis.label.set_color("black")
+    ax.tick_params(axis="x", colors="black")
+    ax.tick_params(axis="y", colors="black")
+
+
+def _output_figure(config: CumulativePlotConfig) -> None:
+    """Save the current figure when a save path is set, otherwise show it."""
+    if config.save_path is not None:
+        plt.savefig(
+            os.path.join(config.save_path, config.file_name), dpi=config.dpi, bbox_inches="tight", pad_inches=0.2
+        )
+    else:
+        plt.gcf().set_size_inches(*config.figure_size)
+        plt.show()
+    plt.close()
+
+
 def plot_cumulative(
-    colormap: str,
     data_struct: Dict[str, pd.DataFrame],
     models: List[str],
     uncertainty_types: List[Tuple[str, str]],
-    bins: Union[List[int], np.ndarray],
-    title: str,
-    compare_to_all: bool = False,
-    save_path: Optional[str] = None,
-    file_name: str = "cumulative_error.pdf",
-    error_scaling_factor: float = 1,
+    bins: Union[int, List[int], np.ndarray],
+    config: Optional[CumulativePlotConfig] = None,
 ) -> None:
     """
     Generate cumulative error distribution plots for uncertainty quantification analysis.
 
-    This function creates cumulative distribution plots showing the percentage of images with errors below certain
-    thresholds. It's useful for understanding the overall error distribution across different uncertainty bins and
-    comparing model performance.
+    Creates cumulative distribution plots showing the percentage of images with errors below certain
+    thresholds, which is useful for understanding the overall error distribution across uncertainty
+    bins and for comparing model performance.
 
     Args:
-        colormap (str): Matplotlib colormap name for consistent visual distinction across plots
-            (e.g., 'Set1', 'tab10', 'viridis').
         data_struct (Dict[str, pd.DataFrame]): Dictionary containing dataframes for each model.
             Keys are model names, values are DataFrames with uncertainty and error columns.
         models (List[str]): List of model names to compare. These should be keys in data_struct.
         uncertainty_types (List[Tuple[str, str]]): List of tuples describing uncertainty-error combinations to analyze.
             Each tuple contains (uncertainty_type, error_type).
-        bins (Union[List[int], np.ndarray]): Bin indices to include in the analysis.
+        bins (Union[int, List[int], np.ndarray]): Bin indices to include in the analysis.
             Can be a single value, list, or numpy array.
-        title (str): Title for the plot (e.g., "Cumulative Error Distribution - Dataset Name").
-        compare_to_all (bool, optional): Whether to compare the given subset of bins to all data points. If True, adds
-            comparison lines for complete dataset. Defaults to False.
-        save_path (Optional[str], optional): Directory path where the plot will be saved. If None, displays the plot
-            on screen interactively instead of saving. Defaults to None.
-        file_name (str, optional): Name of the output file when saving the plot. This is joined with save_path to
-            create the full file path. Defaults to "cumulative_error.pdf".
-        error_scaling_factor (float, optional): Multiplicative factor to scale error values
-            (e.g., 1.0 for mm, 0.1 for cm). Defaults to 1.0.
+        config (CumulativePlotConfig, optional): Presentation, output and styling settings.
+            Defaults to :class:`CumulativePlotConfig`.
 
     Note:
         - The plot uses logarithmic scaling on the x-axis for better visualization of error distributions
-        - A vertical reference line is drawn at x=5 (typically representing 5mm error threshold)
+        - A vertical reference line is drawn at ``config.reference_line_x``
         - Different line styles distinguish between models and uncertainty types
         - The y-axis shows cumulative percentage (0-100%)
     """
+    config = config or CumulativePlotConfig()
 
     # make sure bins is a list and not a single value
     bins = [bins] if not isinstance(bins, (list, np.ndarray)) else bins
@@ -383,80 +478,34 @@ def plot_cumulative(
         _ = plt.figure()
 
         ax = plt.gca()
-        plt.xticks(fontsize=10)
-        plt.yticks(fontsize=10)
+        _style_cumulative_axes(ax, config)
 
-        ax.set_xlabel("Error (mm)", fontsize=10)
-        ax.set_ylabel("Number of images in %", fontsize=10)
-        plt.title(title)
-
-        ax.set_xscale("log")
-        line_styles = [":", "-", "dotted", "-."]
-        colors = colormaps.get_cmap(colormap)(np.arange(len(uncertainty_types) + 1))
+        colors = colormaps.get_cmap(config.colormap)(np.arange(len(uncertainty_types) + 1))
         for i, (uncertainty, _) in enumerate(uncertainty_types):
             color = colors[i]
             for hash_idx, model_type in enumerate(models):
-                line = line_styles[hash_idx]
+                # The selected bins, and optionally the full dataset for comparison, share one code
+                # path; they differ only in the rows kept and the line style used.
+                selections = [(bins, config.line_styles[hash_idx])]
+                if config.compare_to_all:
+                    selections.append((None, config.line_styles[len(models) + hash_idx]))
 
-                # Filter only the bins selected
-                dataframe = data_struct[model_type]
-                model_un_errors = (
-                    dataframe[dataframe[uncertainty + " Uncertainty bins"].isin(bins)][uncertainty + " Error"].values
-                    * error_scaling_factor
-                )
-
-                p = 100 * np.arange(len(model_un_errors)) / (len(model_un_errors) - 1)
-
-                sorted_errors = np.sort(model_un_errors)
-
-                ax.plot(
-                    sorted_errors,
-                    p,
-                    label=model_type + " " + uncertainty,
-                    color=color,
-                    linestyle=line,
-                    dash_capstyle="round",
-                )
-
-                if compare_to_all:
-                    dataframe = data_struct[model_type]
-                    model_un_errors = dataframe[uncertainty + " Error"].values * error_scaling_factor
-
-                    p = 100 * np.arange(len(model_un_errors)) / (len(model_un_errors) - 1)
-
-                    sorted_errors = np.sort(model_un_errors)
-                    line = line_styles[len(models) + hash_idx]
+                for selected_bins, line in selections:
+                    errors = _model_errors(
+                        data_struct[model_type], uncertainty, selected_bins, config.error_scaling_factor
+                    )
+                    sorted_errors, percentages = _cumulative_curve(errors)
                     ax.plot(
                         sorted_errors,
-                        p,
+                        percentages,
                         label=model_type + " " + uncertainty,
                         color=color,
                         linestyle=line,
                         dash_capstyle="round",
                     )
 
-        handles, labels = ax.get_legend_handles_labels()
-        ax.legend(handles, labels, prop={"size": 10})
-        plt.axvline(x=5, color=colors[len(uncertainty_types)])
-
-        for axis in [ax.xaxis, ax.yaxis]:
-            axis.set_major_formatter(ScalarFormatter())
-
-        plt.xticks([1, 2, 3, 4, 5, 10, 20, 30])
-
-        ax.xaxis.label.set_color("black")
-        ax.yaxis.label.set_color("black")
-
-        ax.tick_params(axis="x", colors="black")
-        ax.tick_params(axis="y", colors="black")
-
-        if save_path is not None:
-            plt.savefig(os.path.join(save_path, file_name), dpi=100, bbox_inches="tight", pad_inches=0.2)
-            plt.close()
-        else:
-            plt.gcf().set_size_inches(16.0, 10.0)
-            plt.show()
-            plt.close()
+        _finalize_cumulative_axes(ax, colors[len(uncertainty_types)], config)
+        _output_figure(config)
 
 
 def _calculate_correlations(uncertainties: np.ndarray, scaled_errors: np.ndarray) -> Dict[str, List[float]]:

--- a/kale/interpret/uncertainty_utils.py
+++ b/kale/interpret/uncertainty_utils.py
@@ -43,10 +43,7 @@ def analyze_and_plot_uncertainty_correlation(
     **fig_kwargs: Any,
 ) -> Dict[str, List[Any]]:
     """
-    Complete uncertainty-error correlation analysis with visualization.
-
-    This is the recommended entry point for most uncertainty analysis workflows
-    as it provides both numerical results and visual insights.
+    Run the uncertainty-error correlation analysis and plot the result.
 
     Args:
         errors (np.ndarray): Array of prediction errors. Must have same length
@@ -91,16 +88,7 @@ def analyze_and_plot_uncertainty_correlation(
             - 'pearson': [correlation_coefficient, p_value] for Pearson linear correlation
 
     Raises:
-        ValueError: If input arrays have different lengths, are empty, or contain
-            invalid parameter values (e.g., sample_ratio not in (0,1])
-        KeyError: If required analysis components fail to generate expected results
-
-    Note:
-        - The function automatically validates inputs and provides informative error messages
-        - Bootstrap confidence bands provide visual uncertainty around the main fit
-        - Quantile-based analysis reveals how correlation varies across uncertainty ranges
-        - Both parametric (Pearson) and non-parametric (Spearman) correlations are computed
-        - The plot includes correlation statistics prominently displayed for quick assessment
+        ValueError: If input arrays have different lengths or are empty.
     """
 
     # Analyze correlation
@@ -205,7 +193,7 @@ def plot_uncertainty_correlation(
     **fig_kwargs: Any,
 ) -> None:
     """
-    Create a comprehensive visualization of uncertainty-error correlation analysis.
+    Plot the uncertainty-error correlation analysis: scatter points, the piecewise fit and its bootstrap bands.
 
     Args:
         uncertainties (np.ndarray): Array of uncertainty estimates
@@ -333,13 +321,7 @@ def quantile_binning_and_estimate_errors(
 
 @dataclass
 class CumulativePlotConfig:
-    """
-    Configuration for :func:`plot_cumulative`.
-
-    Groups the presentation, output and styling settings so that callers pass one object instead of a
-    long parameter list, and so that the plot's constants are named and overridable rather than
-    embedded in the plotting code.
-    """
+    """Presentation, output and styling settings for :func:`plot_cumulative`."""
 
     # Presentation
     colormap: str = "Set1"  # Matplotlib colormap name for consistent colours across plots
@@ -400,7 +382,12 @@ def _model_errors(
 
 
 def _style_cumulative_axes(ax, config: CumulativePlotConfig) -> None:
-    """Apply axis labels, fonts and the logarithmic x scale."""
+    """Apply the title, axis labels, fonts and logarithmic x scale.
+
+    Args:
+        ax: The matplotlib axes to style.
+        config (CumulativePlotConfig): Settings providing the title, labels and font size.
+    """
     plt.xticks(fontsize=config.font_size)
     plt.yticks(fontsize=config.font_size)
     ax.set_xlabel(config.x_label, fontsize=config.font_size)
@@ -410,7 +397,13 @@ def _style_cumulative_axes(ax, config: CumulativePlotConfig) -> None:
 
 
 def _finalize_cumulative_axes(ax, reference_color, config: CumulativePlotConfig) -> None:
-    """Add the legend, reference line, tick formatting and colours."""
+    """Add the legend, vertical reference line, tick formatting and label colours.
+
+    Args:
+        ax: The matplotlib axes to finalize.
+        reference_color: Colour of the vertical reference line.
+        config (CumulativePlotConfig): Settings providing the font size, reference line position and x ticks.
+    """
     handles, labels = ax.get_legend_handles_labels()
     ax.legend(handles, labels, prop={"size": config.font_size})
     plt.axvline(x=config.reference_line_x, color=reference_color)
@@ -427,7 +420,11 @@ def _finalize_cumulative_axes(ax, reference_color, config: CumulativePlotConfig)
 
 
 def _output_figure(config: CumulativePlotConfig) -> None:
-    """Save the current figure when a save path is set, otherwise show it."""
+    """Save the current figure when a save path is set, otherwise show it, then close it.
+
+    Args:
+        config (CumulativePlotConfig): Settings providing the save path, file name, dpi and figure size.
+    """
     if config.save_path is not None:
         plt.savefig(
             os.path.join(config.save_path, config.file_name), dpi=config.dpi, bbox_inches="tight", pad_inches=0.2
@@ -512,10 +509,6 @@ def _calculate_correlations(uncertainties: np.ndarray, scaled_errors: np.ndarray
     """
     Calculate Spearman and Pearson correlations between uncertainties and errors.
 
-    This function computes both Spearman rank correlation (non-parametric) and
-    Pearson correlation (parametric) to assess the relationship between uncertainty
-    estimates and prediction errors.
-
     Args:
         uncertainties (np.ndarray): Array of uncertainty values
         scaled_errors (np.ndarray): Array of scaled error values
@@ -534,11 +527,7 @@ def _fit_piecewise_model(
     uncertainties: np.ndarray, scaled_errors: np.ndarray, quantile_thresholds: List[float]
 ) -> pwlf.PiecewiseLinFit:
     """
-    Fit a piecewise linear model to uncertainty-error data using specified breakpoints.
-
-    This function creates and fits a piecewise linear regression model that can capture
-    non-linear relationships between uncertainties and errors by fitting different
-    linear segments at different uncertainty ranges.
+    Fit a piecewise linear model to uncertainty-error data using the given breakpoints.
 
     Args:
         uncertainties (np.ndarray): Array of uncertainty values (independent variable)
@@ -547,8 +536,7 @@ def _fit_piecewise_model(
             as breakpoints for the piecewise linear model
 
     Returns:
-        pwlf.PiecewiseLinFit: Fitted piecewise linear model object that can be used
-            for predictions and plotting
+        pwlf.PiecewiseLinFit: The fitted piecewise linear model.
     """
     piecewise_model = pwlf.PiecewiseLinFit(uncertainties, scaled_errors)
     piecewise_model.fit_with_breaks(quantile_thresholds)
@@ -563,11 +551,7 @@ def _generate_bootstrap_models(
     sample_ratio: float = 0.6,
 ) -> List[pwlf.PiecewiseLinFit]:
     """
-    Generate bootstrap piecewise models for confidence interval estimation.
-
-    This function creates multiple piecewise linear models using bootstrap sampling
-    to estimate confidence intervals around the main piecewise fit. Each bootstrap
-    model is fitted on a random subset of the original data.
+    Fit piecewise linear models to repeated random samples of the data.
 
     Args:
         uncertainties (np.ndarray): Array of uncertainty values
@@ -578,11 +562,8 @@ def _generate_bootstrap_models(
             Must be between 0 and 1. Defaults to 0.6.
 
     Returns:
-        List[pwlf.PiecewiseLinFit]: List of fitted bootstrap piecewise models
-
-    Note:
-        Each bootstrap model is fitted on a random sample of size
-        int(len(data) * sample_ratio) drawn without replacement from the original data.
+        List[pwlf.PiecewiseLinFit]: One fitted model per bootstrap sample. Each sample has
+            ``int(len(data) * sample_ratio)`` points drawn with replacement.
     """
     bootstrap_models = []
 
@@ -600,11 +581,7 @@ def _generate_bootstrap_models(
 
 def _get_quantile_bounds(quantile_thresholds: List[float], uncertainties: np.ndarray, idx: int) -> tuple[float, float]:
     """
-    Get minimum and maximum bounds for a specific quantile segment.
-
-    This function determines the boundary values for a quantile segment based on
-    the segment index and the list of quantile thresholds. It handles edge cases
-    for the first and last segments.
+    Get the minimum and maximum bounds of a quantile segment.
 
     Args:
         quantile_thresholds (List[float]): List of quantile threshold values that
@@ -614,12 +591,9 @@ def _get_quantile_bounds(quantile_thresholds: List[float], uncertainties: np.nda
         idx (int): Index of the quantile segment (0-based)
 
     Returns:
-        tuple[float, float]: Tuple containing (min_value, max_value) for the segment
-
-    Note:
-        - For idx=0 (first segment): min_val = min(uncertainties), max_val = first threshold
-        - For middle segments: min_val = previous threshold, max_val = current threshold
-        - For last segment: min_val = last threshold, max_val = max(uncertainties)
+        tuple[float, float]: The ``(min_value, max_value)`` of the segment. The first segment starts at
+            ``min(uncertainties)``, the last ends at ``max(uncertainties)``, and the others are bounded by
+            consecutive thresholds.
     """
     if idx == 0:
         min_val = min(uncertainties)
@@ -636,22 +610,14 @@ def _get_quantile_bounds(quantile_thresholds: List[float], uncertainties: np.nda
 
 def _calculate_segment_centers(quantile_thresholds: List[float], uncertainties: np.ndarray) -> List[float]:
     """
-    Calculate center positions for each quantile segment for label placement.
-
-    This function computes the midpoint of each quantile segment, which is used
-    for positioning x-axis labels in plots. The center is calculated as the
-    arithmetic mean of the segment's minimum and maximum bounds.
+    Calculate the midpoint of each quantile segment, used to position the x-axis labels.
 
     Args:
         quantile_thresholds (List[float]): List of quantile threshold values
         uncertainties (np.ndarray): Array of uncertainty values for determining bounds
 
     Returns:
-        List[float]: List of center positions for each quantile segment
-
-    Note:
-        The number of segments is len(quantile_thresholds) + 1, as thresholds
-        define boundaries between segments.
+        List[float]: The center of each of the ``len(quantile_thresholds) + 1`` segments.
     """
     bin_label_locs = []
     for idx in range(len(quantile_thresholds) + 1):
@@ -664,11 +630,7 @@ def _plot_bootstrap_confidence_bands(
     ax, bootstrap_models: List[pwlf.PiecewiseLinFit], uncertainties: np.ndarray, num_pred_points: int = 10000
 ) -> None:
     """
-    Plot bootstrap confidence bands on the given axes.
-
-    This function visualizes uncertainty in the piecewise linear fit by plotting
-    prediction lines from multiple bootstrap models. The ensemble of lines creates
-    a confidence band around the main fit.
+    Plot the prediction line of every bootstrap model on the given axes, forming a confidence band.
 
     Args:
         ax: Matplotlib axes object to plot on
@@ -678,12 +640,7 @@ def _plot_bootstrap_confidence_bands(
             Defaults to 10000.
 
     Returns:
-        None: Plots directly on the provided axes
-
-    Note:
-        - Each bootstrap model is plotted as a grey line with low alpha (0.2)
-        - Lines are plotted in reverse order ([::-1]) for proper visualization
-        - Uses zorder=2 to place confidence bands behind main elements
+        None: Plots directly on the provided axes.
     """
     uncertainties_pred = np.linspace(min(uncertainties), max(uncertainties), num=num_pred_points)
 
@@ -694,10 +651,7 @@ def _plot_bootstrap_confidence_bands(
 
 def _plot_scatter_points(ax, uncertainties: np.ndarray, scaled_errors: np.ndarray, scatter_color: str) -> None:
     """
-    Plot scatter points of uncertainties vs errors on the given axes.
-
-    This function creates a scatter plot showing the relationship between uncertainty
-    estimates and scaled errors. Each point represents one data sample.
+    Scatter the uncertainties against the scaled errors on the given axes, one point per sample.
 
     Args:
         ax: Matplotlib axes object to plot on
@@ -706,12 +660,7 @@ def _plot_scatter_points(ax, uncertainties: np.ndarray, scaled_errors: np.ndarra
         scatter_color (str): Color for the scatter points
 
     Returns:
-        None: Plots directly on the provided axes
-
-    Note:
-        - Uses circular markers ('o') with low alpha (0.2) for transparency
-        - Points are placed at zorder=1 to appear behind other plot elements
-        - Alpha blending helps visualize point density in overlapping regions
+        None: Plots directly on the provided axes.
     """
     ax.scatter(uncertainties, scaled_errors, marker="o", color=scatter_color, zorder=1, alpha=0.2)
 
@@ -725,11 +674,7 @@ def _plot_piecewise_segments(
     num_pred_points: int = 20000,
 ) -> None:
     """
-    Plot piecewise linear segments with different colors and background shading.
-
-    This function visualizes the fitted piecewise linear model by plotting each
-    segment in a different color and adding background shading to distinguish
-    quantile regions.
+    Plot each segment of the piecewise linear model in its own colour, with the quantile region shaded behind it.
 
     Args:
         ax: Matplotlib axes object to plot on
@@ -741,13 +686,7 @@ def _plot_piecewise_segments(
             Defaults to 20000.
 
     Returns:
-        None: Plots directly on the provided axes
-
-    Note:
-        - Each segment gets a different color from the colors list (cycles using modulo)
-        - Background shading (axvspan) with alpha=0.1 highlights quantile regions
-        - Piecewise lines use zorder=3 to appear on top of other elements
-        - High num_pred_points ensures smooth curve appearance
+        None: Plots directly on the provided axes.
     """
     uncertainties_pred = np.linspace(min(uncertainties), max(uncertainties), num=num_pred_points)
     scaled_errors_pred = piecewise_model.predict(uncertainties_pred)
@@ -773,11 +712,7 @@ def _setup_plot_formatting(
     font_size: int = 25,
 ) -> None:
     """
-    Setup comprehensive plot formatting including labels, ticks, and correlation text.
-
-    This function handles all aspects of plot formatting including axis labels,
-    tick formatting, correlation coefficient display, and overall plot styling.
-    It creates a publication-ready visualization of the uncertainty-error correlation.
+    Set the axis labels, quantile tick labels and correlation text on the given axes.
 
     Args:
         ax: Matplotlib axes object to format
@@ -788,14 +723,8 @@ def _setup_plot_formatting(
         font_size (int, optional): Font size for labels and text. Defaults to 25.
 
     Returns:
-        None: Modifies the provided axes object in-place
-
-    Note:
-        - X-axis labels are formatted as Q_1, Q_2, ..., Q_n using LaTeX notation
-        - Correlation coefficient (ρ) and p-value are displayed prominently
-        - P-values < 0.001 are shown as "< 0.001" for readability
-        - Uses bold formatting for correlation statistics
-        - Axis labels indicate uncertainty quantiles and error in mm
+        None: Modifies the provided axes in place. Tick labels are ``Q_1 … Q_n``; the Spearman
+            coefficient and p-value (rounded to three decimals, floored at 0.001) are written on the plot.
     """
     # Set x-axis ticks and labels
     ax.set_xticks(bin_label_locs)

--- a/kale/interpret/uncertainty_utils.py
+++ b/kale/interpret/uncertainty_utils.py
@@ -2,6 +2,7 @@
 # Author: Lawrence Schobs, lawrenceschobs@gmail.com
 #         Wenjie Zhao, mcsoft12138@outlook.com
 #         Zhongwei Ji, jizhongwei1999@outlook.com
+#         Charles Anjah, cmanjahart@gmail.com
 # =============================================================================
 
 """

--- a/tests/evaluate/test_similarity_metrics.py
+++ b/tests/evaluate/test_similarity_metrics.py
@@ -116,9 +116,7 @@ class TestEvaluateCorrelations:
         mock_analyze.return_value = {}
         mock_invert.side_effect = lambda frame, key: frame
 
-        evaluate_correlations(
-            bin_predictions, UNCERTAINTY_PAIRS, [("S-MHA", True)], CorrelationConfig(num_bins=2)
-        )
+        evaluate_correlations(bin_predictions, UNCERTAINTY_PAIRS, [("S-MHA", True)], CorrelationConfig(num_bins=2))
 
         mock_invert.assert_called_once()
         assert mock_invert.call_args.args[1] == "S-MHA Uncertainty"

--- a/tests/evaluate/test_similarity_metrics.py
+++ b/tests/evaluate/test_similarity_metrics.py
@@ -1,0 +1,133 @@
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from kale.evaluate.similarity_metrics import _quantile_thresholds, CorrelationConfig, evaluate_correlations
+
+UNCERTAINTY_PAIRS = [("S-MHA", "S-MHA Error", "S-MHA Uncertainty")]
+NO_INVERSION = [("S-MHA", False)]
+
+
+@pytest.fixture
+def bin_predictions():
+    """Two testing folds of predictions for a single model."""
+    return {
+        "U-NET": pd.DataFrame(
+            {
+                "Testing Fold": [0, 0, 0, 0, 1, 1, 1, 1],
+                "S-MHA Error": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+                "S-MHA Uncertainty": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8],
+            }
+        )
+    }
+
+
+class TestCorrelationConfig:
+    """Configuration defaults for evaluate_correlations (issue #555)."""
+
+    def test_defaults(self):
+        config = CorrelationConfig()
+
+        assert config.num_bins == 10
+        assert config.num_folds == 8
+        assert config.error_scaling_factor == 1.0
+        assert config.combine_middle_bins is False
+        assert config.colormap == "Set1"
+        assert config.save_path is None
+        assert config.to_log is False
+
+
+class TestQuantileThresholds:
+    """Threshold derivation, previously inlined in evaluate_correlations."""
+
+    def test_returns_one_threshold_fewer_than_bins(self):
+        values = np.arange(100, dtype=float)
+
+        thresholds = _quantile_thresholds(values, num_bins=4, combine_middle_bins=False)
+
+        assert len(thresholds) == 3
+        assert thresholds == sorted(thresholds)
+
+    def test_combine_middle_bins_keeps_only_outer_thresholds(self):
+        values = np.arange(100, dtype=float)
+
+        full = _quantile_thresholds(values, num_bins=5, combine_middle_bins=False)
+        combined = _quantile_thresholds(values, num_bins=5, combine_middle_bins=True)
+
+        # The middle bins merge into one, leaving the two edge bins distinct.
+        assert combined == [full[0], full[-1]]
+
+
+class TestEvaluateCorrelations:
+    """evaluate_correlations orchestration (issue #555, and the coverage gap noted in #410).
+
+    The plotting call is mocked: saving figures is what makes this function awkward to test in CI,
+    and the behaviour under test here is the data selection and configuration handling.
+    """
+
+    @patch("kale.evaluate.similarity_metrics.analyze_and_plot_uncertainty_correlation")
+    def test_returns_stats_keyed_by_model_and_uncertainty(self, mock_analyze, bin_predictions):
+        mock_analyze.return_value = {"all_folds": {"r": 0.5}}
+
+        result = evaluate_correlations(bin_predictions, UNCERTAINTY_PAIRS, NO_INVERSION, CorrelationConfig(num_bins=4))
+
+        assert result == {"U-NET": {"S-MHA": {"all_folds": {"r": 0.5}}}}
+
+    @patch("kale.evaluate.similarity_metrics.analyze_and_plot_uncertainty_correlation")
+    def test_only_requested_folds_are_used(self, mock_analyze, bin_predictions):
+        """num_folds selects the testing folds, so fold 1 is excluded when only one fold is requested."""
+        mock_analyze.return_value = {}
+
+        evaluate_correlations(
+            bin_predictions, UNCERTAINTY_PAIRS, NO_INVERSION, CorrelationConfig(num_bins=2, num_folds=1)
+        )
+
+        errors = mock_analyze.call_args.args[0]
+        np.testing.assert_array_equal(errors, [1.0, 2.0, 3.0, 4.0])
+
+    @patch("kale.evaluate.similarity_metrics.analyze_and_plot_uncertainty_correlation")
+    def test_config_is_forwarded_to_the_analysis(self, mock_analyze, bin_predictions, tmp_path):
+        mock_analyze.return_value = {}
+        config = CorrelationConfig(
+            num_bins=2, colormap="tab10", error_scaling_factor=2.5, save_path=str(tmp_path), to_log=True
+        )
+
+        evaluate_correlations(bin_predictions, UNCERTAINTY_PAIRS, NO_INVERSION, config)
+
+        kwargs = mock_analyze.call_args.kwargs
+        assert kwargs["colormap"] == "tab10"
+        assert kwargs["error_scaling_factor"] == 2.5
+        assert kwargs["to_log"] is True
+        assert kwargs["save_path"].endswith("U-NET_S-MHA_correlation_pwr_all_targets.pdf")
+
+    @patch("kale.evaluate.similarity_metrics.analyze_and_plot_uncertainty_correlation")
+    def test_no_save_path_means_no_figure_path(self, mock_analyze, bin_predictions):
+        mock_analyze.return_value = {}
+
+        evaluate_correlations(bin_predictions, UNCERTAINTY_PAIRS, NO_INVERSION, CorrelationConfig(num_bins=2))
+
+        assert mock_analyze.call_args.kwargs["save_path"] is None
+
+    @patch("kale.evaluate.similarity_metrics.apply_confidence_inversion")
+    @patch("kale.evaluate.similarity_metrics.analyze_and_plot_uncertainty_correlation")
+    def test_uncertainty_inversion_is_applied_when_requested(self, mock_analyze, mock_invert, bin_predictions):
+        mock_analyze.return_value = {}
+        mock_invert.side_effect = lambda frame, key: frame
+
+        evaluate_correlations(
+            bin_predictions, UNCERTAINTY_PAIRS, [("S-MHA", True)], CorrelationConfig(num_bins=2)
+        )
+
+        mock_invert.assert_called_once()
+        assert mock_invert.call_args.args[1] == "S-MHA Uncertainty"
+
+    @patch("kale.evaluate.similarity_metrics.apply_confidence_inversion")
+    @patch("kale.evaluate.similarity_metrics.analyze_and_plot_uncertainty_correlation")
+    def test_uncertainty_inversion_is_skipped_when_not_requested(self, mock_analyze, mock_invert, bin_predictions):
+        mock_analyze.return_value = {}
+
+        evaluate_correlations(bin_predictions, UNCERTAINTY_PAIRS, NO_INVERSION, CorrelationConfig(num_bins=2))
+
+        mock_invert.assert_not_called()

--- a/tests/evaluate/test_similarity_metrics.py
+++ b/tests/evaluate/test_similarity_metrics.py
@@ -25,7 +25,7 @@ def bin_predictions():
 
 
 class TestCorrelationConfig:
-    """Configuration defaults for evaluate_correlations (issue #555)."""
+    """Configuration defaults for evaluate_correlations."""
 
     def test_defaults(self):
         config = CorrelationConfig()
@@ -40,7 +40,7 @@ class TestCorrelationConfig:
 
 
 class TestQuantileThresholds:
-    """Threshold derivation, previously inlined in evaluate_correlations."""
+    """Quantile threshold derivation."""
 
     def test_returns_one_threshold_fewer_than_bins(self):
         values = np.arange(100, dtype=float)
@@ -61,11 +61,7 @@ class TestQuantileThresholds:
 
 
 class TestEvaluateCorrelations:
-    """evaluate_correlations orchestration (issue #555, and the coverage gap noted in #410).
-
-    The plotting call is mocked: saving figures is what makes this function awkward to test in CI,
-    and the behaviour under test here is the data selection and configuration handling.
-    """
+    """Data selection and configuration handling in evaluate_correlations, with the plotting call mocked."""
 
     @patch("kale.evaluate.similarity_metrics.analyze_and_plot_uncertainty_correlation")
     def test_returns_stats_keyed_by_model_and_uncertainty(self, mock_analyze, bin_predictions):

--- a/tests/interpret/test_uncertainty_utils.py
+++ b/tests/interpret/test_uncertainty_utils.py
@@ -5,6 +5,7 @@ import pytest
 
 from kale.interpret.uncertainty_utils import (
     analyze_and_plot_uncertainty_correlation,
+    CumulativePlotConfig,
     plot_cumulative,
     quantile_binning_and_estimate_errors,
 )
@@ -154,13 +155,11 @@ class TestPlotFunctions:
         mock_gca.return_value = mock_ax
 
         plot_cumulative(
-            colormap="Set1",
             data_struct=data_struct,
             models=["ResNet50"],
             uncertainty_types=[("epistemic", "")],
             bins=[1, 2],
-            title="Test Plot",
-            save_path=None,
+            config=CumulativePlotConfig(colormap="Set1", title="Test Plot", save_path=None),
         )
 
         mock_style_context.assert_called_once_with("ggplot")
@@ -190,13 +189,11 @@ class TestPlotFunctions:
 
         save_path = str(tmp_path)
         plot_cumulative(
-            colormap="Set1",
             data_struct=data_struct,
             models=["ResNet50"],
             uncertainty_types=[("epistemic", "")],
             bins=[1, 2],
-            title="Test Plot",
-            save_path=save_path,
+            config=CumulativePlotConfig(colormap="Set1", title="Test Plot", save_path=save_path),
         )
 
         mock_savefig.assert_called_once()
@@ -317,3 +314,53 @@ class TestParameterValidation:
         # Zero bins should raise a ZeroDivisionError
         with pytest.raises(ZeroDivisionError):
             quantile_binning_and_estimate_errors(ERRORS, UNCERTAINTIES, num_bins=0)
+
+
+class TestCumulativePlotConfig:
+    """Configuration defaults and overrides for plot_cumulative (issue #555)."""
+
+    def test_defaults_match_previous_hardcoded_values(self):
+        """The defaults preserve the constants the plotting code used to embed inline."""
+        config = CumulativePlotConfig()
+
+        assert config.colormap == "Set1"
+        assert config.file_name == "cumulative_error.pdf"
+        assert config.error_scaling_factor == 1.0
+        assert config.compare_to_all is False
+        assert config.font_size == 10
+        assert config.reference_line_x == 5.0
+        assert config.x_ticks == [1, 2, 3, 4, 5, 10, 20, 30]
+        assert config.line_styles == [":", "-", "dotted", "-."]
+        assert config.figure_size == (16.0, 10.0)
+        assert config.dpi == 100
+
+    def test_mutable_defaults_are_not_shared(self):
+        """Each config owns its list fields, so mutating one cannot affect another."""
+        first, second = CumulativePlotConfig(), CumulativePlotConfig()
+
+        first.x_ticks.append(99)
+        first.line_styles.append("--")
+
+        assert 99 not in second.x_ticks
+        assert "--" not in second.line_styles
+
+    @patch("matplotlib.pyplot.close")
+    @patch("matplotlib.pyplot.savefig")
+    @patch("matplotlib.pyplot.gca")
+    def test_config_overrides_are_applied(self, mock_gca, mock_savefig, mock_close, tmp_path):
+        """Overridden styling and output settings reach matplotlib."""
+        pd = pytest.importorskip("pandas")
+        frame = pd.DataFrame({"epistemic Uncertainty bins": [1, 1, 2], "epistemic Error": [1.0, 2.0, 3.0]})
+        mock_ax = MagicMock()
+        mock_ax.get_legend_handles_labels.return_value = ([], [])
+        mock_gca.return_value = mock_ax
+
+        config = CumulativePlotConfig(
+            title="Custom", save_path=str(tmp_path), file_name="custom.pdf", dpi=42, x_label="X", y_label="Y"
+        )
+        plot_cumulative({"m": frame}, ["m"], [("epistemic", "")], [1, 2], config)
+
+        mock_ax.set_xlabel.assert_called_once_with("X", fontsize=10)
+        mock_ax.set_ylabel.assert_called_once_with("Y", fontsize=10)
+        assert mock_savefig.call_args.args[0].endswith("custom.pdf")
+        assert mock_savefig.call_args.kwargs["dpi"] == 42

--- a/tests/interpret/test_uncertainty_utils.py
+++ b/tests/interpret/test_uncertainty_utils.py
@@ -247,7 +247,7 @@ class TestQuantileBinningAndEstErrors:
         assert len(est_errors) == 2
 
     def test_error_wise_type_handling(self):
-        """Test that error_wise type raises NotImplementedError (not yet implemented)."""
+        """Test that error_wise type raises NotImplementedError."""
         # error-wise type is not implemented yet and should raise NotImplementedError
         with pytest.raises(NotImplementedError, match="error-wise Quantile Binning not implemented yet"):
             quantile_binning_and_estimate_errors(ERRORS, UNCERTAINTIES, num_bins=5, threshold_type="error-wise")
@@ -257,7 +257,7 @@ class TestEdgeCases:
     """Test edge cases and error conditions."""
 
     def test_quantile_binning_single_bin(self):
-        """Test quantile binning with single bin (edge case)."""
+        """Test quantile binning with a single bin."""
         # Single bin should result in no boundaries
         est_bounds, est_errors = quantile_binning_and_estimate_errors(ERRORS, UNCERTAINTIES, num_bins=1)
         assert len(est_bounds) == 0
@@ -317,10 +317,10 @@ class TestParameterValidation:
 
 
 class TestCumulativePlotConfig:
-    """Configuration defaults and overrides for plot_cumulative (issue #555)."""
+    """Configuration defaults and overrides for plot_cumulative."""
 
-    def test_defaults_match_previous_hardcoded_values(self):
-        """The defaults preserve the constants the plotting code used to embed inline."""
+    def test_defaults(self):
+        """The default configuration values."""
         config = CumulativePlotConfig()
 
         assert config.colormap == "Set1"


### PR DESCRIPTION
Fixes #555.

### Description
`plot_cumulative` and `evaluate_correlations` took long parameter lists with inline constants. This introduces `CumulativePlotConfig` and `CorrelationConfig` (following the existing `QuantileBinningConfig` pattern) and extracts helpers, so callers pass one config object. Also drops a dead `num_bins = 3` assignment. Behaviour is unchanged (verified on fixtures); both public signatures change, and the internal callers/tests are updated. `evaluate_correlations` gains its first tests.

### Status
Ready

### Types of changes
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [ ] Source for documentation at `docs` manually updated for new API.
