### PR TITLE
Remove commented-out dead code in gradient_penalty

### DIFF
--- a/kale/evaluate/metrics.py
+++ b/kale/evaluate/metrics.py
@@ -173,7 +173,6 @@ def gradient_penalty(critic, h_s, h_t):
 
     alpha = torch.rand(h_s.size(0), 1)
     alpha = alpha.expand(h_s.size()).type_as(h_s)
-    # try:
     differences = h_t - h_s
 
     interpolates = h_s + (alpha * differences)
@@ -189,8 +188,6 @@ def gradient_penalty(critic, h_s, h_t):
     )[0]
     gradient_norm = gradients.norm(2, dim=1)
     gradient_penalty = ((gradient_norm - 1) ** 2).mean()
-    # except:
-    #     gradient_penalty = 0
 
     return gradient_penalty
 


### PR DESCRIPTION
Fixes #546.

### Description
Removes the commented-out `# try:` / `# except:` / `# gradient_penalty = 0` lines inside `gradient_penalty` in `kale/evaluate/metrics.py`. No executable code changes — the function's behaviour is unchanged.

Verified:
- `tests/evaluate/test_metrics.py` — 18 passed.
- Import check: `from kale.evaluate.metrics import gradient_penalty` OK.

This is a comment-only deletion, so there is no observable behaviour to regression-test.

### Status
**Ready**

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] Source for documentation at `docs` manually updated for new API.