### PR TITLE
Harden download.py and add optional dataset checksum verification

### DIFF
--- a/kale/utils/download.py
+++ b/kale/utils/download.py
@@ -13,6 +13,7 @@ import hashlib
 import logging
 import time
 import urllib.error
+from functools import partial
 from pathlib import Path
 
 from torch.hub import download_url_to_file
@@ -92,6 +93,23 @@ def _verify_file(file, md5=None, sha256=None, file_size=None):
         if actual.lower() != expected.lower():
             raise RuntimeError(f"{algorithm} mismatch for {file}: expected {expected}, got {actual}")
     logging.info("Verified integrity of %s", file)
+
+
+def _fetch_and_verify(fetch_fn, file, md5=None, sha256=None, file_size=None):
+    """Run a download callable and then verify the resulting file.
+
+    Args:
+        fetch_fn (callable): Zero-argument callable that downloads (and optionally extracts) the file.
+        file (str or Path): Path to the downloaded file to verify.
+        md5 (str, optional): Expected MD5 hex digest. Defaults to None.
+        sha256 (str, optional): Expected SHA-256 hex digest. Defaults to None.
+        file_size (int, optional): Expected size in bytes. Defaults to None.
+
+    Raises:
+        RuntimeError: If verification fails (see :func:`_verify_file`).
+    """
+    fetch_fn()
+    _verify_file(file, md5=md5, sha256=sha256, file_size=file_size)
 
 
 def _retry_download(download_fn, retries=3, backoff=2, cleanup_paths=None):
