### PR TITLE
Group bin-wise errors in a single linear pass

### DIFF
--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -408,8 +408,12 @@ class DataProcessor:
         bin_keys: List[List] = [[] for _ in range(num_bins)]
         bin_errors: List[List] = [[] for _ in range(num_bins)]
 
-        # Bins are compared as strings because they may be stored as either numbers or strings.
+        # Bins and uids are both compared as strings because either may be stored as a number or a
+        # string. The original grouping used str(...) on both sides, so a uid stored as an int in
+        # one frame and a str in the other still lined up; indexing the errors by str(uid) preserves
+        # that while staying linear.
         index_by_bin_label = {str(bin_idx): bin_idx for bin_idx in range(num_bins)}
+        errors_by_str_uid = {str(key): value for key, value in errors_dict.items()}
 
         # A single pass over the predictions, so grouping stays linear in the number of samples
         # rather than rescanning them once per bin.
@@ -419,8 +423,9 @@ class DataProcessor:
                 continue
 
             bin_keys[bin_idx].append(key)
-            if key in errors_dict:
-                bin_errors[bin_idx].append(errors_dict[key])
+            str_uid = str(key)
+            if str_uid in errors_by_str_uid:
+                bin_errors[bin_idx].append(errors_by_str_uid[str_uid])
 
         return bin_keys, bin_errors
 

--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -26,7 +26,7 @@ Main Classes:
 import copy
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import cast, Dict, List, Optional, Tuple
+from typing import Any, cast, Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -172,8 +172,10 @@ class BinResults:
             Length equals the number of bins.
         all_bins (List[List[float]]): Raw evaluation metrics for each bin and target.
             Outer list represents bins, inner lists contain values for each target.
-        all_bins_concat_targets_sep (List[List[List[float]]]): Evaluation metrics
+        all_bins_concat_targets_sep (List[List[List[Any]]]): Evaluation metrics
             organized for target-separated analysis. Structure: [target][bin][values].
+            The values are metric-specific: bound accuracy and Jaccard record one number per
+            fold, whereas mean errors record the list of errors for that fold.
 
     Note:
         This base class provides the common structure for fold-level results.
@@ -184,7 +186,7 @@ class BinResults:
     mean_all_targets: float
     mean_all_bins: List[float]
     all_bins: List[List[float]]
-    all_bins_concat_targets_sep: List[List[List[float]]]
+    all_bins_concat_targets_sep: List[List[List[Any]]]
 
 
 @dataclass
@@ -741,6 +743,7 @@ class BaseEvaluator(ABC):
         self.current_num_bins_: int = config.original_num_bins
         self.current_targets_: List[int] = []
         self.current_uncertainty_type_: str = ""
