### PR TITLE
Unify optimizer kwarg validation across trainers

### DIFF
--- a/kale/pipeline/base_nn_trainer.py
+++ b/kale/pipeline/base_nn_trainer.py
@@ -29,6 +29,7 @@ import torch.nn as nn
 from sklearn.metrics import accuracy_score
 
 import kale.evaluate.metrics as losses
+from kale.utils.validate import validate_kwargs
 
 
 class BaseNNTrainer(pl.LightningModule):
@@ -86,24 +87,27 @@ class BaseNNTrainer(pl.LightningModule):
             optimizer = torch.optim.Adam(self.parameters(), lr=self._init_lr)
             return [optimizer]
         if self._optimizer_params["type"] == "Adam":
+            valid_optim_params = validate_kwargs(torch.optim.Adam, self._optimizer_params["optim_params"])
             optimizer = torch.optim.Adam(
                 self.parameters(),
                 lr=self._init_lr,
-                **self._optimizer_params["optim_params"],
+                **valid_optim_params,
             )
             return [optimizer]
         if self._optimizer_params["type"] == "AdamW":
+            valid_optim_params = validate_kwargs(torch.optim.AdamW, self._optimizer_params["optim_params"])
             optimizer = torch.optim.AdamW(
                 self.parameters(),
                 lr=self._init_lr,
-                **self._optimizer_params["optim_params"],
+                **valid_optim_params,
             )
             return [optimizer]
         if self._optimizer_params["type"] == "SGD":
+            valid_optim_params = validate_kwargs(torch.optim.SGD, self._optimizer_params["optim_params"])
             optimizer = torch.optim.SGD(
                 self.parameters(),
                 lr=self._init_lr,
-                **self._optimizer_params["optim_params"],
+                **valid_optim_params,
             )
 
             if self._adapt_lr:
@@ -181,10 +185,11 @@ class CNNTransformerTrainer(BaseNNTrainer):
         """Set up an SGD optimizer and multistep learning rate scheduler. When self._adapt_lr is True, the learning
         rate will be decayed by self.lr_gamma every step in milestones.
         """
+        valid_optim_params = validate_kwargs(torch.optim.SGD, self._optimizer_params["optim_params"])
         optimizer = torch.optim.SGD(
             self.parameters(),
             lr=self._init_lr,
-            **self._optimizer_params["optim_params"],
+            **valid_optim_params,
         )
         if self._adapt_lr:
             scheduler = torch.optim.lr_scheduler.MultiStepLR(

--- a/tests/pipeline/test_base_nn_trainer.py
+++ b/tests/pipeline/test_base_nn_trainer.py
@@ -109,6 +109,21 @@ class TestBaseTrainer:
             trainer.configure_optimizers()
             assert "Unknown optimizer type Unknown." in str(excinfo.value)
 
+    def test_configure_optimizers_filters_invalid_optim_params(self, trainer):
+        # optim_params that are not accepted by the optimizer constructor are silently
+        # filtered via validate_kwargs, consistent with kale.pipeline.domain_adapter.
+        # Before unification this raised TypeError (unexpected keyword argument).
+        trainer.optimizers = ClassNet()
+        trainer._optimizer_params = {
+            "type": "Adam",
+            "optim_params": {"weight_decay": 0.3, "not_a_real_param": 123},
+        }
+        optimizers = trainer.configure_optimizers()
+        assert isinstance(optimizers[0], torch.optim.Adam)
+        # The valid kwarg is kept and the invalid one is dropped rather than raising.
+        assert optimizers[0].defaults["weight_decay"] == 0.3
+        assert "not_a_real_param" not in optimizers[0].defaults
+
 
 class TestCNNTransformerTrainer:
     @pytest.fixture
@@ -158,6 +173,18 @@ class TestCNNTransformerTrainer:
         assert isinstance(optimizers[1], list)
         assert isinstance(optimizers[0][0], torch.optim.SGD)
         assert isinstance(optimizers[1][0], torch.optim.lr_scheduler.MultiStepLR)
+
+    def test_configure_optimizers_filters_invalid_optim_params(self, trainer):
+        # Invalid optim_params are filtered via validate_kwargs rather than raising TypeError.
+        trainer._adapt_lr = False
+        trainer._optimizer_params = {
+            "type": "SGD",
+            "optim_params": {"momentum": 0.2, "not_a_real_param": 123},
+        }
+        optimizers = trainer.configure_optimizers()
+        assert isinstance(optimizers[0], torch.optim.SGD)
+        assert optimizers[0].defaults["momentum"] == 0.2
+        assert "not_a_real_param" not in optimizers[0].defaults
 
     def test_training_step(self, trainer, batch):
         # Test training step. Return torch.Tensor.


### PR DESCRIPTION
Fixes #544.

### Description
`BaseNNTrainer.configure_optimizers` and `CNNTransformerTrainer.configure_optimizers` in `kale/pipeline/base_nn_trainer.py` passed `self._optimizer_params["optim_params"]` straight into the torch optimizer constructors, whereas `kale.pipeline.domain_adapter` already wraps them in `validate_kwargs(...)` (`kale/utils/validate.py`). This unifies the base trainers onto the same validated path so both code paths behave identically.

### Behaviour change (please note)
This is **not** a pure cleanup. `validate_kwargs` filters `optim_params` down to keys accepted by the optimizer constructor:
- **Before:** an `optim_params` key the optimizer does not accept raised `TypeError: __init__() got an unexpected keyword argument ...`.
- **After:** that key is silently dropped, matching the long-standing behaviour in `domain_adapter`.

Valid optimizer configurations are entirely unaffected — same optimizer, same hyperparameters. Only the handling of *invalid* keys changes (hard error → silently ignored). I have ticked **Breaking change** because the error semantics of a public method change, even though no valid usage breaks.

### Verified
- Added regression tests `test_configure_optimizers_filters_invalid_optim_params` for both `TestBaseTrainer` and `TestCNNTransformerTrainer`. Reverting only the source change makes both fail with `TypeError` (the old raw path); with the fix both pass.
- `tests/pipeline/test_base_nn_trainer.py` — 22 passed.
- Pinned pre-commit green to convergence; clean tree.
- Import check OK.

### Status
**Ready**

### Types of changes
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] Source for documentation at `docs` manually updated for new API.