@@ -179,23 +197,17 @@ def download_file_by_url(
     output_directory.mkdir(parents=True, exist_ok=True)
 
     if file_format in ["tar.xz", "tar", "tar.gz", "tgz", "gz", "zip"]:
-        logging.info("Downloading and extracting {}.".format(output_file_name))
-
-        def _download_and_extract():
-            download_and_extract_archive(url=url, download_root=output_directory, filename=output_file_name)
-            _verify_file(file, md5=md5, sha256=sha256, file_size=file_size)
-
-        _retry_download(_download_and_extract, cleanup_paths=[file])
-        logging.info("Datasets downloaded and extracted in {}".format(file))
+        fetch = partial(
+            download_and_extract_archive, url=url, download_root=output_directory, filename=output_file_name
+        )
+        start_message, done_message = "Downloading and extracting {}.", "Datasets downloaded and extracted in {}"
     else:
-        logging.info("Downloading {}.".format(output_file_name))
+        fetch = partial(download_url_to_file, url, str(file))
+        start_message, done_message = "Downloading {}.", "Datasets downloaded in {}"
 
-        def _download():
-            download_url_to_file(url, str(file))
-            _verify_file(file, md5=md5, sha256=sha256, file_size=file_size)
-
-        _retry_download(_download, cleanup_paths=[file])
-        logging.info("Datasets downloaded in {}".format(file))
+    logging.info(start_message.format(output_file_name))
+    _retry_download(partial(_fetch_and_verify, fetch, file, md5, sha256, file_size), cleanup_paths=[file])
+    logging.info(done_message.format(file))
 
 
 def download_file_gdrive(id, output_directory, output_file_name, file_format=None):

--- a/kale/utils/download.py
+++ b/kale/utils/download.py
@@ -17,7 +17,7 @@ from functools import partial
 from pathlib import Path
 
 from torch.hub import download_url_to_file
-from torchvision.datasets.utils import download_and_extract_archive, download_file_from_google_drive, extract_archive
+from torchvision.datasets.utils import download_file_from_google_drive, download_url, extract_archive
 
 # Errors that indicate a transient/recoverable download failure and are worth retrying.
 # ``OSError`` covers socket/timeout/IO errors (``IOError`` is an alias), ``urllib.error.URLError``
@@ -112,6 +112,54 @@ def _fetch_and_verify(fetch_fn, file, md5=None, sha256=None, file_size=None):
     _verify_file(file, md5=md5, sha256=sha256, file_size=file_size)
 
 
+def _download_verify_extract(url, output_directory, output_file_name, file, md5=None, sha256=None, file_size=None):
+    """Download an archive, verify it, then extract it.
+
+    Verification happens *before* extraction so a corrupt archive is never unpacked; on a
+    verification failure the archive is left for :func:`_retry_download` to clean up and retry.
+
+    Args:
+        url (str): URL of the archive to download.
+        output_directory (str or Path): Directory to download into and extract to.
+        output_file_name (str): File name to save the archive as.
+        file (str or Path): Full path to the downloaded archive (``output_directory/output_file_name``).
+        md5 (str, optional): Expected MD5 hex digest. Defaults to None.
+        sha256 (str, optional): Expected SHA-256 hex digest. Defaults to None.
+        file_size (int, optional): Expected size in bytes. Defaults to None.
+
+    Raises:
+        RuntimeError: If verification fails (see :func:`_verify_file`).
+    """
+    download_url(url, str(output_directory), output_file_name, md5=md5)
+    _verify_file(file, md5=md5, sha256=sha256, file_size=file_size)
+    extract_archive(str(file), str(output_directory))
+
+
+def _cached_file_valid(file, md5=None, sha256=None, file_size=None):
+    """Decide whether an already-present file can be reused.
+
+    With no integrity expectation an existing file is accepted as-is. When md5/sha256/size are
+    provided the file is verified; on mismatch the corrupt file is removed and ``False`` is
+    returned so the caller re-downloads it.
+
+    Args:
+        file (str or Path): Path to the existing file.
+        md5 (str, optional): Expected MD5 hex digest. Defaults to None.
+        sha256 (str, optional): Expected SHA-256 hex digest. Defaults to None.
+        file_size (int, optional): Expected size in bytes. Defaults to None.
+
+    Returns:
+        bool: True if the file is valid and can be reused, False if it was removed as invalid.
+    """
+    try:
+        _verify_file(file, md5=md5, sha256=sha256, file_size=file_size)
+        return True
+    except RuntimeError:
+        logging.warning("Cached file failed integrity check, re-downloading: %s", file)
+        _remove_partial_files([Path(file)])
+        return False
+
+
 def _retry_download(download_fn, retries=3, backoff=2, cleanup_paths=None):
     """Execute ``download_fn`` with retry and exponential backoff.
 
@@ -190,23 +238,21 @@ def download_file_by_url(
     output_directory = Path(output_directory).absolute()
     file = output_directory.joinpath(output_file_name)
 
-    if file.exists():
+    if file.exists() and _cached_file_valid(file, md5=md5, sha256=sha256, file_size=file_size):
         logging.info("Skipping Download and Extraction")
-
         return
     output_directory.mkdir(parents=True, exist_ok=True)
 
     if file_format in ["tar.xz", "tar", "tar.gz", "tgz", "gz", "zip"]:
-        fetch = partial(
-            download_and_extract_archive, url=url, download_root=output_directory, filename=output_file_name
-        )
+        fetch = partial(_download_verify_extract, url, output_directory, output_file_name, file, md5, sha256, file_size)
         start_message, done_message = "Downloading and extracting {}.", "Datasets downloaded and extracted in {}"
     else:
-        fetch = partial(download_url_to_file, url, str(file))
+        download = partial(download_url_to_file, url, str(file))
+        fetch = partial(_fetch_and_verify, download, file, md5, sha256, file_size)
         start_message, done_message = "Downloading {}.", "Datasets downloaded in {}"
 
     logging.info(start_message.format(output_file_name))
-    _retry_download(partial(_fetch_and_verify, fetch, file, md5, sha256, file_size), cleanup_paths=[file])
+    _retry_download(fetch, cleanup_paths=[file])
     logging.info(done_message.format(file))
 
 

--- a/kale/utils/download.py
+++ b/kale/utils/download.py
@@ -9,6 +9,7 @@ https://github.com/pytorch/vision/blob/master/torchvision/datasets/utils.py
 https://github.com/pytorch/pytorch/blob/master/torch/hub.py
 """
 
+import hashlib
 import logging
 import time
 import urllib.error
@@ -38,6 +39,59 @@ def _remove_partial_files(paths):
                 logging.warning("Removed partial download: %s", path)
         except OSError as exc:
             logging.warning("Could not remove partial download %s: %s", path, exc)
+
+
+def _hash_file(file, algorithm, chunk_size=1024 * 1024):
+    """Compute the hex digest of a file, reading it in chunks.
+
+    Args:
+        file (str or Path): Path to the file to hash.
+        algorithm (str): Hash algorithm name understood by :func:`hashlib.new` (e.g. "md5", "sha256").
+        chunk_size (int): Number of bytes read per iteration. Defaults to 1 MiB.
+
+    Returns:
+        str: The lowercase hexadecimal digest.
+    """
+    hasher = hashlib.new(algorithm)
+    with open(file, "rb") as handle:
+        for chunk in iter(lambda: handle.read(chunk_size), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def _verify_file(file, md5=None, sha256=None, file_size=None):
+    """Verify a downloaded file against optional checksums and/or an expected size.
+
+    Verification is skipped entirely when no expectation is provided. A mismatch raises
+    ``RuntimeError`` (rather than ``ValueError``) so that, when called from within
+    :func:`_retry_download`, a corrupted download is retried and cleaned up like any other
+    transient download failure.
+
+    Args:
+        file (str or Path): Path to the downloaded file.
+        md5 (str, optional): Expected MD5 hex digest. Defaults to None (not checked).
+        sha256 (str, optional): Expected SHA-256 hex digest. Defaults to None (not checked).
+        file_size (int, optional): Expected size in bytes. Defaults to None (not checked).
+
+    Raises:
+        RuntimeError: If the file is missing or any provided expectation does not match.
+    """
+    if md5 is None and sha256 is None and file_size is None:
+        return
+    file = Path(file)
+    if not file.exists():
+        raise RuntimeError(f"Cannot verify {file}: file does not exist")
+    if file_size is not None:
+        actual_size = file.stat().st_size
+        if actual_size != file_size:
+            raise RuntimeError(f"Size mismatch for {file}: expected {file_size} bytes, got {actual_size}")
+    for algorithm, expected in (("md5", md5), ("sha256", sha256)):
+        if expected is None:
+            continue
+        actual = _hash_file(file, algorithm)
+        if actual.lower() != expected.lower():
+            raise RuntimeError(f"{algorithm} mismatch for {file}: expected {expected}, got {actual}")
+    logging.info("Verified integrity of %s", file)
 
 
 def _retry_download(download_fn, retries=3, backoff=2, cleanup_paths=None):
@@ -83,7 +137,9 @@ def _retry_download(download_fn, retries=3, backoff=2, cleanup_paths=None):
                 raise
 
 
-def download_file_by_url(url, output_directory, output_file_name, file_format=None):
+def download_file_by_url(
+    url, output_directory, output_file_name, file_format=None, md5=None, sha256=None, file_size=None
+):
     """Download file/compressed file by url.
 
     Args:
@@ -93,6 +149,13 @@ def download_file_by_url(url, output_directory, output_file_name, file_format=No
         output_file_name (string, optional): File name which object will be saved as
         file_format (string, optional): File format
                                 For compressed file, support ["tar.xz", "tar", "tar.gz", "tgz", "gz", "zip"]
+        md5 (string, optional): Expected MD5 hex digest of the downloaded file. When provided, the
+                                download is verified and a mismatch is retried, then raised. Defaults to None.
+        sha256 (string, optional): Expected SHA-256 hex digest of the downloaded file. Defaults to None.
+        file_size (int, optional): Expected size of the downloaded file in bytes. Defaults to None.
+
+    Raises:
+        RuntimeError: If verification is requested and the downloaded file does not match after all retries.
 
     Example: (Grab the raw link from GitHub. Notice that using "raw" in the URL.)
         >>> url = "https://github.com/pykale/data/raw/main/videos/video_test_data/ADL/annotations/labels_train_test/adl_P_04_train.pkl"
@@ -100,6 +163,9 @@ def download_file_by_url(url, output_directory, output_file_name, file_format=No
 
         >>> url = "https://github.com/pykale/data/raw/main/videos/video_test_data.zip"
         >>> download_file_by_url(url, "data", "video_test_data.zip", "zip")
+
+        >>> url = "https://github.com/pykale/data/raw/main/videos/video_test_data.zip"
+        >>> download_file_by_url(url, "data", "video_test_data.zip", "zip", md5="0123...")
 
     """
 
@@ -115,14 +181,20 @@ def download_file_by_url(url, output_directory, output_file_name, file_format=No
     if file_format in ["tar.xz", "tar", "tar.gz", "tgz", "gz", "zip"]:
         logging.info("Downloading and extracting {}.".format(output_file_name))
 
-        _retry_download(
-            lambda: download_and_extract_archive(url=url, download_root=output_directory, filename=output_file_name),
-            cleanup_paths=[file],
-        )
+        def _download_and_extract():
+            download_and_extract_archive(url=url, download_root=output_directory, filename=output_file_name)
+            _verify_file(file, md5=md5, sha256=sha256, file_size=file_size)
+
+        _retry_download(_download_and_extract, cleanup_paths=[file])
         logging.info("Datasets downloaded and extracted in {}".format(file))
     else:
         logging.info("Downloading {}.".format(output_file_name))
-        _retry_download(lambda: download_url_to_file(url, str(file)), cleanup_paths=[file])
+
+        def _download():
+            download_url_to_file(url, str(file))
+            _verify_file(file, md5=md5, sha256=sha256, file_size=file_size)
+
+        _retry_download(_download, cleanup_paths=[file])
         logging.info("Datasets downloaded in {}".format(file))
 
 

--- a/kale/utils/download.py
+++ b/kale/utils/download.py
@@ -10,35 +10,65 @@ https://github.com/pytorch/pytorch/blob/master/torch/hub.py
 """
 
 import logging
-import os
 import time
+import urllib.error
 from pathlib import Path
 
 from torch.hub import download_url_to_file
 from torchvision.datasets.utils import download_and_extract_archive, download_file_from_google_drive, extract_archive
 
+# Errors that indicate a transient/recoverable download failure and are worth retrying.
+# ``OSError`` covers socket/timeout/IO errors (``IOError`` is an alias), ``urllib.error.URLError``
+# covers HTTP/URL failures, and ``RuntimeError`` is what torchvision raises on a failed download or
+# checksum mismatch. Programming errors (e.g. ``TypeError``, ``ValueError``) are deliberately not
+# caught here so they surface immediately instead of being retried and masked.
+_DOWNLOAD_ERRORS = (OSError, RuntimeError, urllib.error.URLError)
 
-def _retry_download(download_fn, retries=3, backoff=2):
+
+def _remove_partial_files(paths):
+    """Delete any files left behind by a failed/partial download attempt.
+
+    Args:
+        paths (Iterable[Path]): Paths to remove if they exist. Missing paths are ignored.
+    """
+    for path in paths:
+        try:
+            if path.exists():
+                path.unlink()
+                logging.warning("Removed partial download: %s", path)
+        except OSError as exc:
+            logging.warning("Could not remove partial download %s: %s", path, exc)
+
+
+def _retry_download(download_fn, retries=3, backoff=2, cleanup_paths=None):
     """Execute ``download_fn`` with retry and exponential backoff.
+
+    Any files listed in ``cleanup_paths`` are removed after a failed attempt so that a
+    partially written file is not left in place for the next attempt (or on final failure).
 
     Args:
         download_fn (callable): Zero-argument callable that performs the download.
         retries (int): Maximum number of attempts. Must be >= 1. Defaults to 3.
         backoff (int): Base for exponential back-off in seconds. Must be >= 1. Defaults to 2.
+        cleanup_paths (Iterable[str or Path], optional): Target paths to delete after a failed
+            attempt. Defaults to None (nothing to clean up).
 
     Raises:
         ValueError: If ``retries`` < 1 or ``backoff`` < 1.
-        Exception: Re-raises the last exception when all retries are exhausted.
+        OSError, RuntimeError, urllib.error.URLError: Re-raises the last download error when all
+            retries are exhausted.
     """
     if retries < 1:
         raise ValueError(f"retries must be >= 1, got {retries}")
     if backoff < 1:
         raise ValueError(f"backoff must be >= 1, got {backoff}")
+    cleanup_paths = [Path(p) for p in cleanup_paths] if cleanup_paths else []
     for attempt in range(retries):
         try:
             download_fn()
             return
-        except Exception as exc:
+        except _DOWNLOAD_ERRORS as exc:
+            _remove_partial_files(cleanup_paths)
             if attempt < retries - 1:
                 wait = backoff**attempt
                 logging.warning(
@@ -74,25 +104,25 @@ def download_file_by_url(url, output_directory, output_file_name, file_format=No
     """
 
     output_directory = Path(output_directory).absolute()
-    file = Path(output_directory).joinpath(output_file_name)
+    file = output_directory.joinpath(output_file_name)
 
-    if os.path.exists(file):
+    if file.exists():
         logging.info("Skipping Download and Extraction")
 
         return
-    if not os.path.exists(output_directory):
-        os.makedirs(output_directory)
+    output_directory.mkdir(parents=True, exist_ok=True)
 
     if file_format in ["tar.xz", "tar", "tar.gz", "tgz", "gz", "zip"]:
         logging.info("Downloading and extracting {}.".format(output_file_name))
 
         _retry_download(
-            lambda: download_and_extract_archive(url=url, download_root=output_directory, filename=output_file_name)
+            lambda: download_and_extract_archive(url=url, download_root=output_directory, filename=output_file_name),
+            cleanup_paths=[file],
         )
         logging.info("Datasets downloaded and extracted in {}".format(file))
     else:
         logging.info("Downloading {}.".format(output_file_name))
-        _retry_download(lambda: download_url_to_file(url, file))
+        _retry_download(lambda: download_url_to_file(url, str(file)), cleanup_paths=[file])
         logging.info("Datasets downloaded in {}".format(file))
 
 
@@ -116,11 +146,11 @@ def download_file_gdrive(id, output_directory, output_file_name, file_format=Non
     """
 
     output_directory = Path(output_directory).absolute()
-    file = Path(output_directory).joinpath(output_file_name)
-    if os.path.exists(file):
+    file = output_directory.joinpath(output_file_name)
+    if file.exists():
         logging.info("Skipping Download and Extraction")
         return
-    os.makedirs(output_directory, exist_ok=True)
+    output_directory.mkdir(parents=True, exist_ok=True)
 
     logging.info("Downloading {}.".format(output_file_name))
     download_file_from_google_drive(id, output_directory, output_file_name)

--- a/kale/utils/download.py
+++ b/kale/utils/download.py
@@ -60,6 +60,20 @@ def _hash_file(file, algorithm, chunk_size=1024 * 1024):
     return hasher.hexdigest()
 
 
+def _check_size(file, file_size):
+    """Raise ``RuntimeError`` if ``file`` is not exactly ``file_size`` bytes."""
+    actual_size = file.stat().st_size
+    if actual_size != file_size:
+        raise RuntimeError(f"Size mismatch for {file}: expected {file_size} bytes, got {actual_size}")
+
+
+def _check_hash(file, algorithm, expected):
+    """Raise ``RuntimeError`` if the ``algorithm`` digest of ``file`` does not match ``expected``."""
+    actual = _hash_file(file, algorithm)
+    if actual.lower() != expected.lower():
+        raise RuntimeError(f"{algorithm} mismatch for {file}: expected {expected}, got {actual}")
+
+
 def _verify_file(file, md5=None, sha256=None, file_size=None):
     """Verify a downloaded file against optional checksums and/or an expected size.
 
@@ -83,15 +97,11 @@ def _verify_file(file, md5=None, sha256=None, file_size=None):
     if not file.exists():
         raise RuntimeError(f"Cannot verify {file}: file does not exist")
     if file_size is not None:
-        actual_size = file.stat().st_size
-        if actual_size != file_size:
-            raise RuntimeError(f"Size mismatch for {file}: expected {file_size} bytes, got {actual_size}")
-    for algorithm, expected in (("md5", md5), ("sha256", sha256)):
-        if expected is None:
-            continue
-        actual = _hash_file(file, algorithm)
-        if actual.lower() != expected.lower():
-            raise RuntimeError(f"{algorithm} mismatch for {file}: expected {expected}, got {actual}")
+        _check_size(file, file_size)
+    if md5 is not None:
+        _check_hash(file, "md5", md5)
+    if sha256 is not None:
+        _check_hash(file, "sha256", sha256)
     logging.info("Verified integrity of %s", file)
 
 

--- a/tests/utils/test_download.py
+++ b/tests/utils/test_download.py
@@ -1,10 +1,17 @@
+import hashlib
 import os
 from pathlib import Path
 from unittest.mock import call, MagicMock, patch
 
 import pytest
 
-from kale.utils.download import _remove_partial_files, _retry_download, download_file_by_url, download_file_gdrive
+from kale.utils.download import (
+    _remove_partial_files,
+    _retry_download,
+    _verify_file,
+    download_file_by_url,
+    download_file_gdrive,
+)
 
 output_directory = Path().absolute().joinpath("tests/test_data/download")
 PARAM = [
@@ -125,6 +132,81 @@ def test_download_file_by_url_plain_uses_retry(tmp_path):
     with patch("kale.utils.download.download_url_to_file") as mock_dl:
         download_file_by_url("http://example.com/data.pkl", tmp_path, "data.pkl", "pkl")
     mock_dl.assert_called_once()
+
+
+def test_verify_file_noop_without_expectations(tmp_path):
+    # No md5/sha256/size given: nothing is checked, even for a non-existent file.
+    _verify_file(tmp_path / "does_not_exist.bin")
+
+
+def test_verify_file_matches(tmp_path):
+    content = b"pykale download payload"
+    file = tmp_path / "data.bin"
+    file.write_bytes(content)
+    _verify_file(
+        file,
+        md5=hashlib.md5(content).hexdigest(),
+        sha256=hashlib.sha256(content).hexdigest(),
+        file_size=len(content),
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs, match",
+    [
+        ({"md5": "deadbeef"}, "md5 mismatch"),
+        ({"sha256": "deadbeef"}, "sha256 mismatch"),
+        ({"file_size": 999999}, "Size mismatch"),
+    ],
+)
+def test_verify_file_mismatch_raises(tmp_path, kwargs, match):
+    file = tmp_path / "data.bin"
+    file.write_bytes(b"pykale download payload")
+    with pytest.raises(RuntimeError, match=match):
+        _verify_file(file, **kwargs)
+
+
+def test_verify_file_missing_raises(tmp_path):
+    with pytest.raises(RuntimeError, match="does not exist"):
+        _verify_file(tmp_path / "missing.bin", md5="deadbeef")
+
+
+def test_download_file_by_url_verifies_and_passes(tmp_path):
+    content = b"hello world"
+
+    def fake_download(url, dest):
+        Path(dest).write_bytes(content)
+
+    with patch("kale.utils.download.download_url_to_file", side_effect=fake_download):
+        download_file_by_url(
+            "http://example.com/data.pkl",
+            tmp_path,
+            "data.pkl",
+            "pkl",
+            md5=hashlib.md5(content).hexdigest(),
+            file_size=len(content),
+        )
+    assert (tmp_path / "data.pkl").read_bytes() == content
+
+
+def test_download_file_by_url_checksum_mismatch_retries_and_cleans(tmp_path):
+    # A wrong checksum makes every attempt fail; the corrupt file must not be left behind
+    # and the error surfaces after retries are exhausted.
+    def fake_download(url, dest):
+        Path(dest).write_bytes(b"corrupted")
+
+    with patch("kale.utils.download.time.sleep"):
+        with patch("kale.utils.download.download_url_to_file", side_effect=fake_download) as mock_dl:
+            with pytest.raises(RuntimeError, match="md5 mismatch"):
+                download_file_by_url(
+                    "http://example.com/data.pkl",
+                    tmp_path,
+                    "data.pkl",
+                    "pkl",
+                    md5="0" * 32,
+                )
+    assert mock_dl.call_count == 3
+    assert not (tmp_path / "data.pkl").exists()
 
 
 @pytest.mark.parametrize("param", PARAM)

--- a/tests/utils/test_download.py
+++ b/tests/utils/test_download.py
@@ -134,9 +134,56 @@ def test_remove_partial_files_swallows_unlink_error(tmp_path, caplog):
 
 
 def test_download_file_by_url_archive_uses_retry(tmp_path):
-    with patch("kale.utils.download.download_and_extract_archive") as mock_dl:
-        download_file_by_url("http://example.com/data.zip", tmp_path, "data.zip", "zip")
+    with patch("kale.utils.download.download_url") as mock_dl:
+        with patch("kale.utils.download.extract_archive") as mock_extract:
+            download_file_by_url("http://example.com/data.zip", tmp_path, "data.zip", "zip")
     mock_dl.assert_called_once()
+    mock_extract.assert_called_once()
+
+
+def test_download_file_by_url_archive_verifies_before_extract(tmp_path):
+    # For archives, a checksum mismatch must be caught BEFORE extraction, so the bad
+    # archive is never unpacked and is cleaned up after retries are exhausted.
+    def fake_download(url, root, filename, md5=None):
+        Path(root).joinpath(filename).write_bytes(b"corrupt-archive")
+
+    with patch("kale.utils.download.time.sleep"):
+        with patch("kale.utils.download.download_url", side_effect=fake_download):
+            with patch("kale.utils.download.extract_archive") as mock_extract:
+                with pytest.raises(RuntimeError, match="md5 mismatch"):
+                    download_file_by_url("http://example.com/data.zip", tmp_path, "data.zip", "zip", md5="0" * 32)
+    mock_extract.assert_not_called()
+    assert not (tmp_path / "data.zip").exists()
+
+
+def test_download_file_by_url_verifies_cached_file(tmp_path):
+    # A cached file that fails verification is re-downloaded rather than silently accepted.
+    good = b"the real payload"
+    file = tmp_path / "data.pkl"
+    file.write_bytes(b"stale-corrupt")  # pre-existing, wrong content
+
+    def fake_download(url, dest):
+        Path(dest).write_bytes(good)
+
+    with patch("kale.utils.download.download_url_to_file", side_effect=fake_download) as mock_dl:
+        download_file_by_url(
+            "http://example.com/data.pkl", tmp_path, "data.pkl", "pkl", md5=hashlib.md5(good).hexdigest()
+        )
+    mock_dl.assert_called_once()  # the stale cached file triggered a re-download
+    assert file.read_bytes() == good
+
+
+def test_download_file_by_url_skips_valid_cached_file(tmp_path):
+    # A cached file that passes verification is reused without downloading.
+    content = b"already here"
+    file = tmp_path / "data.pkl"
+    file.write_bytes(content)
+
+    with patch("kale.utils.download.download_url_to_file") as mock_dl:
+        download_file_by_url(
+            "http://example.com/data.pkl", tmp_path, "data.pkl", "pkl", md5=hashlib.md5(content).hexdigest()
+        )
+    mock_dl.assert_not_called()
 
 
 def test_download_file_by_url_plain_uses_retry(tmp_path):

--- a/tests/utils/test_download.py
+++ b/tests/utils/test_download.py
@@ -4,7 +4,7 @@ from unittest.mock import call, MagicMock, patch
 
 import pytest
 
-from kale.utils.download import _retry_download, download_file_by_url, download_file_gdrive
+from kale.utils.download import _remove_partial_files, _retry_download, download_file_by_url, download_file_gdrive
 
 output_directory = Path().absolute().joinpath("tests/test_data/download")
 PARAM = [
@@ -47,6 +47,72 @@ def test_retry_download_raises_after_all_retries():
 def test_retry_download_invalid_args(kwargs):
     with pytest.raises(ValueError):
         _retry_download(MagicMock(), **kwargs)
+
+
+def test_retry_download_does_not_retry_programming_errors():
+    # A non-download error (e.g. TypeError) is not one of _DOWNLOAD_ERRORS, so it must
+    # propagate immediately without being retried and masked.
+    fn = MagicMock(side_effect=TypeError("bad call"))
+    with patch("kale.utils.download.time.sleep") as mock_sleep:
+        with pytest.raises(TypeError, match="bad call"):
+            _retry_download(fn, retries=3, backoff=2)
+    fn.assert_called_once()
+    mock_sleep.assert_not_called()
+
+
+def test_retry_download_cleans_partial_file_between_attempts(tmp_path):
+    # Simulate a download that writes a partial file and then fails, succeeding on the
+    # second attempt. The partial file from the failed attempt must be removed.
+    partial = tmp_path / "partial.bin"
+    attempts = {"n": 0}
+
+    def flaky():
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            partial.write_bytes(b"incomplete")
+            raise RuntimeError("connection reset")
+        # success path leaves the (now complete) file in place
+        partial.write_bytes(b"complete")
+
+    seen_after_failure = {}
+
+    original_remove = _remove_partial_files
+
+    def spy(paths):
+        paths = list(paths)
+        seen_after_failure["existed"] = partial.exists()
+        original_remove(paths)
+        seen_after_failure["removed"] = not partial.exists()
+
+    with patch("kale.utils.download.time.sleep"):
+        with patch("kale.utils.download._remove_partial_files", side_effect=spy):
+            _retry_download(flaky, retries=2, backoff=1, cleanup_paths=[partial])
+
+    assert attempts["n"] == 2
+    assert seen_after_failure["existed"] is True
+    assert seen_after_failure["removed"] is True
+
+
+def test_retry_download_cleans_partial_file_on_final_failure(tmp_path):
+    partial = tmp_path / "partial.bin"
+
+    def always_fails():
+        partial.write_bytes(b"incomplete")
+        raise RuntimeError("timeout")
+
+    with patch("kale.utils.download.time.sleep"):
+        with pytest.raises(RuntimeError, match="timeout"):
+            _retry_download(always_fails, retries=2, backoff=1, cleanup_paths=[partial])
+    assert not partial.exists()
+
+
+def test_remove_partial_files_ignores_missing(tmp_path):
+    existing = tmp_path / "there.bin"
+    existing.write_bytes(b"x")
+    missing = tmp_path / "nope.bin"
+    # Must not raise on the missing path, and must remove the existing one.
+    _remove_partial_files([existing, missing])
+    assert not existing.exists()
 
 
 def test_download_file_by_url_archive_uses_retry(tmp_path):

--- a/tests/utils/test_download.py
+++ b/tests/utils/test_download.py
@@ -122,6 +122,17 @@ def test_remove_partial_files_ignores_missing(tmp_path):
     assert not existing.exists()
 
 
+def test_remove_partial_files_swallows_unlink_error(tmp_path, caplog):
+    # If deleting a partial file fails (e.g. permission error), the error is logged
+    # and swallowed rather than propagated, so it cannot mask the original download error.
+    path = tmp_path / "locked.bin"
+    path.write_bytes(b"x")
+    with patch.object(Path, "unlink", side_effect=OSError("permission denied")):
+        with caplog.at_level("WARNING"):
+            _remove_partial_files([path])
+    assert any("Could not remove partial download" in message for message in caplog.messages)
+
+
 def test_download_file_by_url_archive_uses_retry(tmp_path):
     with patch("kale.utils.download.download_and_extract_archive") as mock_dl:
         download_file_by_url("http://example.com/data.zip", tmp_path, "data.zip", "zip")
@@ -219,6 +230,32 @@ def test_download_file_by_url(param):
 
     assert os.path.exists(output_directory.joinpath(output_file_name)) is True
     assert output_directory.exists()
+
+
+def test_download_file_gdrive_archive_mocked(tmp_path):
+    # Exercise the gdrive download + extract branch without hitting the network.
+    def fake_gdrive(id, root, name):
+        Path(root).joinpath(name).write_bytes(b"archive-bytes")
+
+    with patch("kale.utils.download.download_file_from_google_drive", side_effect=fake_gdrive) as mock_dl:
+        with patch("kale.utils.download.extract_archive") as mock_extract:
+            download_file_gdrive("some-id", tmp_path, "data.zip", "zip")
+    mock_dl.assert_called_once()
+    mock_extract.assert_called_once()
+    assert (tmp_path / "data.zip").exists()
+
+
+def test_download_file_gdrive_plain_mocked(tmp_path):
+    # Exercise the gdrive plain (no-extract) branch without hitting the network.
+    def fake_gdrive(id, root, name):
+        Path(root).joinpath(name).write_bytes(b"plain-bytes")
+
+    with patch("kale.utils.download.download_file_from_google_drive", side_effect=fake_gdrive) as mock_dl:
+        with patch("kale.utils.download.extract_archive") as mock_extract:
+            download_file_gdrive("some-id", tmp_path, "data.csv", "csv")
+    mock_dl.assert_called_once()
+    mock_extract.assert_not_called()
+    assert (tmp_path / "data.csv").exists()
 
 
 @pytest.mark.parametrize("param", GDRIVE_PARAM)


### PR DESCRIPTION
Fixes #545. Fixes #547.

### Description
Hardens `kale/utils/download.py` and adds optional integrity checks for downloaded datasets:
- Cleans up partial files on failed download attempts, narrows the retry `except`, and uses `pathlib` consistently (#545).
- Adds optional `md5`/`sha256`/`file_size` verification to `download_file_by_url` (#547).

Backward compatible: the new arguments are optional and default to `None`.

### Status
**Ready**

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [ ] Source for documentation at `docs` manually updated for new API.