+        self.current_model_: str = ""
 
     def evaluate(self, bin_predictions: Dict[str, pd.DataFrame], uncertainty_pairs: List, targets: List[int]) -> Dict:
         """
@@ -786,6 +789,7 @@ class BaseEvaluator(ABC):
         self.container_ = ResultsContainer(self.current_num_bins_, len(targets))
 
         for model, data_structs in bin_predictions.items():
+            self.current_model_ = model
             for uncertainty_pair in uncertainty_pairs:
                 self.current_uncertainty_type_ = uncertainty_pair[0]
                 model_key = f"{model} {self.current_uncertainty_type_}"
@@ -1424,6 +1428,211 @@ class JaccardEvaluator(BaseEvaluator):
         }
 
 
+class BoundsEvaluator(BaseEvaluator):
+    """
+    Evaluator for the accuracy of estimated error bounds.
+
+    For each quantile bin, this measures the proportion of predictions whose true error falls inside
+    the bound estimated for that bin, which shows how well the estimated bounds are calibrated.
+
+    Unlike the other evaluators, each fold needs its estimated bounds alongside the predictions, so
+    :meth:`_process_all_folds` attaches them to the fold data.
+
+    Args:
+        estimated_bounds (Dict[str, pd.DataFrame]): Estimated error bounds per model, keyed by
+            ``"<model> Error Bounds"``.
+        config (EvaluationConfig, optional): Evaluation settings. Defaults to :class:`EvaluationConfig`.
+
+    Example:
+
+        .. code-block:: pycon
+
+            >>> evaluator = BoundsEvaluator(bounds, EvaluationConfig(original_num_bins=5))
+            >>> results = evaluator.evaluate(bin_predictions, [["S-MHA"]], targets=[0, 1])
+    """
+
+    def __init__(self, estimated_bounds: Dict[str, pd.DataFrame], config: Optional[EvaluationConfig] = None):
+        super().__init__(config or EvaluationConfig())
+        self.estimated_bounds_ = estimated_bounds
+
+    def _process_all_folds(self, data_structs: pd.DataFrame) -> List[BinResults]:
+        """Process every fold, attaching that fold's estimated bounds to the fold data."""
+        error_bounds = self.estimated_bounds_[self.current_model_ + " Error Bounds"]
+        bounds_column = self.current_uncertainty_type_ + " Uncertainty bounds"
+
+        fold_results = []
+        for fold in range(self.config_.num_folds):
+            fold_data = DataProcessor.extract_fold_data(data_structs, fold, self.current_uncertainty_type_)
+            fold_data.bounds = strip_for_bound(error_bounds[error_bounds["fold"] == fold][bounds_column].values)
+            fold_results.append(self._process_single_fold(fold_data))
+
+        return fold_results
+
+    def _process_single_fold(self, fold_data: FoldData) -> BinResults:
+        """Evaluate bound accuracy for one fold."""
+        assert fold_data.bounds is not None, "Fold data is missing its estimated bounds"
+        result = bin_wise_bound_eval(
+            fold_data.bounds,
+            fold_data.errors,
+            fold_data.bins,
+            self.current_targets_,
+            self.current_uncertainty_type_,
+            num_bins=self.current_num_bins_,
+        )
+
+        return BinResults(
+            mean_all_targets=result[ResultKeys.MEAN_ALL_TARGETS],
+            mean_all_bins=result[ResultKeys.MEAN_ALL_BINS],
+            all_bins=result["mean all"],
+            all_bins_concat_targets_sep=result[ResultKeys.ALL_BINS_CONCAT_TARGETS_SEP],
+        )
+
+    def _aggregate_fold_results(self, model_key: str, fold_results: List[BinResults]):
+        """Collect bound accuracy across folds, per bin and per target."""
+        num_bins = self.current_num_bins_
+        num_targets = len(self.current_targets_)
+
+        mean_bins: List[List] = [[] for _ in range(num_bins)]
+        bins_targets_not_sep: List[List] = [[] for _ in range(num_bins)]
+        targets_sep_foldwise: List[List[List]] = [[[] for _ in range(num_bins)] for _ in range(num_targets)]
+        targets_sep_all: List[List[List]] = [[[] for _ in range(num_bins)] for _ in range(num_targets)]
+
+        for fold in fold_results:
+            for idx_bin in range(len(fold.mean_all_bins)):
+                mean_bins[idx_bin].append(fold.mean_all_bins[idx_bin])
+                bins_targets_not_sep[idx_bin] = bins_targets_not_sep[idx_bin] + fold.all_bins[idx_bin]
+
+                for target_idx in range(num_targets):
+                    fold_bin_values = fold.all_bins_concat_targets_sep[target_idx][idx_bin]
+                    targets_sep_foldwise[target_idx][idx_bin] = (
+                        targets_sep_foldwise[target_idx][idx_bin] + fold_bin_values
+                    )
+                    targets_sep_all[target_idx][idx_bin] = targets_sep_all[target_idx][idx_bin] + fold_bin_values
+
+        assert self.container_ is not None, "Results container is not initialized"
+
+        # Reverses order so they are worst to best i.e. B5 -> B1
+        self.container_.add_main_result(model_key, mean_bins[::-1])
+        self.container_.additional_containers.setdefault(ResultKeys.ALL_BOUND_PERCENTS_NO_TARGET_SEP, {})[
+            model_key
+        ] = bins_targets_not_sep[::-1]
+
+        for target_idx in range(num_targets):
+            self.container_.target_sep_foldwise[target_idx][model_key] = targets_sep_foldwise[target_idx]
+            self.container_.target_sep_all[target_idx][model_key] = targets_sep_all[target_idx]
+
+    def _finalize_results(self) -> Dict:
+        """Map the container onto the error bound result keys."""
+        assert self.container_ is not None, "Results container is not initialized"
+
+        return {
+            ResultKeys.ERROR_BOUNDS_ALL: self.container_.main_results,
+            ResultKeys.ALL_BOUND_PERCENTS_NO_TARGET_SEP: self.container_.additional_containers.get(
+                ResultKeys.ALL_BOUND_PERCENTS_NO_TARGET_SEP, {}
+            ),
+            ResultKeys.ALL_ERROR_BOUND_CONCAT_BINS_TARGET_SEP_FOLDWISE: self.container_.target_sep_foldwise,
+            ResultKeys.ALL_ERROR_BOUND_CONCAT_BINS_TARGET_SEP_ALL: self.container_.target_sep_all,
+        }
+
+
+class ErrorsEvaluator(BaseEvaluator):
+    """
+    Evaluator for the mean localization error of each quantile bin.
+
+    For each bin, this measures the mean error per target and across all targets, which shows whether
+    predictions the model is less certain about do carry larger errors.
+
+    Args:
+        config (EvaluationConfig, optional): Evaluation settings, including ``error_scaling_factor``.
+            Defaults to :class:`EvaluationConfig`.
+
+    Example:
+
+        .. code-block:: pycon
+
+            >>> evaluator = ErrorsEvaluator(EvaluationConfig(original_num_bins=5))
+            >>> results = evaluator.evaluate(bin_predictions, [["S-MHA"]], targets=[0, 1])
+    """
+
+    def __init__(self, config: Optional[EvaluationConfig] = None):
+        super().__init__(config or EvaluationConfig())
+
+    def _process_single_fold(self, fold_data: FoldData) -> BinResults:
+        """Evaluate mean bin errors for one fold."""
+        result = bin_wise_errors(
+            fold_data.errors,
+            fold_data.bins,
+            self.current_num_bins_,
+            self.current_targets_,
+            self.current_uncertainty_type_,
+            error_scaling_factor=self.config_.error_scaling_factor,
+        )
+
+        return BinResults(
+            mean_all_targets=result[ResultKeys.MEAN_ALL_TARGETS],
+            mean_all_bins=result[ResultKeys.MEAN_ALL_BINS],
+            all_bins=result[ResultKeys.ALL_BINS],
+            all_bins_concat_targets_sep=result[ResultKeys.ALL_BINS_CONCAT_TARGETS_SEP],
+        )
+
+    def _aggregate_fold_results(self, model_key: str, fold_results: List[BinResults]):
+        """Collect mean errors across folds, per bin and per target."""
+        num_bins = self.current_num_bins_
+        num_targets = len(self.current_targets_)
+
+        mean_bins: List[List] = [[] for _ in range(num_bins)]
+        all_bins: List[List] = [[] for _ in range(num_bins)]
+        concat_targets_no_sep: List[List] = [[] for _ in range(num_bins)]
+        targets_sep_foldwise: List[List[List]] = [[[] for _ in range(num_bins)] for _ in range(num_targets)]
+        targets_sep_all: List[List[List]] = [[[] for _ in range(num_bins)] for _ in range(num_targets)]
+
+        for fold in fold_results:
+            for idx_bin in range(len(fold.mean_all_bins)):
+                mean_bins[idx_bin].append(fold.mean_all_bins[idx_bin])
+                all_bins[idx_bin] = all_bins[idx_bin] + fold.all_bins[idx_bin]
+
+                # Flatten this bin's errors across every target, dropping the target separation.
+                per_target = [target_bins[idx_bin] for target_bins in fold.all_bins_concat_targets_sep]
+                flattened = [value for sublist in per_target for value in sublist]
+                flattened = [value for sublist in flattened for value in sublist]
+                concat_targets_no_sep[idx_bin] = concat_targets_no_sep[idx_bin] + flattened
+
+                for target_idx in range(num_targets):
+                    fold_bin_values = fold.all_bins_concat_targets_sep[target_idx][idx_bin]
+                    targets_sep_foldwise[target_idx][idx_bin] = (
+                        targets_sep_foldwise[target_idx][idx_bin] + fold_bin_values
+                    )
+                    if fold_bin_values != []:
+                        targets_sep_all[target_idx][idx_bin] = targets_sep_all[target_idx][idx_bin] + fold_bin_values[0]
+
+        assert self.container_ is not None, "Results container is not initialized"
+
+        # reverse orderings, so bins run worst to best i.e. B5 -> B1
+        self.container_.add_main_result(model_key, mean_bins[::-1])
+        self.container_.add_target_separated_result(model_key, all_bins[::-1])
+        self.container_.additional_containers.setdefault(ResultKeys.ALL_ERROR_CONCAT_BINS_TARGET_NO_SEP, {})[
+            model_key
+        ] = concat_targets_no_sep[::-1]
+
+        for target_idx in range(num_targets):
+            self.container_.target_sep_foldwise[target_idx][model_key] = targets_sep_foldwise[target_idx][::-1]
+            self.container_.target_sep_all[target_idx][model_key] = targets_sep_all[target_idx][::-1]
+
+    def _finalize_results(self) -> Dict:
+        """Map the container onto the mean error result keys."""
+        assert self.container_ is not None, "Results container is not initialized"
+
+        return {
+            ResultKeys.ALL_MEAN_ERROR_BINS_NO_SEP: self.container_.main_results,
+            ResultKeys.ALL_MEAN_ERROR_BINS_TARGETS_SEP: self.container_.target_separated_results,
+            ResultKeys.ALL_ERROR_CONCAT_BINS_TARGET_NO_SEP: self.container_.additional_containers.get(
+                ResultKeys.ALL_ERROR_CONCAT_BINS_TARGET_NO_SEP, {}
+            ),
+            ResultKeys.ALL_ERROR_CONCAT_BINS_TARGET_SEP_FOLDWISE: self.container_.target_sep_foldwise,
+            ResultKeys.ALL_ERROR_CONCAT_BINS_TARGET_SEP_ALL: self.container_.target_sep_all,
+        }
+
+
 def evaluate_bounds(
     estimated_bounds: Dict[str, pd.DataFrame],
     bin_predictions: Dict[str, pd.DataFrame],
@@ -1482,88 +1691,12 @@ def evaluate_bounds(
         accuracy of predicted confidence intervals rather than bin overlap.
     """
 
-    if combine_middle_bins:
-        num_bins = 3
-
-    # Initialize results dicts
-    all_bound_percents = {}
-    all_bound_percents_notargetsep = {}
-
-    all_concat_errorbound_bins_target_sep_foldwise = [{} for x in range(len(targets))]  # type: List[Dict]
-    all_concat_errorbound_bins_target_sep_all = [{} for x in range(len(targets))]  # type: List[Dict]
-
-    # Loop over combinations of models (model) and uncertainty types (uncert_pair)
-    for i, (model, data_structs) in enumerate(bin_predictions.items()):
-        error_bounds = estimated_bounds[model + " Error Bounds"]
-
-        for uncert_pair in uncertainty_pairs:
-            uncertainty_type = uncert_pair[0]
-
-            fold_learned_bounds_mean_targets = []
-            fold_learned_bounds_mean_bins = [[] for x in range(num_bins)]  # type: List[List]
-            fold_learned_bounds_bins_targetsnotsep = [[] for x in range(num_bins)]  # type: List[List]
-            fold_all_bins_concat_targets_sep_foldwise = [
-                [[] for y in range(num_bins)] for x in range(len(targets))
-            ]  # type: List[List]
-            fold_all_bins_concat_targets_sep_all = [
-                [[] for y in range(num_bins)] for x in range(len(targets))
-            ]  # type: List[List]
-
-            for fold in range(num_folds):
-                # Get the ids for this fold
-                fold_errors = data_structs[(data_structs["Testing Fold"] == fold)][
-                    ["uid", "Target Index", uncertainty_type + " Error"]
-                ]
-                fold_bins = data_structs[(data_structs["Testing Fold"] == fold)][
-                    ["uid", "Target Index", uncertainty_type + " Uncertainty bins"]
-                ]
-                fold_bounds = strip_for_bound(
-                    error_bounds[error_bounds["fold"] == fold][uncertainty_type + " Uncertainty bounds"].values
-                )
-
-                return_dict = bin_wise_bound_eval(
-                    fold_bounds, fold_errors, fold_bins, targets, uncertainty_type, num_bins=num_bins
-                )
-                fold_learned_bounds_mean_targets.append(return_dict["mean all targets"])
-
-                for idx_bin in range(len(return_dict["mean all bins"])):
-                    fold_learned_bounds_mean_bins[idx_bin].append(return_dict["mean all bins"][idx_bin])
-                    fold_learned_bounds_bins_targetsnotsep[idx_bin] = (
-                        fold_learned_bounds_bins_targetsnotsep[idx_bin] + return_dict["mean all"][idx_bin]
-                    )
-
-                    for target_idx in range(len(targets)):
-                        fold_all_bins_concat_targets_sep_foldwise[target_idx][idx_bin] = (
-                            fold_all_bins_concat_targets_sep_foldwise[target_idx][idx_bin]
-                            + return_dict["all bins concatenated targets separated"][target_idx][idx_bin]
-                        )
-                        combined = (
-                            fold_all_bins_concat_targets_sep_all[target_idx][idx_bin]
-                            + return_dict["all bins concatenated targets separated"][target_idx][idx_bin]
-                        )
-
-                        fold_all_bins_concat_targets_sep_all[target_idx][idx_bin] = combined
-
-            # Reverses order so they are worst to best i.e. B5 -> B1
-            all_bound_percents[model + " " + uncertainty_type] = fold_learned_bounds_mean_bins[::-1]
-            all_bound_percents_notargetsep[model + " " + uncertainty_type] = fold_learned_bounds_bins_targetsnotsep[
-                ::-1
-            ]
-
-            for target_idx in range(len(all_concat_errorbound_bins_target_sep_foldwise)):
-                all_concat_errorbound_bins_target_sep_foldwise[target_idx][
-                    model + " " + uncertainty_type
-                ] = fold_all_bins_concat_targets_sep_foldwise[target_idx]
-                all_concat_errorbound_bins_target_sep_all[target_idx][
-                    model + " " + uncertainty_type
-                ] = fold_all_bins_concat_targets_sep_all[target_idx]
-
-    return {
-        "error_bounds_all": all_bound_percents,
-        "all_bound_percents_notargetsep": all_bound_percents_notargetsep,
-        "all errorbound concat bins targets sep foldwise": all_concat_errorbound_bins_target_sep_foldwise,
-        "all_errorbound_concat_bins_targets_sep_all": all_concat_errorbound_bins_target_sep_all,
-    }
+    config = EvaluationConfig(
+        num_folds=num_folds,
+        original_num_bins=num_bins,
+        combine_middle_bins=combine_middle_bins,
+    )
+    return BoundsEvaluator(estimated_bounds, config).evaluate(bin_predictions, uncertainty_pairs, targets)
 
 
 # Convenience functions for backward compatibility
@@ -1778,109 +1911,13 @@ def get_mean_errors(
 
     """
     # If we are combining the middle bins, we only have the 2 edge bins and the middle bins are combined into 1 bin.
-    if combine_middle_bins:
-        num_bins = 3
-
-    # initialize empty dicts
-    all_mean_error_bins = {}
-    all_mean_error_bins_targets_sep = {}
-    all_concat_error_bins_target_sep_foldwise: List[Dict] = [{} for x in range(len(targets))]
-    all_concat_error_bins_target_sep_all: List[Dict] = [{} for x in range(len(targets))]
-
-    all_concat_error_bins_target_nosep = {}
-    # Loop over models (model) and uncertainty methods (uncert_pair)
-    for i, (model, data_structs) in enumerate(bin_predictions.items()):
-        for uncert_pair in uncertainty_pairs:  # uncert_pair = [pair name, error name , uncertainty name]
-            uncertainty_type = uncert_pair[0]
-
-            # Initialize lists to store fold-wise results
-            fold_mean_targets = []
-            fold_mean_bins: List[List[float]] = [[] for x in range(num_bins)]
-            fold_all_bins: List[List[float]] = [[] for x in range(num_bins)]
-            fold_all_bins_concat_targets_sep_foldwise: List[List[List[float]]] = [
-                [[] for y in range(num_bins)] for x in range(len(targets))
-            ]
-            fold_all_bins_concat_targets_sep_all: List[List[List[float]]] = [
-                [[] for y in range(num_bins)] for x in range(len(targets))
-            ]
-
-            fold_all_bins_concat_targets_nosep: List[List[float]] = [[] for x in range(num_bins)]
-
-            for fold in range(num_folds):
-                # Get the errors and predicted bins for this fold
-                fold_errors = data_structs[(data_structs["Testing Fold"] == fold)][
-                    ["uid", "Target Index", uncertainty_type + " Error"]
-                ]
-                fold_bins = data_structs[(data_structs["Testing Fold"] == fold)][
-                    ["uid", "Target Index", uncertainty_type + " Uncertainty bins"]
-                ]
-
-                return_dict = bin_wise_errors(
-                    fold_errors,
-                    fold_bins,
-                    num_bins,
-                    targets,
-                    uncertainty_type,
-                    error_scaling_factor=error_scaling_factor,
-                )
-                fold_mean_targets.append(return_dict["mean all targets"])
-
-                for idx_bin in range(len(return_dict["mean all bins"])):
-                    fold_mean_bins[idx_bin].append(return_dict["mean all bins"][idx_bin])
-                    fold_all_bins[idx_bin] = fold_all_bins[idx_bin] + return_dict["all bins"][idx_bin]
-
-                    concat_no_sep = [x[idx_bin] for x in return_dict["all bins concatenated targets separated"]]
-
-                    flattened_concat_no_sep = [x for sublist in concat_no_sep for x in sublist]
-                    flattened_concat_no_sep = [x for sublist in flattened_concat_no_sep for x in sublist]
-
-                    fold_all_bins_concat_targets_nosep[idx_bin] = (
-                        fold_all_bins_concat_targets_nosep[idx_bin] + flattened_concat_no_sep
-                    )
-
-                    for target_idx in range(len(targets)):
-                        fold_all_bins_concat_targets_sep_foldwise[target_idx][idx_bin] = (
-                            fold_all_bins_concat_targets_sep_foldwise[target_idx][idx_bin]
-                            + return_dict["all bins concatenated targets separated"][target_idx][idx_bin]
-                        )
-
-                        if return_dict["all bins concatenated targets separated"][target_idx][idx_bin] != []:
-                            combined = (
-                                fold_all_bins_concat_targets_sep_all[target_idx][idx_bin]
-                                + return_dict["all bins concatenated targets separated"][target_idx][idx_bin][0]
-                            )
-                        else:
-                            combined = fold_all_bins_concat_targets_sep_all[target_idx][idx_bin]
-
-                        fold_all_bins_concat_targets_sep_all[target_idx][idx_bin] = combined
-
-            # reverse orderings
-            fold_mean_bins = fold_mean_bins[::-1]
-            fold_all_bins = fold_all_bins[::-1]
-            fold_all_bins_concat_targets_nosep = fold_all_bins_concat_targets_nosep[::-1]
-            fold_all_bins_concat_targets_sep_foldwise = [x[::-1] for x in fold_all_bins_concat_targets_sep_foldwise]
-            fold_all_bins_concat_targets_sep_all = [x[::-1] for x in fold_all_bins_concat_targets_sep_all]
-
-            all_mean_error_bins[model + " " + uncertainty_type] = fold_mean_bins
-            all_mean_error_bins_targets_sep[model + " " + uncertainty_type] = fold_all_bins
-
-            all_concat_error_bins_target_nosep[model + " " + uncertainty_type] = fold_all_bins_concat_targets_nosep
-
-            for target_idx in range(len(fold_all_bins_concat_targets_sep_foldwise)):
-                all_concat_error_bins_target_sep_foldwise[target_idx][
-                    model + " " + uncertainty_type
-                ] = fold_all_bins_concat_targets_sep_foldwise[target_idx]
-                all_concat_error_bins_target_sep_all[target_idx][
-                    model + " " + uncertainty_type
-                ] = fold_all_bins_concat_targets_sep_all[target_idx]
-
-    return {
-        "all_mean_error_bins_nosep": all_mean_error_bins,
-        "all mean error bins targets sep": all_mean_error_bins_targets_sep,
-        "all_error_concat_bins_targets_nosep": all_concat_error_bins_target_nosep,
-        "all error concat bins targets sep foldwise": all_concat_error_bins_target_sep_foldwise,
-        "all_error_concat_bins_targets_sep_all": all_concat_error_bins_target_sep_all,
-    }
+    config = EvaluationConfig(
+        num_folds=num_folds,
+        original_num_bins=num_bins,
+        error_scaling_factor=error_scaling_factor,
+        combine_middle_bins=combine_middle_bins,
+    )
+    return ErrorsEvaluator(config).evaluate(bin_predictions, uncertainty_pairs, targets)
 
 
 def bin_wise_errors(fold_errors, fold_bins, num_bins, targets, uncertainty_key, error_scaling_factor):

--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -408,12 +408,19 @@ class DataProcessor:
         bin_keys: List[List] = [[] for _ in range(num_bins)]
         bin_errors: List[List] = [[] for _ in range(num_bins)]
 
-        for bin_idx in range(num_bins):
-            keys = [key for key, val in bins_dict.items() if str(bin_idx) == str(val)]
-            errors = [errors_dict[key] for key in keys if key in errors_dict]
+        # Bins are compared as strings because they may be stored as either numbers or strings.
+        index_by_bin_label = {str(bin_idx): bin_idx for bin_idx in range(num_bins)}
 
-            bin_keys[bin_idx] = keys
-            bin_errors[bin_idx] = errors
+        # A single pass over the predictions, so grouping stays linear in the number of samples
+        # rather than rescanning them once per bin.
+        for key, bin_value in bins_dict.items():
+            bin_idx = index_by_bin_label.get(str(bin_value))
+            if bin_idx is None:  # Bin assignment outside the requested range.
+                continue
+
+            bin_keys[bin_idx].append(key)
+            if key in errors_dict:
+                bin_errors[bin_idx].append(errors_dict[key])
 
         return bin_keys, bin_errors
 
@@ -1644,17 +1651,7 @@ def bin_wise_bound_eval(
         # Keep track of #samples in each bin for weighted mean.
 
         # turn dictionary of predicted bins into [[num_bins]] array
-        pred_bins_keys = []
-        pred_bins_errors = []
-        for i in range(num_bins):
-            inner_list_bin = list([key for key, val in pred_bins_ti.items() if str(i) == str(val)])
-            inner_list_errors = []
-
-            for id_ in inner_list_bin:
-                inner_list_errors.append(list([val for key, val in true_errors_ti.items() if str(key) == str(id_)])[0])
-
-            pred_bins_errors.append(inner_list_errors)
-            pred_bins_keys.append(inner_list_bin)
+        pred_bins_keys, pred_bins_errors = DataProcessor.group_data_by_bins(true_errors_ti, pred_bins_ti, num_bins)
 
         bins_acc = []
         bins_sizes = []
@@ -1918,19 +1915,8 @@ def bin_wise_errors(fold_errors, fold_bins, num_bins, targets, uncertainty_key, 
         )
         pred_bins_ti = dict(zip(pred_bins_ti.uid, pred_bins_ti[uncertainty_key + " Uncertainty bins"]))
 
-        pred_bins_keys = []
-        pred_bins_errors = []
-
         # This is saving them from best quantile of predictions to worst quantile of predictions in terms of uncertainty
-        for j in range(num_bins):
-            inner_list = list([key for key, val in pred_bins_ti.items() if str(j) == str(val)])
-            inner_list_errors = []
-
-            for id_ in inner_list:
-                inner_list_errors.append(list([val for key, val in true_errors_ti.items() if str(key) == str(id_)])[0])
-
-            pred_bins_errors.append(inner_list_errors)
-            pred_bins_keys.append(inner_list)
+        pred_bins_keys, pred_bins_errors = DataProcessor.group_data_by_bins(true_errors_ti, pred_bins_ti, num_bins)
 
         # Now for each bin, get the mean error
         inner_errors = []

--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -1397,14 +1397,12 @@ class BoundsEvaluator(BaseEvaluator):
         for fold in fold_results:
             for idx_bin in range(len(fold.mean_all_bins)):
                 mean_bins[idx_bin].append(fold.mean_all_bins[idx_bin])
-                bins_targets_not_sep[idx_bin] = bins_targets_not_sep[idx_bin] + fold.all_bins[idx_bin]
+                bins_targets_not_sep[idx_bin].extend(fold.all_bins[idx_bin])
 
                 for target_idx in range(num_targets):
                     fold_bin_values = fold.all_bins_concat_targets_sep[target_idx][idx_bin]
-                    targets_sep_foldwise[target_idx][idx_bin] = (
-                        targets_sep_foldwise[target_idx][idx_bin] + fold_bin_values
-                    )
-                    targets_sep_all[target_idx][idx_bin] = targets_sep_all[target_idx][idx_bin] + fold_bin_values
+                    targets_sep_foldwise[target_idx][idx_bin].extend(fold_bin_values)
+                    targets_sep_all[target_idx][idx_bin].extend(fold_bin_values)
 
         if self.container_ is None:
             raise RuntimeError("Results container is not initialized")
@@ -1488,21 +1486,19 @@ class ErrorsEvaluator(BaseEvaluator):
         for fold in fold_results:
             for idx_bin in range(len(fold.mean_all_bins)):
                 mean_bins[idx_bin].append(fold.mean_all_bins[idx_bin])
-                all_bins[idx_bin] = all_bins[idx_bin] + fold.all_bins[idx_bin]
+                all_bins[idx_bin].extend(fold.all_bins[idx_bin])
 
                 # Flatten this bin's errors across every target, dropping the target separation.
                 per_target = [target_bins[idx_bin] for target_bins in fold.all_bins_concat_targets_sep]
-                flattened = [value for sublist in per_target for value in sublist]
-                flattened = [value for sublist in flattened for value in sublist]
-                concat_targets_no_sep[idx_bin] = concat_targets_no_sep[idx_bin] + flattened
+                sample_errors = [errors for target_values in per_target for errors in target_values]
+                flattened = [value for errors in sample_errors for value in errors]
+                concat_targets_no_sep[idx_bin].extend(flattened)
 
                 for target_idx in range(num_targets):
                     fold_bin_values = fold.all_bins_concat_targets_sep[target_idx][idx_bin]
-                    targets_sep_foldwise[target_idx][idx_bin] = (
-                        targets_sep_foldwise[target_idx][idx_bin] + fold_bin_values
-                    )
-                    if fold_bin_values != []:
-                        targets_sep_all[target_idx][idx_bin] = targets_sep_all[target_idx][idx_bin] + fold_bin_values[0]
+                    targets_sep_foldwise[target_idx][idx_bin].extend(fold_bin_values)
+                    if fold_bin_values:
+                        targets_sep_all[target_idx][idx_bin].extend(fold_bin_values[0])
 
         if self.container_ is None:
             raise RuntimeError("Results container is not initialized")

--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -385,7 +385,9 @@ class DataProcessor:
         # one frame and a str in the other still lined up; indexing the errors by str(uid) preserves
         # that while staying linear.
         index_by_bin_label = {str(bin_idx): bin_idx for bin_idx in range(num_bins)}
-        errors_by_str_uid = {str(key): value for key, value in errors_dict.items()}
+        errors_by_str_uid = {}
+        for key, value in errors_dict.items():
+            errors_by_str_uid.setdefault(str(key), value)
 
         # A single pass over the predictions, so grouping stays linear in the number of samples
         # rather than rescanning them once per bin.

--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -326,7 +326,7 @@ class DataProcessor:
 
         # Compare bins and uids as strings so a uid stored as an int in one frame and a str in the other still lines up.
         index_by_bin_label = {str(bin_idx): bin_idx for bin_idx in range(num_bins)}
-        errors_by_str_uid = {}
+        errors_by_str_uid: Dict = {}
         for key, value in errors_dict.items():
             errors_by_str_uid.setdefault(str(key), value)
 

--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -396,8 +396,9 @@ class DataProcessor:
 
             bin_keys[bin_idx].append(key)
             str_uid = str(key)
-            if str_uid in errors_by_str_uid:
-                bin_errors[bin_idx].append(errors_by_str_uid[str_uid])
+            if str_uid not in errors_by_str_uid:
+                raise ValueError(f"No error found for uid {key!r}")
+            bin_errors[bin_idx].append(errors_by_str_uid[str_uid])
 
         return bin_keys, bin_errors
 

--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -1323,7 +1323,8 @@ class JaccardEvaluator(BaseEvaluator):
             model_key (str): Model-uncertainty combination identifier.
             aggregated_metrics (Dict[str, List[List[float]]]): Aggregated metrics from all folds.
         """
-        assert self.container_ is not None, "Results container is not initialized"
+        if self.container_ is None:
+            raise RuntimeError("Results container is not initialized")
 
         # Store main jaccard results
         self.container_.add_main_result(model_key, aggregated_metrics["fold_jaccard_bins"])
@@ -1345,7 +1346,8 @@ class JaccardEvaluator(BaseEvaluator):
             model_key (str): Model-uncertainty combination identifier.
             jaccard_results (List[JaccardBinResults]): Results from all folds.
         """
-        assert self.container_ is not None, "Results container is not initialized"
+        if self.container_ is None:
+            raise RuntimeError("Results container is not initialized")
 
         # Process each fold's target-separated results
         for fold_idx in range(len(jaccard_results)):
@@ -1360,7 +1362,8 @@ class JaccardEvaluator(BaseEvaluator):
             model_key (str): Model-uncertainty combination identifier.
             result (JaccardBinResults): Results from one fold.
         """
-        assert self.container_ is not None, "Results container is not initialized"
+        if self.container_ is None:
+            raise RuntimeError("Results container is not initialized")
 
         for target_idx in range(len(result.all_bins_concat_targets_sep)):
             self._initialize_target_containers_if_needed(model_key, target_idx)
@@ -1385,7 +1388,8 @@ class JaccardEvaluator(BaseEvaluator):
             model_key (str): Model-uncertainty combination identifier.
             target_idx (int): Index of the target.
         """
-        assert self.container_ is not None, "Results container is not initialized"
+        if self.container_ is None:
+            raise RuntimeError("Results container is not initialized")
 
         # Initialize foldwise container if needed
         if target_idx < len(self.container_.target_sep_foldwise):
@@ -1420,7 +1424,8 @@ class JaccardEvaluator(BaseEvaluator):
             This method maps the container's organized data structure to the specific
             result keys expected by the Jaccard evaluation API.
         """
-        assert self.container_ is not None, "Results container is not initialized"
+        if self.container_ is None:
+            raise RuntimeError("Results container is not initialized")
         return {
             ResultKeys.JACCARD_ALL: self.container_.main_results,
             ResultKeys.JACCARD_TARGETS_SEPARATED: self.container_.target_separated_results,
@@ -1475,7 +1480,8 @@ class BoundsEvaluator(BaseEvaluator):
 
     def _process_single_fold(self, fold_data: FoldData) -> BinResults:
         """Evaluate bound accuracy for one fold."""
-        assert fold_data.bounds is not None, "Fold data is missing its estimated bounds"
+        if fold_data.bounds is None:
+            raise RuntimeError("Fold data is missing its estimated bounds")
         result = bin_wise_bound_eval(
             fold_data.bounds,
             fold_data.errors,
@@ -1514,7 +1520,8 @@ class BoundsEvaluator(BaseEvaluator):
                     )
                     targets_sep_all[target_idx][idx_bin] = targets_sep_all[target_idx][idx_bin] + fold_bin_values
 
-        assert self.container_ is not None, "Results container is not initialized"
+        if self.container_ is None:
+            raise RuntimeError("Results container is not initialized")
 
         # Reverses order so they are worst to best i.e. B5 -> B1
         self.container_.add_main_result(model_key, mean_bins[::-1])
@@ -1528,7 +1535,8 @@ class BoundsEvaluator(BaseEvaluator):
 
     def _finalize_results(self) -> Dict:
         """Map the container onto the error bound result keys."""
-        assert self.container_ is not None, "Results container is not initialized"
+        if self.container_ is None:
+            raise RuntimeError("Results container is not initialized")
 
         return {
             ResultKeys.ERROR_BOUNDS_ALL: self.container_.main_results,
@@ -1610,7 +1618,8 @@ class ErrorsEvaluator(BaseEvaluator):
                     if fold_bin_values != []:
                         targets_sep_all[target_idx][idx_bin] = targets_sep_all[target_idx][idx_bin] + fold_bin_values[0]
 
-        assert self.container_ is not None, "Results container is not initialized"
+        if self.container_ is None:
+            raise RuntimeError("Results container is not initialized")
 
         # reverse orderings, so bins run worst to best i.e. B5 -> B1
         self.container_.add_main_result(model_key, mean_bins[::-1])
@@ -1625,7 +1634,8 @@ class ErrorsEvaluator(BaseEvaluator):
 
     def _finalize_results(self) -> Dict:
         """Map the container onto the mean error result keys."""
-        assert self.container_ is not None, "Results container is not initialized"
+        if self.container_ is None:
+            raise RuntimeError("Results container is not initialized")
 
         return {
             ResultKeys.ALL_MEAN_ERROR_BINS_NO_SEP: self.container_.main_results,

--- a/kale/evaluate/uncertainty_metrics.py
+++ b/kale/evaluate/uncertainty_metrics.py
@@ -88,13 +88,8 @@ class EvaluationConfig:
     """
     Configuration parameters for uncertainty quantification evaluation.
 
-    This dataclass defines the settings and parameters used throughout the evaluation process for uncertainty
-    quantification metrics. It provides default values for common evaluation scenarios while allowing customization for
-    specific research needs.
-
     Attributes:
-        num_folds (int): Number of cross-validation folds for evaluation. Defaults to 8. Higher values provide more
-            robust statistical estimates but increase computational cost.
+        num_folds (int): Number of cross-validation folds for evaluation. Defaults to 8.
         original_num_bins (int): Number of quantile bins for uncertainty evaluation. Defaults to 10. Controls the
             granularity of uncertainty analysis.
         error_scaling_factor (float): Scaling factor applied to prediction errors during evaluation. Defaults to 1.0 (no
@@ -128,9 +123,6 @@ class FoldData:
     """
     Container for evaluation data from a single cross-validation fold.
 
-    This dataclass organizes the data required for evaluating a single fold in cross-validation, including prediction
-    errors, uncertainty bins, and optional error bounds information.
-
     Attributes:
         errors (pd.DataFrame): DataFrame containing prediction errors for the fold. Expected columns include UID,
             target_idx, and model-specific error columns.
@@ -160,17 +152,16 @@ class BinResults:
     """
     Base container for evaluation results from a single fold.
 
-    This dataclass stores the fundamental evaluation metrics computed for a single cross-validation fold, organized by
-    targets and bins. Serves as the base class for specialized result containers like JaccardBinResults.
-
     Attributes:
         mean_all_targets (float): Mean evaluation metric across all targets in the fold.
         mean_all_bins (List[float]): Mean evaluation metric for each bin across targets. Length equals the number of
             bins.
         all_bins (List[List[float]]): Raw evaluation metrics for each bin and target. Outer list represents bins, inner
             lists contain values for each target.
-        all_bins_concat_targets_sep (List[List[List[float]]]): Evaluation metrics organized for target-separated
-            analysis. Structure: [target][bin][values].
+        all_bins_concat_targets_sep (List[List[List[Any]]]): Values grouped by target and bin within one fold.
+            Bounds and Jaccard use float values, so each target/bin entry is [metric]. Errors use List[float] values,
+            so each entry is [[sample_errors...]], or [] for an empty bin. Bounds and errors store bins from lowest
+            to highest uncertainty; Jaccard stores bins in the reverse order.
     """
 
     mean_all_targets: float
@@ -184,18 +175,7 @@ class JaccardBinResults(BinResults):
     """
     Extended results container for Jaccard similarity evaluation with precision and recall.
 
-    This specialized container extends BinResults to include additional metrics specific to Jaccard similarity
-    evaluation: precision and recall. These metrics provide comprehensive assessment of uncertainty quantification
-        quality.
-
     Attributes:
-        Inherits from BinResults:
-            - mean_all_targets: Mean Jaccard similarity across all targets
-            - mean_all_bins: Mean Jaccard similarity for each bin
-            - all_bins: Raw Jaccard similarities for each bin and target
-            - all_bins_concat_targets_sep: Target-separated Jaccard similarities
-
-        Additional Jaccard-specific attributes:
         mean_all_targets_recall (float): Mean recall across all targets in the fold.
         mean_all_bins_recall (List[float]): Mean recall for each bin across targets.
         all_bins_recall (List[List[float]]): Raw recall values for each bin and target.
@@ -214,13 +194,7 @@ class JaccardBinResults(BinResults):
 
 class ResultsContainer:
     """
-    Container for organizing and managing complex nested evaluation results.
-
-    This class provides a structured way to organize evaluation results across different dimensions: models, uncertainty
-    types, bins, targets, and folds. It handles both main aggregated results and target-separated detailed results.
-
-    The container supports multiple evaluation metrics and provides methods for adding results in an organized manner.
-    It's designed to work with the Template Method pattern in BaseEvaluator.
+    Store evaluation results by model, uncertainty type, bin, target, and fold.
 
     Attributes:
         num_bins (int): Number of uncertainty bins in the evaluation.
@@ -230,10 +204,10 @@ class ResultsContainer:
         target_sep_foldwise (List[Dict]): Target-separated results for each fold.
         target_sep_all (List[Dict]): Target-separated results aggregated across folds.
         additional_containers (Dict): Container for evaluation-specific results.
-
-    Jaccard-specific attributes: recall_results (Dict): Recall metrics for all model-uncertainty combinations.
-    recall_target_separated (Dict): Target-separated recall results. precision_results (Dict): Precision metrics for all
-        combinations. precision_target_separated (Dict): Target-separated precision results.
+        recall_results (Dict): Recall metrics for all model-uncertainty combinations.
+        recall_target_separated (Dict): Target-separated recall results.
+        precision_results (Dict): Precision metrics for all model-uncertainty combinations.
+        precision_target_separated (Dict): Target-separated precision results.
 
     Example:
 
@@ -257,12 +231,7 @@ class ResultsContainer:
         self._init_containers()
 
     def _init_containers(self):
-        """
-        Initialize all result containers with empty data structures.
-
-        Sets up the internal data structures needed to organize evaluation results across different dimensions (main
-        results, target-separated results, fold-wise results, and evaluation-specific containers).
-        """
+        """Initialize empty result containers."""
         # Main results
         self.main_results = {}
         self.target_separated_results = {}
@@ -274,7 +243,7 @@ class ResultsContainer:
         # Additional containers for specific evaluations
         self.additional_containers = {}
 
-        # Add missing attributes for JaccardEvaluator
+        # Jaccard metrics
         self.recall_results = {}
         self.recall_target_separated = {}
         self.precision_results = {}
@@ -290,29 +259,7 @@ class ResultsContainer:
 
 
 class DataProcessor:
-    """
-    Utility class for data processing operations in uncertainty evaluation.
-
-    This class provides static methods for extracting and filtering data from DataFrames for evaluation purposes. It
-    handles fold-specific data extraction, target filtering, and data structure preparation for evaluation workflows.
-
-    The class is designed as a collection of utility methods that can be used across different evaluator implementations
-    without maintaining state.
-
-    Key Operations:
-        - Extract data for specific cross-validation folds
-        - Filter data by target indices
-        - Prepare data structures for evaluation processing
-        - Handle column name mapping and data type conversions
-
-    Example:
-
-        .. code-block:: pycon
-
-            >>> processor = DataProcessor()
-            >>> fold_data = processor.extract_fold_data(df, fold=0, uncertainty_type="epistemic")
-            >>> filtered_data = processor.filter_by_target(fold_data.errors, target_idx=1)
-    """
+    """Extract fold data and group predictions by uncertainty bin."""
 
     @staticmethod
     def extract_fold_data(data_structs: pd.DataFrame, fold: int, uncertainty_type: str) -> FoldData:
@@ -350,9 +297,6 @@ class DataProcessor:
         """
         Group prediction data by their assigned uncertainty bins.
 
-        Organizes prediction keys and errors into bin-wise groups based on their uncertainty bin assignments. This
-        enables bin-wise evaluation of prediction quality and uncertainty calibration.
-
         Args:
             errors_dict (Dict): Dictionary mapping prediction keys to error values. Keys should correspond to unique
                 prediction identifiers.
@@ -380,17 +324,12 @@ class DataProcessor:
         bin_keys: List[List] = [[] for _ in range(num_bins)]
         bin_errors: List[List] = [[] for _ in range(num_bins)]
 
-        # Bins and uids are both compared as strings because either may be stored as a number or a
-        # string. The original grouping used str(...) on both sides, so a uid stored as an int in
-        # one frame and a str in the other still lined up; indexing the errors by str(uid) preserves
-        # that while staying linear.
+        # Compare bins and uids as strings so a uid stored as an int in one frame and a str in the other still lines up.
         index_by_bin_label = {str(bin_idx): bin_idx for bin_idx in range(num_bins)}
         errors_by_str_uid = {}
         for key, value in errors_dict.items():
             errors_by_str_uid.setdefault(str(key), value)
 
-        # A single pass over the predictions, so grouping stays linear in the number of samples
-        # rather than rescanning them once per bin.
         for key, bin_value in bins_dict.items():
             bin_idx = index_by_bin_label.get(str(bin_value))
             if bin_idx is None:  # Bin assignment outside the requested range.
@@ -406,31 +345,7 @@ class DataProcessor:
 
 
 class QuantileCalculator:
-    """
-    Utility class for calculating quantile-based error distributions and thresholds.
-
-    This class provides methods for computing quantile boundaries and grouping prediction errors into quantile-based
-    bins. It supports both standard quantile binning and combined middle bin configurations for simplified analysis.
-
-    The quantile approach enables analysis of prediction quality across different uncertainty levels by creating bins
-    that contain equal numbers of predictions but varying error characteristics.
-
-    Key Features:
-        - Automatic quantile threshold calculation
-        - Flexible bin combination for middle quantiles
-        - Error and key grouping by quantile boundaries
-        - Support for worst-to-best ordering (B5 to B1)
-
-    Example:
-
-        .. code-block:: pycon
-
-            >>> calculator = QuantileCalculator()
-            >>> errors = {'pred1': 0.1, 'pred2': 0.5, 'pred3': 0.3}
-            >>> thresholds, err_groups, key_groups = calculator.calculate_error_quantiles(
-            ...     errors, num_bins=3, combine_middle_bins=False
-            ... )
-    """
+    """Compute quantile thresholds and group errors into quantile-based bins."""
 
     @staticmethod
     def calculate_error_quantiles(
@@ -454,10 +369,6 @@ class QuantileCalculator:
                 - quantile_thresholds: List of quantile boundary values
                 - error_groups: List of error value lists for each bin (worst to best)
                 - key_groups: List of prediction key lists for each bin (worst to best)
-
-        Note:
-            Results are ordered from worst to best performance (B5 to B1 convention) to match the expected evaluation
-            output format.
 
         Example:
 
@@ -541,32 +452,7 @@ class QuantileCalculator:
 
 
 class MetricsCalculator:
-    """
-    Utility class for calculating evaluation metrics in uncertainty quantification.
-
-    This class provides static methods for computing various metrics used to assess the quality of uncertainty
-    quantification, including Jaccard similarity, precision, recall, and bound accuracy. The methods are designed to
-    work with different evaluation strategies and provide consistent metric calculations.
-
-    Key Metrics:
-        - Jaccard Similarity: Measures overlap between predicted and ground truth sets
-        - Precision: Accuracy of positive predictions within bins
-        - Recall: Coverage of actual positive cases by predictions
-        - Bound Accuracy: Whether errors fall within expected confidence bounds
-
-    The class supports both binary classification metrics (for set-based evaluation) and regression-style bound checking
-    for error prediction accuracy.
-
-    Example:
-
-        .. code-block:: pycon
-
-            >>> calculator = MetricsCalculator()
-            >>> jaccard, recall, precision = calculator.calculate_jaccard_metrics(
-            ...     predicted_keys=['p1', 'p2'], ground_truth_keys=['p1', 'p3']
-            ... )
-            >>> # jaccard ≈ 0.33, recall = 0.5, precision = 0.5
-    """
+    """Compute Jaccard similarity, recall, precision, and bound accuracy for uncertainty evaluation."""
 
     @staticmethod
     def calculate_jaccard_metrics(predicted_keys: List, ground_truth_keys: List) -> Tuple[float, float, float]:
@@ -632,24 +518,18 @@ class MetricsCalculator:
     @staticmethod
     def calculate_bound_accuracy(error: float, bin_idx: int, bounds: List[float]) -> bool:
         """
-        Check if error falls within expected bounds for the bin.
+        Check whether an error falls within its bin's half-open range ``(lower, upper]``.
 
-        Determines whether a prediction error falls within the expected error bounds for a specific uncertainty bin.
-        This method is used to assess the accuracy of uncertainty-based error predictions.
+        Bin 0 covers ``(0, bounds[0]]``, intermediate bin ``i`` covers ``(bounds[i-1], bounds[i]]``, and the last bin
+        covers ``(bounds[-1], inf)``.
 
         Args:
             error (float): The prediction error value to check.
             bin_idx (int): Index of the uncertainty bin (0-based).
-            bounds (List[float]): List of error boundary values that define the expected error ranges for each bin.
+            bounds (List[float]): Upper bound of each finite bin, ordered from tightest to loosest.
 
         Returns:
-            bool: True if the error falls within the expected bounds for the specified bin, False otherwise.
-
-        Note:
-            Bin ranges follow the pattern (lower_bound, upper_bound], where:
-            - Bin 0: (0, bounds[0]] - errors greater than 0 and up to bounds[0]
-            - Bin i: (bounds[i-1], bounds[i]] - errors greater than bounds[i-1] and up to bounds[i]
-            - Last bin: (bounds[-1], ∞) - errors greater than the last bound
+            bool: True if the error falls within the bin's range.
         """
         if bin_idx == 0:
             return 0 < error <= bounds[bin_idx]
@@ -663,31 +543,14 @@ class BaseEvaluator(ABC):
     """
     Abstract base class for uncertainty quantification evaluation strategies.
 
-    This class implements the Template Method pattern to provide a consistent evaluation framework while allowing
-    specialized implementations for different metrics (Jaccard, error bounds, etc.). It manages the evaluation workflow
-    across multiple folds, models, and uncertainty types.
-
-    Design Pattern: Uses Template Method pattern where the main evaluation flow is defined in the base class, while
-    specific evaluation logic is implemented by subclasses.
-
-    Key Features:
-        - Cross-validation fold processing
-        - Multi-model and multi-uncertainty type support
-        - Configurable bin combining and scaling
-        - Result aggregation and formatting
-
-    Workflow:
-        1. Process each model and uncertainty type combination
-        2. Extract data for each cross-validation fold
-        3. Apply subclass-specific evaluation (_process_single_fold)
-        4. Aggregate results across folds (_aggregate_fold_results)
-        5. Format final results (_finalize_results)
+    Evaluate models and uncertainty types across folds, collecting the metrics produced by each subclass.
 
     Attributes:
         config_ (EvaluationConfig): Configuration containing evaluation parameters
         current_num_bins_ (int): Number of bins for current evaluation (may differ from original)
         current_targets_ (List[int]): Target indices for current evaluation
         current_uncertainty_type_ (str): Current uncertainty type being processed
+        current_model_ (str): Current model being evaluated
     """
 
     def __init__(self, config: EvaluationConfig):
@@ -699,7 +562,6 @@ class BaseEvaluator(ABC):
                 bins, and processing options.
         """
         self.config_ = config
-        # Instance variables to reduce parameter passing
         self.container_: Optional[ResultsContainer] = None
         self.current_num_bins_: int = config.original_num_bins
         self.current_targets_: List[int] = []
@@ -708,11 +570,7 @@ class BaseEvaluator(ABC):
 
     def evaluate(self, bin_predictions: Dict[str, pd.DataFrame], uncertainty_pairs: List, targets: List[int]) -> Dict:
         """
-        Main evaluation method implementing the template method pattern.
-
-        Orchestrates the complete evaluation process across all models, uncertainty types, and cross-validation folds.
-        This method defines the evaluation workflow while delegating specific evaluation logic to subclass
-        implementations.
+        Evaluate each model and uncertainty type across the configured folds.
 
         Args:
             bin_predictions (Dict[str, pd.DataFrame]): Dictionary mapping model names to DataFrames containing bin
@@ -724,20 +582,8 @@ class BaseEvaluator(ABC):
                 results by target.
 
         Returns:
-            Dict: Comprehensive evaluation results dictionary. Structure depends on the specific evaluator
-                implementation but typically includes:
-                - Main results across all folds and targets
-                - Target-separated results for detailed analysis
-                - Additional metrics specific to the evaluation type
-
-        Workflow:
-            1. Initialize result containers for data organization
-            2. For each model and uncertainty type combination:
-               a. Process all cross-validation folds
-               b. Aggregate fold results
-            3. Finalize and format results for output
+            Dict: Aggregated metrics and target-separated results in the concrete evaluator's format.
         """
-        # Set instance variables to reduce parameter passing
         self.current_targets_ = targets
         self.current_num_bins_ = (
             self.config_.combined_num_bins if self.config_.combine_middle_bins else self.config_.original_num_bins
@@ -762,26 +608,19 @@ class BaseEvaluator(ABC):
         """
         Process evaluation for a single cross-validation fold.
 
-        This abstract method must be implemented by subclasses to define how evaluation metrics are calculated for data
-        from a single fold.
-
         Args:
             fold_data (FoldData): Container with errors and bins data for one fold. Contains filtered DataFrames for the
                 current fold, uncertainty type, and any additional data needed for evaluation.
 
         Returns:
-            BinResults: Results structure containing evaluation metrics for this fold. The specific subclass of
-                BinResults depends on the evaluation type (e.g., JaccardBinResults for Jaccard evaluation).
+            BinResults: Results structure containing evaluation metrics for this fold.
         """
         pass
 
     @abstractmethod
-    def _aggregate_fold_results(self, model_key: str, fold_results: List[BinResults]):
+    def _aggregate_fold_results(self, model_key: str, fold_results: List[BinResults]) -> None:
         """
         Aggregate results across all folds for a model-uncertainty combination.
-
-        This abstract method defines how fold-level results are combined and stored in the results container for final
-        output formatting.
 
         Args:
             model_key (str): Identifier for the current model-uncertainty combination (format: "model_name
@@ -796,8 +635,6 @@ class BaseEvaluator(ABC):
         """
         Convert results container into final output format.
 
-        This abstract method handles the final formatting of evaluation results to match the expected API output format.
-
         Returns:
             Dict: Final results dictionary with keys matching the expected API format. Structure depends on the
                 evaluation type but typically includes main results, target-separated results, and evaluation-specific
@@ -809,18 +646,12 @@ class BaseEvaluator(ABC):
         """
         Process all cross-validation folds for a given model and uncertainty type.
 
-        Iterates through all configured cross-validation folds, extracting data for each fold and applying the
-        subclass-specific evaluation logic to compute fold-level results. This method coordinates the fold-wise
-        evaluation process within the Template Method pattern.
-
         Args:
             data_structs (pd.DataFrame): Complete dataset containing all folds and evaluation data for the current
                 model. Must include columns for fold identification, UIDs, target indices, errors, and uncertainty bins.
 
         Returns:
-            List[BinResults]: List of evaluation results from all folds, where each element contains the evaluation
-            metrics (e.g., Jaccard similarity, error bounds) computed for one fold. The specific type of BinResults
-            depends on the evaluator implementation (e.g., JaccardBinResults for Jaccard evaluation).
+            List[BinResults]: Results in fold order.
         """
         fold_results = []
 
@@ -836,20 +667,12 @@ class JaccardEvaluator(BaseEvaluator):
     """
     Evaluator for calculating Jaccard similarity metrics for uncertainty quantification.
 
-    This evaluator computes Jaccard similarity between prediction confidence bins and error bins to assess the quality
-    of uncertainty quantification. It measures how well the model's confidence aligns with actual prediction accuracy.
+    Compare predicted uncertainty bins with quantiles of the observed errors using Jaccard similarity, recall,
+    and precision.
 
     The Jaccard similarity is calculated as: J(A, B) = |A ∩ B| / |A ∪ B|
 
-    Where A represents the high-confidence predictions and B represents the correct predictions within each bin.
-
-    Attributes:
-        config_ (EvaluationConfig): Configuration object containing evaluation parameters including bin counts,
-            confidence thresholds, and target separation settings.
-        data_processor (DataProcessor): Handles data filtering and preprocessing operations.
-        quantile_calculator (QuantileCalculator): Computes quantile-based bin boundaries.
-        metrics_calculator (MetricsCalculator): Calculates evaluation metrics including Jaccard similarity and
-            statistical measures.
+    A and B contain the sample UIDs in the corresponding uncertainty and error bins.
 
     Example:
 
@@ -866,16 +689,6 @@ class JaccardEvaluator(BaseEvaluator):
     """
 
     def __init__(self, config: Optional[EvaluationConfig] = None):
-        """
-        Initialize JaccardEvaluator with configuration and required components.
-
-        Sets up the evaluator with configuration parameters and calls the parent class constructor to initialize the
-        evaluation framework.
-
-        Args:
-            config (Optional[EvaluationConfig]): Configuration object containing evaluation parameters such as bin
-                counts, thresholds, and settings for target separation. If None, uses default EvaluationConfig values.
-        """
         super().__init__(config or EvaluationConfig())
 
     @classmethod
@@ -970,20 +783,12 @@ class JaccardEvaluator(BaseEvaluator):
         """
         Process Jaccard evaluation metrics for a single cross-validation fold.
 
-        Computes Jaccard similarity, precision, and recall metrics for each bin and target within a single fold. This
-        method implements the core evaluation logic for assessing uncertainty quantification quality.
-
         Args:
             fold_data (FoldData): Container with errors and bins data for the current fold. Contains filtered DataFrames
                 with prediction errors and uncertainty bins for evaluation.
 
         Returns:
-            JaccardBinResults: Results container with computed metrics including:
-                - bin_jaccard: List of Jaccard similarities for each bin
-                - bin_recall: List of recall values for each bin
-                - bin_precision: List of precision values for each bin
-                - target_metrics: Target-specific evaluation results
-                - bins_targets_separated: Bin results separated by target
+            JaccardBinResults: Mean and per-target Jaccard, recall, and precision metrics in descending bin order.
         """
         all_target_jaccard = []
         all_target_recall = []
@@ -1043,14 +848,11 @@ class JaccardEvaluator(BaseEvaluator):
                 - 'bin_recall': List of recall values for each bin
                 - 'bin_precision': List of precision values for each bin
         """
-        # Extract and prepare target-specific data
         errors_dict, bins_dict = self._extract_target_data(fold_data, target_idx)
 
-        # Get predicted bins and ground truth quantiles
         pred_bin_keys = self._get_predicted_bin_keys(errors_dict, bins_dict)
         gt_key_groups = self._get_ground_truth_quantiles(errors_dict)
 
-        # Calculate bin-wise metrics
         bin_jaccard, bin_recall, bin_precision = self._calculate_bin_wise_metrics(pred_bin_keys, gt_key_groups)
 
         return JaccardEvaluator._format_target_results(bin_jaccard, bin_recall, bin_precision)
@@ -1139,12 +941,9 @@ class JaccardEvaluator(BaseEvaluator):
 
         return bin_jaccard, bin_recall, bin_precision
 
-    def _aggregate_fold_results(self, model_key: str, fold_results: List[BinResults]):
+    def _aggregate_fold_results(self, model_key: str, fold_results: List[BinResults]) -> None:
         """
         Aggregate Jaccard evaluation results across all cross-validation folds.
-
-        Combines fold-level Jaccard similarity, precision, and recall results into aggregated statistics for a specific
-        model-uncertainty combination. Handles both main results and target-separated results based on configuration.
 
         Args:
             model_key (str): Identifier for the current model-uncertainty combination (format: "model_name
@@ -1152,16 +951,12 @@ class JaccardEvaluator(BaseEvaluator):
             fold_results (List[BinResults]): List of JaccardBinResults from all folds for the current model-uncertainty
                 combination.
         """
-        # Cast to JaccardBinResults since we know that's what JaccardEvaluator produces
         jaccard_results = cast(List[JaccardBinResults], fold_results)
 
-        # Aggregate fold-level metrics
         aggregated_metrics = self._aggregate_fold_metrics(jaccard_results)
 
-        # Store main results in container
         self._store_main_results(model_key, aggregated_metrics)
 
-        # Store target-separated results
         self._store_target_separated_results(model_key, jaccard_results)
 
     def _aggregate_fold_metrics(self, jaccard_results: List[JaccardBinResults]) -> Dict[str, List[List[float]]]:
@@ -1174,10 +969,8 @@ class JaccardEvaluator(BaseEvaluator):
         Returns:
             Dict[str, List[List[float]]]: Dictionary containing aggregated metrics for each metric type.
         """
-        # Create template for empty bin containers and copy it to avoid repetitive for loops
         empty_bins_template: List[List[float]] = [[] for _ in range(self.current_num_bins_)]
 
-        # Initialize containers by copying the template
         fold_jaccard_bins = copy.deepcopy(empty_bins_template)
         fold_recall_bins = copy.deepcopy(empty_bins_template)
         fold_precision_bins = copy.deepcopy(empty_bins_template)
@@ -1186,7 +979,6 @@ class JaccardEvaluator(BaseEvaluator):
         fold_all_recall_bins = copy.deepcopy(empty_bins_template)
         fold_all_precision_bins = copy.deepcopy(empty_bins_template)
 
-        # Aggregate results across folds
         for result in jaccard_results:
             for bin_idx in range(len(result.mean_all_bins)):
                 fold_jaccard_bins[bin_idx].append(result.mean_all_bins[bin_idx])
@@ -1217,15 +1009,12 @@ class JaccardEvaluator(BaseEvaluator):
         if self.container_ is None:
             raise RuntimeError("Results container is not initialized")
 
-        # Store main jaccard results
         self.container_.add_main_result(model_key, aggregated_metrics["fold_jaccard_bins"])
         self.container_.add_target_separated_result(model_key, aggregated_metrics["fold_all_jaccard_bins"])
 
-        # Store recall results
         self.container_.recall_results[model_key] = aggregated_metrics["fold_recall_bins"]
         self.container_.recall_target_separated[model_key] = aggregated_metrics["fold_all_recall_bins"]
 
-        # Store precision results
         self.container_.precision_results[model_key] = aggregated_metrics["fold_precision_bins"]
         self.container_.precision_target_separated[model_key] = aggregated_metrics["fold_all_precision_bins"]
 
@@ -1240,7 +1029,6 @@ class JaccardEvaluator(BaseEvaluator):
         if self.container_ is None:
             raise RuntimeError("Results container is not initialized")
 
-        # Process each fold's target-separated results
         for fold_idx in range(len(jaccard_results)):
             result = jaccard_results[fold_idx]
             self._process_fold_target_separation(model_key, result)
@@ -1261,12 +1049,10 @@ class JaccardEvaluator(BaseEvaluator):
 
             for bin_idx in range(self.current_num_bins_):
                 if target_idx < len(self.container_.target_sep_foldwise):
-                    # Store foldwise target-separated results
                     self.container_.target_sep_foldwise[target_idx][model_key][bin_idx].extend(
                         result.all_bins_concat_targets_sep[target_idx][bin_idx]
                     )
 
-                    # Store overall target-separated results
                     self.container_.target_sep_all[target_idx][model_key][bin_idx].extend(
                         result.all_bins_concat_targets_sep[target_idx][bin_idx]
                     )
@@ -1282,12 +1068,10 @@ class JaccardEvaluator(BaseEvaluator):
         if self.container_ is None:
             raise RuntimeError("Results container is not initialized")
 
-        # Initialize foldwise container if needed
         if target_idx < len(self.container_.target_sep_foldwise):
             if model_key not in self.container_.target_sep_foldwise[target_idx]:
                 self.container_.target_sep_foldwise[target_idx][model_key] = [[] for _ in range(self.current_num_bins_)]
 
-        # Initialize overall container if needed
         if target_idx < len(self.container_.target_sep_all):
             if model_key not in self.container_.target_sep_all[target_idx]:
                 self.container_.target_sep_all[target_idx][model_key] = [[] for _ in range(self.current_num_bins_)]
@@ -1330,9 +1114,6 @@ class BoundsEvaluator(BaseEvaluator):
 
     For each quantile bin, this measures the proportion of predictions whose true error falls inside
     the bound estimated for that bin, which shows how well the estimated bounds are calibrated.
-
-    Unlike the other evaluators, each fold needs its estimated bounds alongside the predictions, so
-    :meth:`_process_all_folds` attaches them to the fold data.
 
     Args:
         estimated_bounds (Dict[str, pd.DataFrame]): Estimated error bounds per model, keyed by
@@ -1384,15 +1165,28 @@ class BoundsEvaluator(BaseEvaluator):
             all_bins_concat_targets_sep=result[ResultKeys.ALL_BINS_CONCAT_TARGETS_SEP],
         )
 
-    def _aggregate_fold_results(self, model_key: str, fold_results: List[BinResults]):
-        """Collect bound accuracy across folds, per bin and per target."""
+    def _aggregate_fold_results(self, model_key: str, fold_results: List[BinResults]) -> None:
+        """Store bound accuracy by bin, fold, and target.
+
+        For each model key, main results use [bin][fold] and unseparated accuracies use [bin][fold * target],
+        ordered by fold then target. Both use descending uncertainty bins. The two target-separated outputs use
+        [target][model_key][bin][fold], with ascending uncertainty bins and an accuracy value for every fold.
+
+        Args:
+            model_key (str): Model and uncertainty identifier used in the result containers.
+            fold_results (List[BinResults]): Results in fold order, with bins ordered from lowest to highest
+                uncertainty and targets ordered as in current_targets_.
+
+        Raises:
+            RuntimeError: If the results container has not been initialized.
+        """
         num_bins = self.current_num_bins_
         num_targets = len(self.current_targets_)
 
-        mean_bins: List[List] = [[] for _ in range(num_bins)]
-        bins_targets_not_sep: List[List] = [[] for _ in range(num_bins)]
-        targets_sep_foldwise: List[List[List]] = [[[] for _ in range(num_bins)] for _ in range(num_targets)]
-        targets_sep_all: List[List[List]] = [[[] for _ in range(num_bins)] for _ in range(num_targets)]
+        mean_bins: List[List[float]] = [[] for _ in range(num_bins)]
+        bins_targets_not_sep: List[List[float]] = [[] for _ in range(num_bins)]
+        targets_sep_foldwise: List[List[List[float]]] = [[[] for _ in range(num_bins)] for _ in range(num_targets)]
+        targets_sep_all: List[List[List[float]]] = [[[] for _ in range(num_bins)] for _ in range(num_targets)]
 
         for fold in fold_results:
             for idx_bin in range(len(fold.mean_all_bins)):
@@ -1407,7 +1201,6 @@ class BoundsEvaluator(BaseEvaluator):
         if self.container_ is None:
             raise RuntimeError("Results container is not initialized")
 
-        # Reverses order so they are worst to best i.e. B5 -> B1
         self.container_.add_main_result(model_key, mean_bins[::-1])
         self.container_.additional_containers.setdefault(ResultKeys.ALL_BOUND_PERCENTS_NO_TARGET_SEP, {})[
             model_key
@@ -1472,16 +1265,32 @@ class ErrorsEvaluator(BaseEvaluator):
             all_bins_concat_targets_sep=result[ResultKeys.ALL_BINS_CONCAT_TARGETS_SEP],
         )
 
-    def _aggregate_fold_results(self, model_key: str, fold_results: List[BinResults]):
-        """Collect mean errors across folds, per bin and per target."""
+    def _aggregate_fold_results(self, model_key: str, fold_results: List[BinResults]) -> None:
+        """Store mean and sample errors by bin, fold, and target.
+
+        Main results use [bin][fold], with None for bins empty across all targets. Unseparated values concatenate
+        folds, targets, and samples in that order. Target-separated errors use
+        [target][model_key][bin][nonempty_fold][sample], or [target][model_key][bin][sample] with folds combined.
+        All outputs use descending uncertainty bins; target-separated lists contain only nonempty folds.
+
+        Args:
+            model_key (str): Model and uncertainty identifier used in the result containers.
+            fold_results (List[BinResults]): Results in fold order, with bins ordered from lowest to highest
+                uncertainty and targets ordered as in current_targets_.
+
+        Raises:
+            RuntimeError: If the results container has not been initialized.
+        """
         num_bins = self.current_num_bins_
         num_targets = len(self.current_targets_)
 
-        mean_bins: List[List] = [[] for _ in range(num_bins)]
-        all_bins: List[List] = [[] for _ in range(num_bins)]
-        concat_targets_no_sep: List[List] = [[] for _ in range(num_bins)]
-        targets_sep_foldwise: List[List[List]] = [[[] for _ in range(num_bins)] for _ in range(num_targets)]
-        targets_sep_all: List[List[List]] = [[[] for _ in range(num_bins)] for _ in range(num_targets)]
+        mean_bins: List[List[Optional[float]]] = [[] for _ in range(num_bins)]
+        all_bins: List[List[float]] = [[] for _ in range(num_bins)]
+        concat_targets_no_sep: List[List[float]] = [[] for _ in range(num_bins)]
+        targets_sep_foldwise: List[List[List[List[float]]]] = [
+            [[] for _ in range(num_bins)] for _ in range(num_targets)
+        ]
+        targets_sep_all: List[List[List[float]]] = [[[] for _ in range(num_bins)] for _ in range(num_targets)]
 
         for fold in fold_results:
             for idx_bin in range(len(fold.mean_all_bins)):
@@ -1503,7 +1312,6 @@ class ErrorsEvaluator(BaseEvaluator):
         if self.container_ is None:
             raise RuntimeError("Results container is not initialized")
 
-        # reverse orderings, so bins run worst to best i.e. B5 -> B1
         self.container_.add_main_result(model_key, mean_bins[::-1])
         self.container_.add_target_separated_result(model_key, all_bins[::-1])
         self.container_.additional_containers.setdefault(ResultKeys.ALL_ERROR_CONCAT_BINS_TARGET_NO_SEP, {})[
@@ -1542,13 +1350,8 @@ def evaluate_bounds(
     """
     Evaluate error bound accuracy for uncertainty quantification models.
 
-    This function assesses how well predicted error bounds capture actual prediction errors across different uncertainty
-    bins. It provides a comprehensive evaluation of bound reliability for uncertainty quantification in machine learning
-    models.
-
     Args:
-        estimated_bounds (Dict[str, pd.DataFrame]): Dictionary mapping model names to DataFrames containing estimated
-            error bounds for each prediction.
+        estimated_bounds (Dict[str, pd.DataFrame]): Estimated bounds keyed by "<model> Error Bounds".
         bin_predictions (Dict[str, pd.DataFrame]): Dictionary mapping model names to DataFrames containing bin
             predictions and evaluation data with columns for UIDs, target indices, errors, and uncertainty bins.
         uncertainty_pairs (List): List of uncertainty type pairs to evaluate. Each element should be a list/tuple
@@ -1557,8 +1360,7 @@ def evaluate_bounds(
             assessment.
         targets (List[int]): List of target indices to include in the evaluation. Used to filter data and organize
             results by target.
-        num_folds (int, optional): Number of cross-validation folds for evaluation. Defaults to 8. Higher values provide
-            more robust estimates.
+        num_folds (int, optional): Number of cross-validation folds for evaluation. Defaults to 8.
         combine_middle_bins (bool, optional): Whether to combine middle uncertainty bins for simplified three-bin
             analysis. Defaults to False.
 
@@ -1573,14 +1375,14 @@ def evaluate_bounds(
 
         .. code-block:: pycon
 
-            >>> bounds = {'model1': bounds_df}
+            >>> bounds = {'model1 Error Bounds': bounds_df}
             >>> predictions = {'model1': predictions_df}
             >>> results = evaluate_bounds(
             ...     bounds, predictions,
             ...     uncertainty_pairs=[['epistemic']],
             ...     num_bins=5, targets=[0, 1, 2]
             ... )
-            >>> print(results['error_bounds_all']['model1_epistemic'])
+            >>> results['error_bounds_all']['model1 epistemic']
     """
 
     config = EvaluationConfig(
@@ -1591,13 +1393,9 @@ def evaluate_bounds(
     return BoundsEvaluator(estimated_bounds, config).evaluate(bin_predictions, uncertainty_pairs, targets)
 
 
-# Convenience functions for backward compatibility
 def evaluate_jaccard(bin_predictions, uncertainty_pairs, num_bins, targets, num_folds=8, combine_middle_bins=False):
     """
     Evaluate uncertainty estimation's ability to predict true error quantiles using Jaccard metrics.
-
-    This is a convenience function that uses the new JaccardEvaluator class while maintaining backward compatibility
-    with the original function signature.
 
     Args:
         bin_predictions: Dictionary of DataFrames containing bin predictions for each model
@@ -1664,30 +1462,6 @@ def _bin_accuracy(inbin_errors: list, lower: float, upper: float) -> float:
     return _count_within_bounds(inbin_errors, lower, upper) / len(inbin_errors)
 
 
-def _group_target_errors_by_bin(pred_bins_ti: dict, true_errors_ti: dict, num_bins: int) -> List[List[float]]:
-    """Group a target's errors by the predicted quantile bin of each sample.
-
-    Bin values and uids are compared as strings, so ``1`` and ``"1"`` are treated as equal.
-
-    Args:
-        pred_bins_ti (dict): Maps each sample uid to its predicted quantile bin.
-        true_errors_ti (dict): Maps each sample uid to its true error.
-        num_bins (int): Total number of quantile bins.
-
-    Returns:
-        list: ``num_bins`` lists, each holding the errors of the samples in that bin.
-    """
-    errors_by_uid = {str(uid): error for uid, error in true_errors_ti.items()}
-    binned_errors: List[List[float]] = [[] for _ in range(num_bins)]
-    for uid, bin_val in pred_bins_ti.items():
-        bin_str = str(bin_val)
-        for i in range(num_bins):
-            if str(i) == bin_str:
-                binned_errors[i].append(errors_by_uid[str(uid)])
-                break
-    return binned_errors
-
-
 def _weighted_average(values: list, weights: list) -> float:
     """Return the ``weights``-weighted mean of ``values``, or ``0.0`` if the weights sum to zero.
 
@@ -1713,8 +1487,7 @@ def bin_wise_bound_eval(
     num_bins: int = 5,
 ) -> dict:
     """
-    Helper function for `evaluate_bounds`. Evaluates the accuracy of estimated error bounds for each quantile bin
-    for a given uncertainty type, over a single fold and for multiple targets.
+    Compute error bound accuracy for each target and uncertainty bin in one fold.
 
     Args:
         fold_bounds_all_targets (list): A list of lists of estimated error bounds for each target.
@@ -1729,9 +1502,12 @@ def bin_wise_bound_eval(
               - 'mean all targets': The mean accuracy over all targets and quantile bins.
               - 'mean all bins': A list of mean accuracy values for each quantile bin (all targets included),
                weighted by bin size; ``0.0`` for a bin that is empty for every target.
-              - 'mean all': A list of accuracy values for each quantile bin and target, weighted by # targets in each bin.
+              - 'mean all': Accuracy values organized as [bin][target].
               - 'all bins concatenated targets separated': A list of accuracy values for each quantile bin, concatenated
                for each target separately.
+
+    Raises:
+        ValueError: If an in-range prediction has no matching error, or a target has no samples in the fold.
 
     Example:
 
@@ -1756,15 +1532,9 @@ def bin_wise_bound_eval(
         true_errors_ti = dict(zip(true_errors_ti.uid, true_errors_ti[uncertainty_type + " Error"]))
         pred_bins_ti = dict(zip(pred_bins_ti.uid, pred_bins_ti[uncertainty_type + " Uncertainty bins"]))
 
-        # The error bounds are from B1 -> B5 i.e. best quantile of predictions to worst quantile of predictions
         fold_bounds = fold_bounds_all_targets[i_ti]
 
-        # For each bin, see what % of targets are between the error bounds.
-        # If bin=0 then lower bound = 0, if bin=Q then no upper bound
-        # Keep track of #samples in each bin for weighted mean.
-
-        # turn dictionary of predicted bins into [[num_bins]] array
-        pred_bins_keys, pred_bins_errors = DataProcessor.group_data_by_bins(true_errors_ti, pred_bins_ti, num_bins)
+        _, pred_bins_errors = DataProcessor.group_data_by_bins(true_errors_ti, pred_bins_ti, num_bins)
 
         bins_acc = []
         bins_sizes = []
@@ -1808,10 +1578,7 @@ def get_mean_errors(
     combine_middle_bins: bool = False,
 ) -> Dict:
     """
-    Evaluate uncertainty estimation's mean error of each bin. For each bin, we calculate the mean localization error for
-    each target and for all targets. We calculate the mean error for each dictionary in the bin_predictions dict. For
-    each bin, we calculate: a) the mean and std over all folds and all targets b) the mean and std for each target over
-    all folds.
+    Compute mean localization errors and collect sample errors by uncertainty bin across folds and targets.
 
     Args:
         bin_predictions (Dict): Dict of Pandas DataFrames where each DataFrame has errors, predicted bins for all
@@ -1834,7 +1601,6 @@ def get_mean_errors(
                 "all_error_concat_bins_targets_sep_all": For every fold, every error value in a list. Each target is in a separate list. The list is flattened for all the folds.
 
     """
-    # If we are combining the middle bins, we only have the 2 edge bins and the middle bins are combined into 1 bin.
     config = EvaluationConfig(
         num_folds=num_folds,
         original_num_bins=num_bins,
@@ -1846,19 +1612,22 @@ def get_mean_errors(
 
 def bin_wise_errors(fold_errors, fold_bins, num_bins, targets, uncertainty_key, error_scaling_factor):
     """
-    Helper function for get_mean_errors. Calculates the mean error for each bin and for each target.
+    Compute mean and sample errors for each target and uncertainty bin in one fold.
 
     Args:
         fold_errors (Pandas Dataframe): Pandas Dataframe of errors for this fold.
         fold_bins (Pandas Dataframe): Pandas Dataframe of predicted quantile bins for this fold.
         num_bins (int): Number of quantile bins.
         targets (list): list of targets to measure uncertainty estimation.
-        uncertainty_key (string): Name of uncertainty type to calculate accuracy for.
+        uncertainty_key (string): Uncertainty type identifying the error and bin columns.
         error_scaling_factor (float): Factor to scale the errors by.
 
 
     Returns:
         [Dict]: Dict with mean error statistics.
+
+    Raises:
+        ValueError: If an in-range prediction has no matching error.
     """
 
     all_target_error = []
@@ -1871,22 +1640,17 @@ def bin_wise_errors(fold_errors, fold_bins, num_bins, targets, uncertainty_key, 
             ["uid", uncertainty_key + " Uncertainty bins"]
         ]
 
-        # Zip to dictionary
         true_errors_ti = dict(
             zip(true_errors_ti.uid, true_errors_ti[uncertainty_key + " Error"] * error_scaling_factor)
         )
         pred_bins_ti = dict(zip(pred_bins_ti.uid, pred_bins_ti[uncertainty_key + " Uncertainty bins"]))
 
-        # This is saving them from best quantile of predictions to worst quantile of predictions in terms of uncertainty
-        pred_bins_keys, pred_bins_errors = DataProcessor.group_data_by_bins(true_errors_ti, pred_bins_ti, num_bins)
+        _, pred_bins_errors = DataProcessor.group_data_by_bins(true_errors_ti, pred_bins_ti, num_bins)
 
-        # Now for each bin, get the mean error
         inner_errors = []
         for bin in range(num_bins):
-            # pred_b_keys = pred_bins_keys[bin]
             pred_b_errors = pred_bins_errors[bin]
 
-            # test for empty bin, it would've created a mean_error==nan , so don't add it!
             if pred_b_errors == []:
                 continue
 

--- a/tests/evaluate/test_uncertainty_metrics.py
+++ b/tests/evaluate/test_uncertainty_metrics.py
@@ -284,6 +284,21 @@ class TestDataProcessor:
         assert bin_keys == [[], [], []]
         assert bin_errors == [[], [], []]
 
+    def test_group_data_by_bins_matches_mixed_type_uids(self):
+        """A uid stored as an int in the errors and as a str in the bins is still matched.
+
+        The original grouping compared uids with ``str(key) == str(id_)``, so it tolerated a type
+        mismatch between the two frames. Matching on the string form keeps that behaviour; a plain
+        ``key in errors_dict`` would silently drop the errors here.
+        """
+        errors_dict = {1: 0.1, 2: 0.3}
+        bins_dict = {"1": 0, "2": 1}
+
+        bin_keys, bin_errors = DataProcessor.group_data_by_bins(errors_dict, bins_dict, 2)
+
+        assert bin_keys == [["1"], ["2"]]
+        assert bin_errors == [[0.1], [0.3]]
+
 
 class TestQuantileCalculator:
     """Test QuantileCalculator utility methods."""

--- a/tests/evaluate/test_uncertainty_metrics.py
+++ b/tests/evaluate/test_uncertainty_metrics.py
@@ -247,6 +247,43 @@ class TestDataProcessor:
         assert bin_errors[0] == [0.1, 0.2]
         assert bin_errors[1] == [0.3, 0.4]
 
+    def test_group_data_by_bins_preserves_prediction_order(self):
+        """Within a bin, predictions keep the order they appear in the bins mapping."""
+        errors_dict = {"a": 0.5, "b": 0.1, "c": 0.9}
+        bins_dict = {"c": 0, "a": 0, "b": 0}
+
+        bin_keys, bin_errors = DataProcessor.group_data_by_bins(errors_dict, bins_dict, 1)
+
+        assert bin_keys[0] == ["c", "a", "b"]
+        assert bin_errors[0] == [0.9, 0.5, 0.1]
+
+    def test_group_data_by_bins_accepts_string_bin_labels(self):
+        """Bin assignments stored as strings group the same as numeric ones."""
+        errors_dict = {"pred1": 0.1, "pred2": 0.3}
+        bins_dict = {"pred1": "0", "pred2": "1"}
+
+        bin_keys, bin_errors = DataProcessor.group_data_by_bins(errors_dict, bins_dict, 2)
+
+        assert bin_keys == [["pred1"], ["pred2"]]
+        assert bin_errors == [[0.1], [0.3]]
+
+    def test_group_data_by_bins_ignores_out_of_range_bins(self):
+        """Predictions assigned outside the requested bin range are left out."""
+        errors_dict = {"pred1": 0.1, "pred2": 0.3, "pred3": 0.2}
+        bins_dict = {"pred1": 0, "pred2": 5, "pred3": -1}
+
+        bin_keys, bin_errors = DataProcessor.group_data_by_bins(errors_dict, bins_dict, 2)
+
+        assert bin_keys == [["pred1"], []]
+        assert bin_errors == [[0.1], []]
+
+    def test_group_data_by_bins_handles_empty_input(self):
+        """An empty set of predictions yields one empty list per bin."""
+        bin_keys, bin_errors = DataProcessor.group_data_by_bins({}, {}, 3)
+
+        assert bin_keys == [[], [], []]
+        assert bin_errors == [[], [], []]
+
 
 class TestQuantileCalculator:
     """Test QuantileCalculator utility methods."""

--- a/tests/evaluate/test_uncertainty_metrics.py
+++ b/tests/evaluate/test_uncertainty_metrics.py
@@ -5,14 +5,18 @@ import pandas as pd
 import pytest
 
 from kale.evaluate.uncertainty_metrics import (
+    BaseEvaluator,
     bin_wise_bound_eval,
     bin_wise_errors,
+    BoundsEvaluator,
     ColumnNames,
     DataProcessor,
+    ErrorsEvaluator,
     evaluate_bounds,
     evaluate_jaccard,
     EvaluationConfig,
     FoldData,
+    get_mean_errors,
     JaccardBinResults,
     JaccardEvaluator,
     MetricsCalculator,
@@ -738,3 +742,70 @@ class TestCrossDataFrameIndexAlignment:
         assert aligned["mean all targets"] == pytest.approx(1.0)
         assert misaligned["mean all targets"] == pytest.approx(aligned["mean all targets"])
         assert misaligned["mean all bins"] == pytest.approx(aligned["mean all bins"])
+
+
+class TestBoundsAndErrorsEvaluators:
+    """The evaluator classes behind evaluate_bounds and get_mean_errors (issue #554)."""
+
+    def test_bounds_evaluator_matches_the_function_wrapper(self, dummy_test_preds):
+        """BoundsEvaluator produces what evaluate_bounds returns, since the function delegates to it."""
+        config = EvaluationConfig(num_folds=8, original_num_bins=5)
+        evaluator = BoundsEvaluator(dummy_test_preds[1], config)
+
+        direct = evaluator.evaluate(dummy_test_preds[0], [["S-MHA", "S-MHA Error", "S-MHA Uncertainty"]], [0, 1])
+        via_wrapper = evaluate_bounds(
+            dummy_test_preds[1],
+            dummy_test_preds[0],
+            [["S-MHA", "S-MHA Error", "S-MHA Uncertainty"]],
+            5,
+            [0, 1],
+            num_folds=8,
+        )
+
+        assert direct.keys() == via_wrapper.keys()
+        assert direct["error_bounds_all"] == via_wrapper["error_bounds_all"]
+
+    def test_errors_evaluator_matches_the_function_wrapper(self, dummy_test_preds):
+        """ErrorsEvaluator produces what get_mean_errors returns, since the function delegates to it."""
+        config = EvaluationConfig(num_folds=8, original_num_bins=5)
+        evaluator = ErrorsEvaluator(config)
+
+        direct = evaluator.evaluate(dummy_test_preds[0], [["S-MHA", "S-MHA Error", "S-MHA Uncertainty"]], [0, 1])
+        via_wrapper = get_mean_errors(
+            dummy_test_preds[0], [["S-MHA", "S-MHA Error", "S-MHA Uncertainty"]], 5, [0, 1], num_folds=8
+        )
+
+        assert direct.keys() == via_wrapper.keys()
+        assert direct["all_mean_error_bins_nosep"] == via_wrapper["all_mean_error_bins_nosep"]
+
+    def test_evaluators_derive_from_the_shared_base(self):
+        """Both evaluators plug into the same template as JaccardEvaluator."""
+        assert issubclass(BoundsEvaluator, BaseEvaluator)
+        assert issubclass(ErrorsEvaluator, BaseEvaluator)
+
+    def test_combine_middle_bins_reduces_the_bin_count(self, dummy_test_preds):
+        """combine_middle_bins collapses the middle bins, leaving the configured combined count."""
+        config = EvaluationConfig(num_folds=1, original_num_bins=10, combine_middle_bins=True)
+        evaluator = ErrorsEvaluator(config)
+
+        results = evaluator.evaluate(dummy_test_preds[0], [["S-MHA", "S-MHA Error", "S-MHA Uncertainty"]], [0, 1])
+
+        assert len(results["all_mean_error_bins_nosep"]["U-NET S-MHA"]) == config.combined_num_bins
+
+    def test_error_scaling_factor_scales_the_reported_errors(self, dummy_test_preds):
+        """The configured scaling factor is applied to the mean errors."""
+        pair = [["S-MHA", "S-MHA Error", "S-MHA Uncertainty"]]
+        base = ErrorsEvaluator(EvaluationConfig(num_folds=1, original_num_bins=5)).evaluate(
+            dummy_test_preds[0], pair, [0, 1]
+        )
+        scaled = ErrorsEvaluator(EvaluationConfig(num_folds=1, original_num_bins=5, error_scaling_factor=2.0)).evaluate(
+            dummy_test_preds[0], pair, [0, 1]
+        )
+
+        base_bins = base["all_mean_error_bins_nosep"]["U-NET S-MHA"]
+        scaled_bins = scaled["all_mean_error_bins_nosep"]["U-NET S-MHA"]
+
+        for base_fold_means, scaled_fold_means in zip(base_bins, scaled_bins):
+            for base_value, scaled_value in zip(base_fold_means, scaled_fold_means):
+                if base_value is not None and scaled_value is not None:
+                    assert scaled_value == pytest.approx(base_value * 2.0)

--- a/tests/evaluate/test_uncertainty_metrics.py
+++ b/tests/evaluate/test_uncertainty_metrics.py
@@ -5,18 +5,14 @@ import pandas as pd
 import pytest
 
 from kale.evaluate.uncertainty_metrics import (
-    BaseEvaluator,
     bin_wise_bound_eval,
     bin_wise_errors,
-    BoundsEvaluator,
     ColumnNames,
     DataProcessor,
-    ErrorsEvaluator,
     evaluate_bounds,
     evaluate_jaccard,
     EvaluationConfig,
     FoldData,
-    get_mean_errors,
     JaccardBinResults,
     JaccardEvaluator,
     MetricsCalculator,
@@ -732,70 +728,3 @@ class TestCrossDataFrameIndexAlignment:
         assert aligned["mean all targets"] == pytest.approx(1.0)
         assert misaligned["mean all targets"] == pytest.approx(aligned["mean all targets"])
         assert misaligned["mean all bins"] == pytest.approx(aligned["mean all bins"])
-
-
-class TestBoundsAndErrorsEvaluators:
-    """The evaluator classes behind evaluate_bounds and get_mean_errors (issue #554)."""
-
-    def test_bounds_evaluator_matches_the_function_wrapper(self, dummy_test_preds):
-        """BoundsEvaluator produces what evaluate_bounds returns, since the function delegates to it."""
-        config = EvaluationConfig(num_folds=8, original_num_bins=5)
-        evaluator = BoundsEvaluator(dummy_test_preds[1], config)
-
-        direct = evaluator.evaluate(dummy_test_preds[0], [["S-MHA", "S-MHA Error", "S-MHA Uncertainty"]], [0, 1])
-        via_wrapper = evaluate_bounds(
-            dummy_test_preds[1],
-            dummy_test_preds[0],
-            [["S-MHA", "S-MHA Error", "S-MHA Uncertainty"]],
-            5,
-            [0, 1],
-            num_folds=8,
-        )
-
-        assert direct.keys() == via_wrapper.keys()
-        assert direct["error_bounds_all"] == via_wrapper["error_bounds_all"]
-
-    def test_errors_evaluator_matches_the_function_wrapper(self, dummy_test_preds):
-        """ErrorsEvaluator produces what get_mean_errors returns, since the function delegates to it."""
-        config = EvaluationConfig(num_folds=8, original_num_bins=5)
-        evaluator = ErrorsEvaluator(config)
-
-        direct = evaluator.evaluate(dummy_test_preds[0], [["S-MHA", "S-MHA Error", "S-MHA Uncertainty"]], [0, 1])
-        via_wrapper = get_mean_errors(
-            dummy_test_preds[0], [["S-MHA", "S-MHA Error", "S-MHA Uncertainty"]], 5, [0, 1], num_folds=8
-        )
-
-        assert direct.keys() == via_wrapper.keys()
-        assert direct["all_mean_error_bins_nosep"] == via_wrapper["all_mean_error_bins_nosep"]
-
-    def test_evaluators_derive_from_the_shared_base(self):
-        """Both evaluators plug into the same template as JaccardEvaluator."""
-        assert issubclass(BoundsEvaluator, BaseEvaluator)
-        assert issubclass(ErrorsEvaluator, BaseEvaluator)
-
-    def test_combine_middle_bins_reduces_the_bin_count(self, dummy_test_preds):
-        """combine_middle_bins collapses the middle bins, leaving the configured combined count."""
-        config = EvaluationConfig(num_folds=1, original_num_bins=10, combine_middle_bins=True)
-        evaluator = ErrorsEvaluator(config)
-
-        results = evaluator.evaluate(dummy_test_preds[0], [["S-MHA", "S-MHA Error", "S-MHA Uncertainty"]], [0, 1])
-
-        assert len(results["all_mean_error_bins_nosep"]["U-NET S-MHA"]) == config.combined_num_bins
-
-    def test_error_scaling_factor_scales_the_reported_errors(self, dummy_test_preds):
-        """The configured scaling factor is applied to the mean errors."""
-        pair = [["S-MHA", "S-MHA Error", "S-MHA Uncertainty"]]
-        base = ErrorsEvaluator(EvaluationConfig(num_folds=1, original_num_bins=5)).evaluate(
-            dummy_test_preds[0], pair, [0, 1]
-        )
-        scaled = ErrorsEvaluator(EvaluationConfig(num_folds=1, original_num_bins=5, error_scaling_factor=2.0)).evaluate(
-            dummy_test_preds[0], pair, [0, 1]
-        )
-
-        base_bins = base["all_mean_error_bins_nosep"]["U-NET S-MHA"]
-        scaled_bins = scaled["all_mean_error_bins_nosep"]["U-NET S-MHA"]
-
-        for base_fold_means, scaled_fold_means in zip(base_bins, scaled_bins):
-            for base_value, scaled_value in zip(base_fold_means, scaled_fold_means):
-                if base_value is not None and scaled_value is not None:
-                    assert scaled_value == pytest.approx(base_value * 2.0)

--- a/tests/evaluate/test_uncertainty_metrics.py
+++ b/tests/evaluate/test_uncertainty_metrics.py
@@ -233,71 +233,46 @@ class TestResultsContainer:
 class TestDataProcessor:
     """Test DataProcessor utility methods."""
 
-    def test_group_data_by_bins(self):
-        """Test grouping data by bins."""
-        errors_dict = {"pred1": 0.1, "pred2": 0.3, "pred3": 0.2, "pred4": 0.4}
-        bins_dict = {"pred1": 0, "pred2": 1, "pred3": 0, "pred4": 1}
+    @pytest.mark.parametrize(
+        "errors_dict, bins_dict, num_bins, expected_keys, expected_errors",
+        [
+            # Basic two-bin grouping, keeping the order predictions appear in the bins mapping.
+            (
+                {"pred1": 0.1, "pred2": 0.3, "pred3": 0.2, "pred4": 0.4},
+                {"pred1": 0, "pred2": 1, "pred3": 0, "pred4": 1},
+                2,
+                [["pred1", "pred3"], ["pred2", "pred4"]],
+                [[0.1, 0.2], [0.3, 0.4]],
+            ),
+            # Within a bin, predictions keep the order they appear in the bins mapping.
+            ({"a": 0.5, "b": 0.1, "c": 0.9}, {"c": 0, "a": 0, "b": 0}, 1, [["c", "a", "b"]], [[0.9, 0.5, 0.1]]),
+            # Bin labels stored as strings group the same as numeric ones.
+            ({"pred1": 0.1, "pred2": 0.3}, {"pred1": "0", "pred2": "1"}, 2, [["pred1"], ["pred2"]], [[0.1], [0.3]]),
+            # Predictions assigned outside the requested bin range are left out.
+            (
+                {"pred1": 0.1, "pred2": 0.3, "pred3": 0.2},
+                {"pred1": 0, "pred2": 5, "pred3": -1},
+                2,
+                [["pred1"], []],
+                [[0.1], []],
+            ),
+            # An empty set of predictions yields one empty list per bin.
+            ({}, {}, 3, [[], [], []], [[], [], []]),
+            # A uid stored as an int in the errors and as a str in the bins is still matched, keeping
+            # the original str(key) == str(id_) behaviour; a plain ``key in errors_dict`` would drop it.
+            ({1: 0.1, 2: 0.3}, {"1": 0, "2": 1}, 2, [["1"], ["2"]], [[0.1], [0.3]]),
+        ],
+    )
+    def test_group_data_by_bins(self, errors_dict, bins_dict, num_bins, expected_keys, expected_errors):
+        """Group predictions and their errors into bins across a range of inputs.
 
-        bin_keys, bin_errors = DataProcessor.group_data_by_bins(errors_dict, bins_dict, 2)
-
-        assert len(bin_keys) == 2
-        assert len(bin_errors) == 2
-        assert set(bin_keys[0]) == {"pred1", "pred3"}
-        assert set(bin_keys[1]) == {"pred2", "pred4"}
-        assert bin_errors[0] == [0.1, 0.2]
-        assert bin_errors[1] == [0.3, 0.4]
-
-    def test_group_data_by_bins_preserves_prediction_order(self):
-        """Within a bin, predictions keep the order they appear in the bins mapping."""
-        errors_dict = {"a": 0.5, "b": 0.1, "c": 0.9}
-        bins_dict = {"c": 0, "a": 0, "b": 0}
-
-        bin_keys, bin_errors = DataProcessor.group_data_by_bins(errors_dict, bins_dict, 1)
-
-        assert bin_keys[0] == ["c", "a", "b"]
-        assert bin_errors[0] == [0.9, 0.5, 0.1]
-
-    def test_group_data_by_bins_accepts_string_bin_labels(self):
-        """Bin assignments stored as strings group the same as numeric ones."""
-        errors_dict = {"pred1": 0.1, "pred2": 0.3}
-        bins_dict = {"pred1": "0", "pred2": "1"}
-
-        bin_keys, bin_errors = DataProcessor.group_data_by_bins(errors_dict, bins_dict, 2)
-
-        assert bin_keys == [["pred1"], ["pred2"]]
-        assert bin_errors == [[0.1], [0.3]]
-
-    def test_group_data_by_bins_ignores_out_of_range_bins(self):
-        """Predictions assigned outside the requested bin range are left out."""
-        errors_dict = {"pred1": 0.1, "pred2": 0.3, "pred3": 0.2}
-        bins_dict = {"pred1": 0, "pred2": 5, "pred3": -1}
-
-        bin_keys, bin_errors = DataProcessor.group_data_by_bins(errors_dict, bins_dict, 2)
-
-        assert bin_keys == [["pred1"], []]
-        assert bin_errors == [[0.1], []]
-
-    def test_group_data_by_bins_handles_empty_input(self):
-        """An empty set of predictions yields one empty list per bin."""
-        bin_keys, bin_errors = DataProcessor.group_data_by_bins({}, {}, 3)
-
-        assert bin_keys == [[], [], []]
-        assert bin_errors == [[], [], []]
-
-    def test_group_data_by_bins_matches_mixed_type_uids(self):
-        """A uid stored as an int in the errors and as a str in the bins is still matched.
-
-        The original grouping compared uids with ``str(key) == str(id_)``, so it tolerated a type
-        mismatch between the two frames. Matching on the string form keeps that behaviour; a plain
-        ``key in errors_dict`` would silently drop the errors here.
+        Covers ordering within a bin, string bin labels, out-of-range bins, empty input, and mixed
+        int/str uids between the two frames.
         """
-        errors_dict = {1: 0.1, 2: 0.3}
-        bins_dict = {"1": 0, "2": 1}
+        bin_keys, bin_errors = DataProcessor.group_data_by_bins(errors_dict, bins_dict, num_bins)
 
-        bin_keys, bin_errors = DataProcessor.group_data_by_bins(errors_dict, bins_dict, 2)
-
-        assert bin_keys == [["1"], ["2"]]
-        assert bin_errors == [[0.1], [0.3]]
+        assert bin_keys == expected_keys
+        assert bin_errors == expected_errors
 
 
 class TestQuantileCalculator:

--- a/tests/evaluate/test_uncertainty_metrics.py
+++ b/tests/evaluate/test_uncertainty_metrics.py
@@ -1,5 +1,3 @@
-import logging
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -22,19 +20,12 @@ from kale.evaluate.uncertainty_metrics import (
 from kale.prepdata.tabular_transform import generate_struct_for_qbin
 from kale.utils.seed import set_seed
 
-LOGGER = logging.getLogger(__name__)
-
-
-seed = 36
-set_seed(seed)
-
-ERRORS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-UNCERTAINTIES = [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]
+set_seed(36)
 
 
 @pytest.fixture(scope="module")
 def dummy_test_preds(landmark_uncertainty_tuples_path):
-    bins_all_targets, bins_targets_sep, bounds_all_targets, bounds_targets_sep = generate_struct_for_qbin(
+    bins_all_targets, _, bounds_all_targets, _ = generate_struct_for_qbin(
         ["U-NET"], [0, 1], landmark_uncertainty_tuples_path[2], "SA"
     )
 
@@ -42,7 +33,6 @@ def dummy_test_preds(landmark_uncertainty_tuples_path):
 
 
 class TestEvaluateJaccard:
-    # Using one uncertainty type, test numerous bins
     @pytest.mark.parametrize("num_bins", [2, 3, 4, 5])
     def test_one_uncertainty(self, dummy_test_preds, num_bins):
         jacc_dict = evaluate_jaccard(
@@ -56,9 +46,7 @@ class TestEvaluateJaccard:
 
         assert list(all_jaccard_bins_targets_sep.keys()) == ["U-NET S-MHA"]
         assert len(all_jaccard_bins_targets_sep["U-NET S-MHA"]) == num_bins
-        assert (
-            len(all_jaccard_bins_targets_sep["U-NET S-MHA"][0]) == 8 * 2
-        )  # because each landmark has 8 folds - they are separate
+        assert len(all_jaccard_bins_targets_sep["U-NET S-MHA"][0]) == 8 * 2
 
     def test_one_fold(self, dummy_test_preds):
         jacc_dict = evaluate_jaccard(
@@ -73,9 +61,7 @@ class TestEvaluateJaccard:
 
         assert list(all_jaccard_bins_targets_sep.keys()) == ["U-NET S-MHA"]
         assert len(all_jaccard_bins_targets_sep["U-NET S-MHA"]) == 5
-        assert (
-            len(all_jaccard_bins_targets_sep["U-NET S-MHA"][0]) == 2
-        )  # because each landmark has 1 folds - they are sep
+        assert len(all_jaccard_bins_targets_sep["U-NET S-MHA"][0]) == 2
 
     def test_multiple_uncerts(self, dummy_test_preds):
         jacc_dict = evaluate_jaccard(
@@ -98,7 +84,7 @@ class TestEvaluateJaccard:
             len(all_jaccard_bins_targets_sep["U-NET S-MHA"][0])
             == len(all_jaccard_bins_targets_sep["U-NET E-MHA"][0])
             == 2
-        )  # because each landmark has 8 folds - they are sep
+        )
 
 
 class TestEvaluateBounds:
@@ -121,9 +107,7 @@ class TestEvaluateBounds:
 
         assert list(all_bound_percents_notargetsep.keys()) == ["U-NET S-MHA"]
         assert len(all_bound_percents_notargetsep["U-NET S-MHA"]) == num_bins
-        assert (
-            len(all_bound_percents_notargetsep["U-NET S-MHA"][0]) == 8 * 2
-        )  # because each landmark has 8 folds - they are separate
+        assert len(all_bound_percents_notargetsep["U-NET S-MHA"][0]) == 8 * 2
 
     def test_one_fold(self, dummy_test_preds):
         bound_dict = evaluate_bounds(
@@ -142,9 +126,7 @@ class TestEvaluateBounds:
 
         assert list(all_bound_percents_notargetsep.keys()) == ["U-NET S-MHA"]
         assert len(all_bound_percents_notargetsep["U-NET S-MHA"]) == 5
-        assert (
-            len(all_bound_percents_notargetsep["U-NET S-MHA"][0]) == 2
-        )  # because each landmark has 1 folds - they are sep
+        assert len(all_bound_percents_notargetsep["U-NET S-MHA"][0]) == 2
 
     def test_multiple_uncerts(self, dummy_test_preds):
         bound_dict = evaluate_bounds(
@@ -172,7 +154,7 @@ class TestEvaluateBounds:
             len(all_bound_percents_notargetsep["U-NET S-MHA"][0])
             == len(all_bound_percents_notargetsep["U-NET E-MHA"][0])
             == 8 * 2
-        )  # because each landmark has 8 folds - they are sep
+        )
 
 
 class TestEvaluationConfig:
@@ -216,12 +198,10 @@ class TestResultsContainer:
         """Test adding results to container."""
         container = ResultsContainer(num_bins=5, num_targets=2)
 
-        # Test adding main result
         test_data = [1, 2, 3, 4, 5]
         container.add_main_result("test_key", test_data)
         assert container.main_results["test_key"] == test_data
 
-        # Test adding target separated result
         target_data = [[1, 2], [3, 4], [5, 6]]
         container.add_target_separated_result("test_key", target_data)
         assert container.target_separated_results["test_key"] == target_data
@@ -233,7 +213,6 @@ class TestDataProcessor:
     @pytest.mark.parametrize(
         "errors_dict, bins_dict, num_bins, expected_keys, expected_errors",
         [
-            # Basic two-bin grouping, keeping the order predictions appear in the bins mapping.
             (
                 {"pred1": 0.1, "pred2": 0.3, "pred3": 0.2, "pred4": 0.4},
                 {"pred1": 0, "pred2": 1, "pred3": 0, "pred4": 1},
@@ -241,11 +220,8 @@ class TestDataProcessor:
                 [["pred1", "pred3"], ["pred2", "pred4"]],
                 [[0.1, 0.2], [0.3, 0.4]],
             ),
-            # Within a bin, predictions keep the order they appear in the bins mapping.
             ({"a": 0.5, "b": 0.1, "c": 0.9}, {"c": 0, "a": 0, "b": 0}, 1, [["c", "a", "b"]], [[0.9, 0.5, 0.1]]),
-            # Bin labels stored as strings group the same as numeric ones.
             ({"pred1": 0.1, "pred2": 0.3}, {"pred1": "0", "pred2": "1"}, 2, [["pred1"], ["pred2"]], [[0.1], [0.3]]),
-            # Predictions assigned outside the requested bin range are left out.
             (
                 {"pred1": 0.1, "pred2": 0.3, "pred3": 0.2},
                 {"pred1": 0, "pred2": 5, "pred3": -1},
@@ -253,19 +229,13 @@ class TestDataProcessor:
                 [["pred1"], []],
                 [[0.1], []],
             ),
-            # An empty set of predictions yields one empty list per bin.
             ({}, {}, 3, [[], [], []], [[], [], []]),
-            # A uid stored as an int in the errors and as a str in the bins is still matched, keeping
-            # the original str(key) == str(id_) behaviour; a plain ``key in errors_dict`` would drop it.
             ({1: 0.1, 2: 0.3}, {"1": 0, "2": 1}, 2, [["1"], ["2"]], [[0.1], [0.3]]),
         ],
+        ids=["basic", "prediction-order", "string-bins", "out-of-range", "empty", "mixed-uids"],
     )
     def test_group_data_by_bins(self, errors_dict, bins_dict, num_bins, expected_keys, expected_errors):
-        """Group predictions and their errors into bins across a range of inputs.
-
-        Covers ordering within a bin, string bin labels, out-of-range bins, empty input, and mixed
-        int/str uids between the two frames.
-        """
+        """Check bin membership, UID matching, and prediction order."""
         bin_keys, bin_errors = DataProcessor.group_data_by_bins(errors_dict, bins_dict, num_bins)
 
         assert bin_keys == expected_keys
@@ -407,7 +377,6 @@ class TestJaccardEvaluator:
         evaluator = JaccardEvaluator.create_simple(original_num_bins=5, num_folds=1)
         evaluator.current_uncertainty_type_ = "epistemic"
 
-        # Create mock fold data
         errors_df = pd.DataFrame(
             {
                 ColumnNames.UID: ["uid1", "uid2", "uid3"],
@@ -442,7 +411,6 @@ class TestJaccardEvaluator:
 
         pred_bin_keys = evaluator._get_predicted_bin_keys(errors_dict, bins_dict)
 
-        # Should be reversed (worst to best: B3 to B1)
         assert len(pred_bin_keys) == 3
         assert isinstance(pred_bin_keys, list)
         assert all(isinstance(bin_keys, list) for bin_keys in pred_bin_keys)
@@ -487,7 +455,6 @@ class TestJaccardEvaluator:
         evaluator = JaccardEvaluator.create_simple(original_num_bins=2, num_folds=1)
         evaluator.current_num_bins_ = 2
 
-        # Create mock JaccardBinResults
         results1 = JaccardBinResults(
             mean_all_targets=0.5,
             mean_all_bins=[0.4, 0.6],
@@ -527,13 +494,11 @@ class TestJaccardEvaluator:
 
         results = evaluator.evaluate(bin_predictions=dummy_test_preds[0], uncertainty_pairs=[["S-MHA"]], targets=[0, 1])
 
-        # Check that results match expected structure
         assert "jaccard_all" in results
         assert "Jaccard targets separated" in results
         assert "recall_all" in results
         assert "precision_all" in results
 
-        # Check specific keys and structure
         jaccard_all = results["jaccard_all"]
         assert "U-NET S-MHA" in jaccard_all
         assert len(jaccard_all["U-NET S-MHA"]) == 5  # 5 bins
@@ -555,7 +520,6 @@ class TestJaccardEvaluator:
         results = evaluator.evaluate(bin_predictions=dummy_test_preds[0], uncertainty_pairs=[["S-MHA"]], targets=[0, 1])
 
         jaccard_all = results["jaccard_all"]
-        # When combine_middle_bins=True, should have 3 bins
         assert len(jaccard_all["U-NET S-MHA"]) == 3
 
     def test_multiple_uncertainty_types(self, dummy_test_preds):
@@ -578,10 +542,8 @@ class TestBackwardCompatibility:
 
     def test_jaccard_results_consistency(self, dummy_test_preds):
         """Test that old and new interfaces produce consistent results."""
-        # Old functional interface
         old_results = evaluate_jaccard(dummy_test_preds[0], [["S-MHA"]], 5, [0, 1], num_folds=8)
 
-        # New class interface
         evaluator = JaccardEvaluator.create_simple(original_num_bins=5, num_folds=8)
         new_results = evaluator.evaluate(
             bin_predictions=dummy_test_preds[0], uncertainty_pairs=[["S-MHA"]], targets=[0, 1]
@@ -636,11 +598,9 @@ class TestJaccardBinResults:
             all_bins_precision=[[0.5, 0.6], [0.7, 0.8], [0.9, 1.0]],
         )
 
-        # Test base class attributes
         assert results.mean_all_targets == 0.5
         assert results.mean_all_bins == [0.4, 0.5, 0.6]
 
-        # Test Jaccard-specific attributes
         assert results.mean_all_targets_recall == 0.6
         assert results.mean_all_bins_recall == [0.5, 0.6, 0.7]
         assert results.mean_all_targets_precision == 0.7
@@ -648,8 +608,7 @@ class TestJaccardBinResults:
 
 
 class TestCrossDataFrameIndexAlignment:
-    """``bin_wise_bound_eval`` and ``bin_wise_errors`` group errors by ``uid`` regardless of
-    how ``fold_errors`` and ``fold_bins`` are indexed."""
+    """Check UID-based matching between errors and bins with different DataFrame indices."""
 
     @staticmethod
     def _errors_df():
@@ -672,15 +631,9 @@ class TestCrossDataFrameIndexAlignment:
         )
 
     def test_bin_wise_errors_misaligned_index(self):
-        """Bins must be grouped by uid even when ``fold_bins`` rows are reordered/reindexed.
-
-        The reordered ``fold_bins`` holds the same per-uid data as the aligned frame; only its row order and index
-        differ. The result must match the aligned case and the hand-computed expectation.
-        """
+        """Reordering and reindexing bin rows preserves the expected mean errors."""
         errors_df = self._errors_df()
         bins_aligned = self._bins_df()
-        # Same data, rows reversed and index reset, so a label-aligned mask taken from
-        # fold_errors points at the wrong rows of fold_bins under cross-frame indexing.
         bins_misaligned = self._bins_df().iloc[[3, 2, 1, 0]].reset_index(drop=True)
 
         result = bin_wise_errors(
@@ -700,7 +653,7 @@ class TestCrossDataFrameIndexAlignment:
         assert result["all bins"] == aligned["all bins"]
 
     def test_bin_wise_bound_eval_misaligned_index(self):
-        """Bound accuracy must not depend on the index alignment between the two frames."""
+        """Reordering and reindexing bin rows preserves bound accuracy."""
         errors_df = self._errors_df()
         bins_aligned = self._bins_df()
         bins_misaligned = self._bins_df().iloc[[3, 2, 1, 0]].reset_index(drop=True)
@@ -713,8 +666,6 @@ class TestCrossDataFrameIndexAlignment:
             fold_bounds_all_targets, errors_df, bins_misaligned, targets=[0, 1], uncertainty_type="S-MHA", num_bins=2
         )
 
-        # With these bounds every error falls inside its own bin, so accuracy is perfect,
-        # and the misaligned frame must yield the same result.
         assert aligned["mean all targets"] == pytest.approx(1.0)
         assert misaligned["mean all targets"] == pytest.approx(aligned["mean all targets"])
         assert misaligned["mean all bins"] == pytest.approx(aligned["mean all bins"])

--- a/tests/evaluate/test_uncertainty_metrics_evaluators.py
+++ b/tests/evaluate/test_uncertainty_metrics_evaluators.py
@@ -1,0 +1,90 @@
+import pytest
+
+from kale.evaluate.uncertainty_metrics import (
+    BaseEvaluator,
+    BoundsEvaluator,
+    ErrorsEvaluator,
+    evaluate_bounds,
+    EvaluationConfig,
+    get_mean_errors,
+)
+from kale.prepdata.tabular_transform import generate_struct_for_qbin
+from kale.utils.seed import set_seed
+
+set_seed(36)
+
+
+@pytest.fixture(scope="module")
+def dummy_test_preds(landmark_uncertainty_tuples_path):
+    bins_all_targets, bins_targets_sep, bounds_all_targets, bounds_targets_sep = generate_struct_for_qbin(
+        ["U-NET"], [0, 1], landmark_uncertainty_tuples_path[2], "SA"
+    )
+
+    return bins_all_targets, bounds_all_targets
+
+
+class TestBoundsAndErrorsEvaluators:
+    """The evaluator classes behind evaluate_bounds and get_mean_errors (issue #554)."""
+
+    def test_bounds_evaluator_matches_the_function_wrapper(self, dummy_test_preds):
+        """BoundsEvaluator produces what evaluate_bounds returns, since the function delegates to it."""
+        config = EvaluationConfig(num_folds=8, original_num_bins=5)
+        evaluator = BoundsEvaluator(dummy_test_preds[1], config)
+
+        direct = evaluator.evaluate(dummy_test_preds[0], [["S-MHA", "S-MHA Error", "S-MHA Uncertainty"]], [0, 1])
+        via_wrapper = evaluate_bounds(
+            dummy_test_preds[1],
+            dummy_test_preds[0],
+            [["S-MHA", "S-MHA Error", "S-MHA Uncertainty"]],
+            5,
+            [0, 1],
+            num_folds=8,
+        )
+
+        assert direct.keys() == via_wrapper.keys()
+        assert direct["error_bounds_all"] == via_wrapper["error_bounds_all"]
+
+    def test_errors_evaluator_matches_the_function_wrapper(self, dummy_test_preds):
+        """ErrorsEvaluator produces what get_mean_errors returns, since the function delegates to it."""
+        config = EvaluationConfig(num_folds=8, original_num_bins=5)
+        evaluator = ErrorsEvaluator(config)
+
+        direct = evaluator.evaluate(dummy_test_preds[0], [["S-MHA", "S-MHA Error", "S-MHA Uncertainty"]], [0, 1])
+        via_wrapper = get_mean_errors(
+            dummy_test_preds[0], [["S-MHA", "S-MHA Error", "S-MHA Uncertainty"]], 5, [0, 1], num_folds=8
+        )
+
+        assert direct.keys() == via_wrapper.keys()
+        assert direct["all_mean_error_bins_nosep"] == via_wrapper["all_mean_error_bins_nosep"]
+
+    def test_evaluators_derive_from_the_shared_base(self):
+        """Both evaluators plug into the same template as JaccardEvaluator."""
+        assert issubclass(BoundsEvaluator, BaseEvaluator)
+        assert issubclass(ErrorsEvaluator, BaseEvaluator)
+
+    def test_combine_middle_bins_reduces_the_bin_count(self, dummy_test_preds):
+        """combine_middle_bins collapses the middle bins, leaving the configured combined count."""
+        config = EvaluationConfig(num_folds=1, original_num_bins=10, combine_middle_bins=True)
+        evaluator = ErrorsEvaluator(config)
+
+        results = evaluator.evaluate(dummy_test_preds[0], [["S-MHA", "S-MHA Error", "S-MHA Uncertainty"]], [0, 1])
+
+        assert len(results["all_mean_error_bins_nosep"]["U-NET S-MHA"]) == config.combined_num_bins
+
+    def test_error_scaling_factor_scales_the_reported_errors(self, dummy_test_preds):
+        """The configured scaling factor is applied to the mean errors."""
+        pair = [["S-MHA", "S-MHA Error", "S-MHA Uncertainty"]]
+        base = ErrorsEvaluator(EvaluationConfig(num_folds=1, original_num_bins=5)).evaluate(
+            dummy_test_preds[0], pair, [0, 1]
+        )
+        scaled = ErrorsEvaluator(EvaluationConfig(num_folds=1, original_num_bins=5, error_scaling_factor=2.0)).evaluate(
+            dummy_test_preds[0], pair, [0, 1]
+        )
+
+        base_bins = base["all_mean_error_bins_nosep"]["U-NET S-MHA"]
+        scaled_bins = scaled["all_mean_error_bins_nosep"]["U-NET S-MHA"]
+
+        for base_fold_means, scaled_fold_means in zip(base_bins, scaled_bins):
+            for base_value, scaled_value in zip(base_fold_means, scaled_fold_means):
+                if base_value is not None and scaled_value is not None:
+                    assert scaled_value == pytest.approx(base_value * 2.0)

--- a/tests/evaluate/test_uncertainty_metrics_evaluators.py
+++ b/tests/evaluate/test_uncertainty_metrics_evaluators.py
@@ -1,90 +1,109 @@
+import pandas as pd
 import pytest
 
-from kale.evaluate.uncertainty_metrics import (
-    BaseEvaluator,
-    BoundsEvaluator,
-    ErrorsEvaluator,
-    evaluate_bounds,
-    EvaluationConfig,
-    get_mean_errors,
-)
-from kale.prepdata.tabular_transform import generate_struct_for_qbin
-from kale.utils.seed import set_seed
-
-set_seed(36)
+from kale.evaluate.uncertainty_metrics import bin_wise_bound_eval, bin_wise_errors, evaluate_bounds, get_mean_errors
 
 
-@pytest.fixture(scope="module")
-def dummy_test_preds(landmark_uncertainty_tuples_path):
-    bins_all_targets, bins_targets_sep, bounds_all_targets, bounds_targets_sep = generate_struct_for_qbin(
-        ["U-NET"], [0, 1], landmark_uncertainty_tuples_path[2], "SA"
+@pytest.mark.parametrize("metric", ["errors", "bounds"])
+def test_evaluators_reject_missing_error(metric):
+    """Both metrics raise an error for unmatched prediction UIDs."""
+    fold_errors = pd.DataFrame({"uid": ["a"], "Target Index": 0, "U Error": [1.0]})
+    fold_bins = pd.DataFrame({"uid": ["a", "b"], "Target Index": 0, "U Uncertainty bins": 0})
+
+    with pytest.raises(ValueError, match="No error found for uid 'b'"):
+        if metric == "errors":
+            bin_wise_errors(fold_errors, fold_bins, 2, [0], "U", error_scaling_factor=1.0)
+        else:
+            bin_wise_bound_eval([[5.0]], fold_errors, fold_bins, [0], "U", num_bins=2)
+
+
+@pytest.fixture
+def evaluation_data():
+    """Two folds and targets with unequal bin sizes and an empty middle bin."""
+    errors = [
+        (0, 0, 0, [1.0, 3.0]),
+        (0, 0, 2, [7.0]),
+        (0, 1, 0, [5.0]),
+        (0, 1, 2, [9.0, 11.0]),
+        (1, 0, 0, [2.0]),
+        (1, 0, 2, [6.0, 10.0]),
+        (1, 1, 0, [4.0, 6.0]),
+        (1, 1, 2, [8.0]),
+    ]
+    rows = [
+        (fold, target, f"{bin_idx}-{sample}", error, bin_idx)
+        for fold, target, bin_idx, values in errors
+        for sample, error in enumerate(values)
+    ]
+    predictions = pd.DataFrame(rows, columns=["Testing Fold", "Target Index", "uid", "U Error", "U Uncertainty bins"])
+    bounds = pd.DataFrame({"fold": [0, 0, 1, 1], "U Uncertainty bounds": ["[4.0, 8.0]"] * 4})
+    return {"model": predictions}, {"model Error Bounds": bounds}
+
+
+@pytest.mark.parametrize("combine_middle_bins", [False, True])
+def test_mean_error_results(evaluation_data, combine_middle_bins):
+    """Check every result field against hand-calculated fold and target aggregates."""
+    predictions, _ = evaluation_data
+    result = get_mean_errors(
+        predictions,
+        [["U"]],
+        10 if combine_middle_bins else 3,
+        [0, 1],
+        num_folds=2,
+        combine_middle_bins=combine_middle_bins,
     )
 
-    return bins_all_targets, bounds_all_targets
+    assert result == {
+        "all_mean_error_bins_nosep": {"model U": [[8.5, 8.0], [None, None], [3.5, 3.5]]},
+        "all mean error bins targets sep": {"model U": [[7.0, 10.0, 8.0, 8.0], [], [2.0, 5.0, 2.0, 5.0]]},
+        "all_error_concat_bins_targets_nosep": {
+            "model U": [[7.0, 9.0, 11.0, 6.0, 10.0, 8.0], [], [1.0, 3.0, 5.0, 2.0, 4.0, 6.0]]
+        },
+        "all error concat bins targets sep foldwise": [
+            {"model U": [[[7.0], [6.0, 10.0]], [], [[1.0, 3.0], [2.0]]]},
+            {"model U": [[[9.0, 11.0], [8.0]], [], [[5.0], [4.0, 6.0]]]},
+        ],
+        "all_error_concat_bins_targets_sep_all": [
+            {"model U": [[7.0, 6.0, 10.0], [], [1.0, 3.0, 2.0]]},
+            {"model U": [[9.0, 11.0, 8.0], [], [5.0, 4.0, 6.0]]},
+        ],
+    }
 
 
-class TestBoundsAndErrorsEvaluators:
-    """The evaluator classes behind evaluate_bounds and get_mean_errors (issue #554)."""
+def test_mean_error_scaling(evaluation_data):
+    """The public wrapper applies scaling to both means and individual errors."""
+    predictions, _ = evaluation_data
+    result = get_mean_errors(predictions, [["U"]], 3, [0, 1], num_folds=2, error_scaling_factor=2.0)
 
-    def test_bounds_evaluator_matches_the_function_wrapper(self, dummy_test_preds):
-        """BoundsEvaluator produces what evaluate_bounds returns, since the function delegates to it."""
-        config = EvaluationConfig(num_folds=8, original_num_bins=5)
-        evaluator = BoundsEvaluator(dummy_test_preds[1], config)
+    assert result["all_mean_error_bins_nosep"] == {"model U": [[17.0, 16.0], [None, None], [7.0, 7.0]]}
+    assert result["all_error_concat_bins_targets_nosep"] == {
+        "model U": [[14.0, 18.0, 22.0, 12.0, 20.0, 16.0], [], [2.0, 6.0, 10.0, 4.0, 8.0, 12.0]]
+    }
 
-        direct = evaluator.evaluate(dummy_test_preds[0], [["S-MHA", "S-MHA Error", "S-MHA Uncertainty"]], [0, 1])
-        via_wrapper = evaluate_bounds(
-            dummy_test_preds[1],
-            dummy_test_preds[0],
-            [["S-MHA", "S-MHA Error", "S-MHA Uncertainty"]],
-            5,
-            [0, 1],
-            num_folds=8,
-        )
 
-        assert direct.keys() == via_wrapper.keys()
-        assert direct["error_bounds_all"] == via_wrapper["error_bounds_all"]
+@pytest.mark.parametrize("combine_middle_bins", [False, True])
+def test_bound_results(evaluation_data, combine_middle_bins):
+    """Check weighted accuracy, empty bins, and target bin ordering."""
+    predictions, bounds = evaluation_data
+    result = evaluate_bounds(
+        bounds,
+        predictions,
+        [["U"]],
+        10 if combine_middle_bins else 3,
+        [0, 1],
+        num_folds=2,
+        combine_middle_bins=combine_middle_bins,
+    )
 
-    def test_errors_evaluator_matches_the_function_wrapper(self, dummy_test_preds):
-        """ErrorsEvaluator produces what get_mean_errors returns, since the function delegates to it."""
-        config = EvaluationConfig(num_folds=8, original_num_bins=5)
-        evaluator = ErrorsEvaluator(config)
-
-        direct = evaluator.evaluate(dummy_test_preds[0], [["S-MHA", "S-MHA Error", "S-MHA Uncertainty"]], [0, 1])
-        via_wrapper = get_mean_errors(
-            dummy_test_preds[0], [["S-MHA", "S-MHA Error", "S-MHA Uncertainty"]], 5, [0, 1], num_folds=8
-        )
-
-        assert direct.keys() == via_wrapper.keys()
-        assert direct["all_mean_error_bins_nosep"] == via_wrapper["all_mean_error_bins_nosep"]
-
-    def test_evaluators_derive_from_the_shared_base(self):
-        """Both evaluators plug into the same template as JaccardEvaluator."""
-        assert issubclass(BoundsEvaluator, BaseEvaluator)
-        assert issubclass(ErrorsEvaluator, BaseEvaluator)
-
-    def test_combine_middle_bins_reduces_the_bin_count(self, dummy_test_preds):
-        """combine_middle_bins collapses the middle bins, leaving the configured combined count."""
-        config = EvaluationConfig(num_folds=1, original_num_bins=10, combine_middle_bins=True)
-        evaluator = ErrorsEvaluator(config)
-
-        results = evaluator.evaluate(dummy_test_preds[0], [["S-MHA", "S-MHA Error", "S-MHA Uncertainty"]], [0, 1])
-
-        assert len(results["all_mean_error_bins_nosep"]["U-NET S-MHA"]) == config.combined_num_bins
-
-    def test_error_scaling_factor_scales_the_reported_errors(self, dummy_test_preds):
-        """The configured scaling factor is applied to the mean errors."""
-        pair = [["S-MHA", "S-MHA Error", "S-MHA Uncertainty"]]
-        base = ErrorsEvaluator(EvaluationConfig(num_folds=1, original_num_bins=5)).evaluate(
-            dummy_test_preds[0], pair, [0, 1]
-        )
-        scaled = ErrorsEvaluator(EvaluationConfig(num_folds=1, original_num_bins=5, error_scaling_factor=2.0)).evaluate(
-            dummy_test_preds[0], pair, [0, 1]
-        )
-
-        base_bins = base["all_mean_error_bins_nosep"]["U-NET S-MHA"]
-        scaled_bins = scaled["all_mean_error_bins_nosep"]["U-NET S-MHA"]
-
-        for base_fold_means, scaled_fold_means in zip(base_bins, scaled_bins):
-            for base_value, scaled_value in zip(base_fold_means, scaled_fold_means):
-                if base_value is not None and scaled_value is not None:
-                    assert scaled_value == pytest.approx(base_value * 2.0)
+    targets = [
+        {"model U": [[1.0, 1.0], [1.0, 1.0], [0.0, 0.5]]},
+        {"model U": [[0.0, 0.5], [1.0, 1.0], [1.0, 0.0]]},
+    ]
+    assert result == {
+        "error_bounds_all": {"model U": [[2 / 3, 1 / 3], [0.0, 0.0], [2 / 3, 2 / 3]]},
+        "all_bound_percents_notargetsep": {
+            "model U": [[0.0, 1.0, 0.5, 0.0], [1.0, 1.0, 1.0, 1.0], [1.0, 0.0, 1.0, 0.5]]
+        },
+        "all errorbound concat bins targets sep foldwise": targets,
+        "all_errorbound_concat_bins_targets_sep_all": targets,
+    }


### PR DESCRIPTION
Fixes #552.

### Description
`bin_wise_bound_eval` and `bin_wise_errors` each duplicated an O(n²) grouping loop that rescanned the error dict per prediction. Both now call the existing `DataProcessor.group_data_by_bins`, which is made single-pass and preserves the original string-based uid matching. Outputs are unchanged (verified on fixtures); grouping goes from quadratic to linear. Adds tests for the helper.

`evaluate_bounds` and `get_mean_errors` reimplemented the fold loop `BaseEvaluator` already provides. This adds `BoundsEvaluator` and `ErrorsEvaluator` (alongside `JaccardEvaluator`) and reduces the two functions to thin wrappers, so their signatures and results are unchanged. Adds tests for both evaluators.


### Status
Ready

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] Source for documentation at `docs` manually updated for new API.
